### PR TITLE
Add go.work setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 
 # Go
 go.work
+go.work.sum
 cover.out
 cover.html
 


### PR DESCRIPTION
`go.work.sum` is also generated and shouldn't be committed