### PR TITLE
ci: add pre-commit hooks to enforce linting and style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: local
+    hooks:
+      # # 1. Ensure go.mod/go.sum are tidy across all modules
+      # - id: go-modules-tidy
+      #   name: Go Modules Tidy
+      #   entry: make modules-tidy
+      #   language: system
+      #   files: \.go$
+      #   pass_filenames: false
+
+      # 2. Run Linters and Auto-fixers (gofumpt, golines, etc.)
+      - id: go-lint-fix
+        name: Go Lint Fix
+        entry: make lint-fix
+        language: system
+        files: \.go$
+        pass_filenames: false


### PR DESCRIPTION
Introduces `.pre-commit-config.yaml` to standardize code quality checks across the team and prevent CI failures due to formatting issues.

The configuration includes:
- Standard checks (trailing whitespace, EOF fixing, YAML syntax).
- A local hook to run `make lint-fix` automatically on staged Go files.
- There is a commented block for Go modules tidy in case we want to enable this in the future in some form
- This file can be expanded in the future.

**Setup Instructions:**
To activate these hooks locally, run the following commands:

1. Install the pre-commit tool: $ brew install pre-commit

2. Install the git hooks for this repository: $ pre-commit install

Once installed, the hooks will run automatically on every `git commit`.

These instructions will be added to the README file later.