### PR TITLE
Add planning doc for Cell CRD

### DIFF
--- a/plans/phase-1/cell-management-operator.md
+++ b/plans/phase-1/cell-management-operator.md
@@ -125,7 +125,7 @@ func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 ## Error Handling
 
-- **Etcd unreachable**: Set `TopoServerReachable: false`, requeue with backoff
+- **Etcd unreachable**: Set `spec.topoServerReachable: false`, requeue with backoff
 - **Invalid component references**: Log warning, continue (components may not exist yet)
 - **Registration failure**: Update Condition with error details, requeue
 


### PR DESCRIPTION
Cell CRD handling will require a dedicated module, and this will be one of the confusing part.

The main target is to get the CRD in place first, and relevant resource setup in place.