### PR TITLE
feat(resolver): implement system catalog smart defaulting

### DIFF
--- a/pkg/resolver/cluster_test.go
+++ b/pkg/resolver/cluster_test.go
@@ -46,6 +46,19 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CellTemplate:  FallbackCellTemplate,
 						ShardTemplate: FallbackShardTemplate,
 					},
+					// Expect Smart Defaulting: System Catalog
+					Databases: []multigresv1alpha1.DatabaseConfig{
+						{
+							Name:    DefaultSystemDatabaseName,
+							Default: true,
+							TableGroups: []multigresv1alpha1.TableGroupConfig{
+								{
+									Name:    DefaultSystemTableGroupName,
+									Default: true,
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -65,6 +78,13 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CellTemplate:  "custom-cell",
 						ShardTemplate: "custom-shard",
 					},
+					Databases: []multigresv1alpha1.DatabaseConfig{
+						{
+							Name:        "existing-db",
+							Default:     true,
+							TableGroups: []multigresv1alpha1.TableGroupConfig{{Name: "tg1"}},
+						},
+					},
 				},
 			},
 			want: &multigresv1alpha1.MultigresCluster{
@@ -81,6 +101,13 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CoreTemplate:  "custom-core",
 						CellTemplate:  "custom-cell",
 						ShardTemplate: "custom-shard",
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{
+						{
+							Name:        "existing-db",
+							Default:     true,
+							TableGroups: []multigresv1alpha1.TableGroupConfig{{Name: "tg1"}},
+						},
 					},
 				},
 			},
@@ -110,6 +137,19 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CoreTemplate:  FallbackCoreTemplate,
 						CellTemplate:  FallbackCellTemplate,
 						ShardTemplate: FallbackShardTemplate,
