### PR TITLE
use distroless

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -65,9 +65,30 @@ jobs:
             echo "::error::CodeQL produced ${count} alerts (warning/error)."
             exit 1
           fi
+  scan-intermediate-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan intermediate image with grype
+        id: scan
+        uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
+        continue-on-error: true
+        with:
+          cache-db: true
+          image: "alpine:3.22.2" # sync this with Containerfile
+          output-file: grype.sarif
+          severity-cutoff: high
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@e296a935590eb16afc0c0108289f68c87e2a89a5 # v4.30.7
+        with:
+          sarif_file: grype.sarif
+      - name: Check success or failure
+        if: ${{ steps.scan.outcome == 'failure' }}
+        run: |-
+          jq '.runs[0].results | map(select(.level == "error"))' grype.sarif
+          exit 1
 
   build-go:
-    needs: [ scan-dependencies, scan-codeql ]
+    needs: [ scan-dependencies, scan-codeql, scan-intermediate-image ]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -175,7 +196,7 @@ jobs:
 
       # grype requires that the container image be pushed already because
       # the scanner runs in a container with a different local registry
-      - name: Scan image with grype
+      - name: Scan final image with grype
         id: scan
         uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
         continue-on-error: true

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,10 @@
+# Containerfile for multigres-operator
+
+# Github workflow step anchore/scan-action scans only the final image
+# sync this intermediate FROM reference with:
+#   build-and-release.yaml => scan-intermediate-image
 FROM --platform=$BUILDPLATFORM alpine:3.22.2 AS build
+
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -6,7 +12,7 @@ COPY dist dist
 RUN cp dist/multigres-operator-${TARGETARCH}/multigres-operator-${TARGETARCH} multigres-operator
 RUN chmod +x multigres-operator
 
-FROM alpine:3.22.2
+FROM gcr.io/distroless/static-debian12
 
 COPY --from=build multigres-operator multigres-operator
 


### PR DESCRIPTION
Switches final image to distroless.

However, `anchore/scan-action` / `grype` only scans the final image, and since the intermediate (builder) image is still running alpine (because distroless doesn't have `cp`), there was a gap in the code scanner. To solve this, I added another step in the workflow which scans the intermediate image FROM dependency. Unfortunately it must be kept in sync manually, so I also added some comments to that effect.

The final image has gone from 11MB to 4.4MB.