### PR TITLE
speed up pull request build by only building amd64

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,3 +14,5 @@ permissions:
 jobs:
   run:
     uses: ./.github/workflows/build-and-release.yaml
+    with:
+      architectures: '["amd64"]'


### PR DESCRIPTION
`build-scan-push-container` job reduced from >25min to <3min, probably due to emulation.