### PR TITLE
docs: update API design to reflect TopoServer and CoreTemplate changes

### DIFF
--- a/plans/phase-1/api-design/multigres-operator-api-v1alpha1-design.md
+++ b/plans/phase-1/api-design/multigres-operator-api-v1alpha1-design.md
@@ -417,7 +417,6 @@ spec:
           memory: "2Gi"
 
   # Defines the MultiAdmin component.
-  # Note: The 'spec' nesting is removed here (Flattened) compared to the Cluster CR.
   multiadmin:
     replicas: 2
     resources:


### PR DESCRIPTION
Updates the V1Alpha1 design document to match the recent API refactoring.

Changes:
- Updates `CoreTemplate` examples to remove the `spec` nesting for `multiadmin` and restrict `globalTopoServer` to managed-only configurations (removing `external` options from templates).
- Updates `TopoServer` child CR examples to use the new structure, wrapping configuration under an `etcd` key to allow for future extensibility.