### PR TITLE
Support option parameters for shorthand

### DIFF
--- a/pkg/testutil/envtest.go
+++ b/pkg/testutil/envtest.go
@@ -251,7 +251,11 @@ func startManager(t testing.TB, ctx context.Context, mgr manager.Manager) <-chan
 // cascading deletion, use kind based testing instead.
 //
 // Also, for more control, you can use the individual functions separately.
-func SetUpEnvtestManager(t testing.TB, scheme *runtime.Scheme, opts ...EnvtestOption) manager.Manager {
+func SetUpEnvtestManager(
+	t testing.TB,
+	scheme *runtime.Scheme,
+	opts ...EnvtestOption,
+) manager.Manager {
 	t.Helper()
 
 	cfg := SetUpEnvtest(t, opts...)


### PR DESCRIPTION
The option param is important for setting the extra CRD path. While this convenience function is not strictly necessary, it would make sense to add the option support which only passes down to the relevant function.

This does not change any of the behaviour, and the test coverage remains the same, 100%.