+					},
+					// Expect Smart Defaulting for DBs
+					Databases: []multigresv1alpha1.DatabaseConfig{
+						{
+							Name:    DefaultSystemDatabaseName,
+							Default: true,
+							TableGroups: []multigresv1alpha1.TableGroupConfig{
+								{
+									Name:    DefaultSystemTableGroupName,
+									Default: true,
+								},
+							},
+						},
 					},
 					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerSpec{
 						Etcd: &multigresv1alpha1.EtcdSpec{
@@ -156,6 +196,19 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CellTemplate:  FallbackCellTemplate,
 						ShardTemplate: FallbackShardTemplate,
 					},
+					// Expect Smart Defaulting for DBs
+					Databases: []multigresv1alpha1.DatabaseConfig{
+						{
+							Name:    DefaultSystemDatabaseName,
+							Default: true,
+							TableGroups: []multigresv1alpha1.TableGroupConfig{
+								{
+									Name:    DefaultSystemTableGroupName,
+									Default: true,
+								},
+							},
+						},
+					},
 					Cells: []multigresv1alpha1.CellConfig{
 						{
 							Name: "cell-1",
@@ -195,12 +248,63 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CellTemplate:  FallbackCellTemplate,
 						ShardTemplate: FallbackShardTemplate,
 					},
+					// Expect Smart Defaulting for DBs
+					Databases: []multigresv1alpha1.DatabaseConfig{
+						{
+							Name:    DefaultSystemDatabaseName,
+							Default: true,
+							TableGroups: []multigresv1alpha1.TableGroupConfig{
+								{
+									Name:    DefaultSystemTableGroupName,
+									Default: true,
+								},
+							},
+						},
+					},
 					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerSpec{
 						Etcd: &multigresv1alpha1.EtcdSpec{
 							Image:     "custom-etcd",
 							Replicas:  ptr.To(DefaultEtcdReplicas),
 							Resources: DefaultResourcesEtcd(),
 							Storage:   multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
+						},
+					},
+				},
+			},
+		},
+		"Smart Defaulting: Inject TableGroup when DB exists": {
+			input: &multigresv1alpha1.MultigresCluster{
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Databases: []multigresv1alpha1.DatabaseConfig{
+						{Name: "postgres", Default: true}, // No TableGroups
+					},
+				},
+			},
+			want: &multigresv1alpha1.MultigresCluster{
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Images: multigresv1alpha1.ClusterImages{
+						Postgres:        DefaultPostgresImage,
+						MultiAdmin:      DefaultMultiAdminImage,
+						MultiOrch:       DefaultMultiOrchImage,
+						MultiPooler:     DefaultMultiPoolerImage,
+						MultiGateway:    DefaultMultiGatewayImage,
+						ImagePullPolicy: DefaultImagePullPolicy,
+					},
+					TemplateDefaults: multigresv1alpha1.TemplateDefaults{
+						CoreTemplate:  FallbackCoreTemplate,
+						CellTemplate:  FallbackCellTemplate,
+						ShardTemplate: FallbackShardTemplate,
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{
+						{
+							Name:    "postgres",
+							Default: true,
+							TableGroups: []multigresv1alpha1.TableGroupConfig{
+								{
+									Name:    DefaultSystemTableGroupName,
+									Default: true,
+								},
+							},
 						},
 					},
 				},

--- a/pkg/resolver/defaults.go
+++ b/pkg/resolver/defaults.go
@@ -21,6 +21,12 @@ const (
 	// FallbackShardTemplate is the name of the template to look for if no specific ShardTemplate is referenced.
 	FallbackShardTemplate = "default"
 
+	// DefaultSystemDatabaseName is the name of the mandatory system database.
+	DefaultSystemDatabaseName = "postgres"
+
+	// DefaultSystemTableGroupName is the name of the mandatory default table group.
+	DefaultSystemTableGroupName = "default"
+
 	// DefaultPostgresImage is the default container image used for PostgreSQL instances.
 	DefaultPostgresImage = "postgres:15-alpine"
 

--- a/pkg/resolver/go.mod
+++ b/pkg/resolver/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/numtide/multigres-operator/api v0.0.0-20251224124005-355869230728
+	github.com/numtide/multigres-operator/api v0.0.0-20260103121224-057738b43b3b
 	k8s.io/api v0.34.3
 	k8s.io/apimachinery v0.34.3
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4

--- a/pkg/resolver/go.sum
+++ b/pkg/resolver/go.sum
@@ -82,6 +82,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/numtide/multigres-operator/api v0.0.0-20251224124005-355869230728 h1:a+iM4L0nC7kUgcAD1P+wuNJg4x0rjcy6rVZ3+vF52Cc=
 github.com/numtide/multigres-operator/api v0.0.0-20251224124005-355869230728/go.mod h1:A1bBmTxHr+362dGZ5G6u2S4xsP6enbgdUS/UJUOmKbc=
+github.com/numtide/multigres-operator/api v0.0.0-20260103121224-057738b43b3b h1:twErev/AdyVQvlYa5vbo5wqq+NlexZJmIm0pwEQd5qI=
+github.com/numtide/multigres-operator/api v0.0.0-20260103121224-057738b43b3b/go.mod h1:A1bBmTxHr+362dGZ5G6u2S4xsP6enbgdUS/UJUOmKbc=
 github.com/onsi/ginkgo/v2 v2.25.3 h1:Ty8+Yi/ayDAGtk4XxmmfUy4GabvM+MegeB4cDLRi6nw=
 github.com/onsi/ginkgo/v2 v2.25.3/go.mod h1:43uiyQC4Ed2tkOzLsEYm7hnrb7UJTWHYNsuy3bG/snE=
 github.com/onsi/gomega v1.38.3 h1:eTX+W6dobAYfFeGC2PV6RwXRu/MyT+cQguijutvkpSM=


### PR DESCRIPTION
This commit implements the "Smart Defaulting" logic for the System Catalog as defined in Design 8 (API) and Design 4 (Admission Control).

Previously, the resolver only applied static defaults (images, template refs), leaving the `spec.databases` list empty if not provided by the user. This prevented the "Ultra-Minimalist" configuration (defining only Cells) from functioning, as no database would be reconciled.

Changes:
- Update `PopulateClusterDefaults` to automatically inject the mandatory `postgres` database (marked default) if the database list is empty.
- Automatically inject the mandatory `default` TableGroup if a database's tablegroup list is empty.
- Add system constants for default database and tablegroup names.
- Update unit tests to verify that minimalist configs now resolve to a fully valid System Catalog topology.

This prepares the shared resolver logic for the upcoming Mutating Webhook implementation and immediately fixes the fallback path for the Controller.