### PR TITLE
docs(design): update v1alpha1 design with system catalog defaults and constraints. Image settings passed down to children

### DIFF
--- a/plans/phase-1/api-design/multigres-operator-api-v1alpha1-design.md
+++ b/plans/phase-1/api-design/multigres-operator-api-v1alpha1-design.md
@@ -681,8 +681,12 @@ spec:
   name: "us-east-1a"
   zone: "us-east-1a" # this would be region if that was chosen instead.
 
-  # Image passed down from global configuration
-  multigatewayImage: "multigres/multigres:latest"
+  # Images and pull config passed down from global configuration
+  images:
+    imagePullPolicy: "IfNotPresent"
+    imagePullSecrets:
+      - name: "my-registry-secret"
+    multigateway: "multigres/multigres:latest"
 
   # Resolved from CellTemplate + Overrides
   multigateway:
@@ -777,10 +781,13 @@ metadata:
 spec:
   databaseName: "production_db"
   tableGroupName: "orders_tg"
-  default: false
+  default: true
 
-  # Images passed down from global configuration
+  # Images and pull config passed down from global configuration
   images:
+    imagePullPolicy: "IfNotPresent"
+    imagePullSecrets:
+      - name: "my-registry-secret"
     multiorch: "multigres/multigres:latest"
     multipooler: "multigres/multigres:latest"
     postgres: "postgres:15.3"
@@ -940,8 +947,11 @@ spec:
   tableGroupName: "orders_tg"
   shardName: "0"
 
-  # Images passed down from global configuration
+  # Images and pull config passed down from global configuration
   images:
+    imagePullPolicy: "IfNotPresent"
+    imagePullSecrets:
+      - name: "my-registry-secret"
     multiorch: "multigres/multigres:latest"
     multipooler: "multigres/multigres:latest"
     postgres: "postgres:15.3"


### PR DESCRIPTION
This commit updates the `v1alpha1` API design document to align with the current routing limitations of the Multigres Gateway (which currently requires a single database named "postgres" and a tablegroup named "default").

**Changes:**
* **Temporary Constraints:** Added a section explaining that v1alpha1 enforces a Single-Database topology until Gateway routing logic matures.
* **Smart Defaulting:** Documented the new webhook logic that automatically injects the System Database (`postgres`) and Default TableGroup (`default`) if they are missing from the spec.
* **Validation Rules:** Added strict CEL validation requirements:
    * `MaxItems: 1` for databases.
    * Mandatory naming (`postgres`, `default`) for system resources.
    * **Mandatory Default TableGroup:** A new rule requiring every database to have exactly one tablegroup marked `default: true`.
* **Updated Examples:** Refactored all end-user examples to use the valid `postgres` system database configuration instead of invalid custom names, while keeping the "User Database" example as a commented reference for future capabilities.