### PR TITLE
Update pool slice to map to match with spec

### DIFF
--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -37,9 +37,9 @@ type ShardSpec struct {
 	MultiOrch MultiOrchSpec `json:"multiOrch,omitempty"`
 
 	// Pools defines the different pools of pods for this shard (e.g., replicas, read-only).
-	// This is a direct copy from the parent MultiTableGroup's shardTemplate.
+	// This is a direct copy from the parent TableGroup's Pools definition.
 	// +optional
-	Pools []ShardPoolSpec `json:"pools,omitempty"`
+	Pools map[string]ShardPoolSpec `json:"pools,omitempty"`
 }
 
 // ShardImagesSpec defines the images required for a Shard.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -809,9 +809,9 @@ func (in *ShardSpec) DeepCopyInto(out *ShardSpec) {
 	in.MultiOrch.DeepCopyInto(&out.MultiOrch)
 	if in.Pools != nil {
 		in, out := &in.Pools, &out.Pools
-		*out = make([]ShardPoolSpec, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
+		*out = make(map[string]ShardPoolSpec, len(*in))
+		for key, val := range *in {
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 }

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -144,10 +144,7 @@ spec:
                     type: object
                 type: object
               pools:
-                description: |-
-                  Pools defines the different pools of pods for this shard (e.g., replicas, read-only).
-                  This is a direct copy from the parent MultiTableGroup's shardTemplate.
-                items:
+                additionalProperties:
                   description: |-
                     ShardPoolSpec defines the desired state of a pool of shard replicas (e.g., primary, replica, read-only).
                     This is the core reusable spec for a shard's pod.
@@ -1424,7 +1421,10 @@ spec:
                       - readOnly
                       type: string
                   type: object
-                type: array
+                description: |-
+                  Pools defines the different pools of pods for this shard (e.g., replicas, read-only).
+                  This is a direct copy from the parent TableGroup's Pools definition.
+                type: object
             type: object
             x-kubernetes-validations:
             - message: at least one shard pool must be defined


### PR DESCRIPTION
This is what it looks like based on https://github.com/numtide/multigres-operator/blob/multigres-cluster-cr-design/plans/phase-1/api-design/multigres-operator-api-v1alpha1-design.md#child-cr-shard

``` yaml
apiVersion: multigres.com/v1alpha1
kind: Shard
metadata:
  name: "production-db-orders-tg-0"
  namespace: example
  labels:
     # ...
  ownerReferences:
    - apiVersion: multigres.com/v1alpha1
      # ...
spec:
  shardName: "0"

  images:
    # ...
  
  multiOrch:
    image: "multigres/multigres:latest"
    # ....

  pools:
    primary:
      cell: "us-east-1a" 
      type: "readWrite"
      replicas: 2
      storage:
        # ...
```

It used to be a slice, and now it is using as a map, which gives easier mapping and suffix usage for the resource names.