### PR TITLE
Add RBAC markers for API resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./api/..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./api/..." output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=config/rbac
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/v1alpha1/cell_types.go
+++ b/api/v1alpha1/cell_types.go
@@ -22,6 +22,21 @@ import (
 )
 
 // ============================================================================
+// RBAC Markers (Temporary Location)
+// ============================================================================
+//
+// TODO: Move these RBAC markers to the controller implementation
+// (pkg/resource-handler/controller/cell/cell_controller.go)
+// to follow kubebuilder conventions. They are temporarily placed here because
+// controller-gen cannot process files in go.work modules.
+//
+// +kubebuilder:rbac:groups=multigres.com,resources=cells,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=multigres.com,resources=cells/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=multigres.com,resources=cells/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+
+// ============================================================================
 // Cell Spec (Read-only API)
 // ============================================================================
 //

--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -22,6 +22,22 @@ import (
 )
 
 // ============================================================================
+// RBAC Markers (Temporary Location)
+// ============================================================================
+//
+// TODO: Move these RBAC markers to the controller implementation
+// (pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go)
+// to follow kubebuilder conventions. They are temporarily placed here because
+// controller-gen cannot process files in go.work modules.
+//
+// +kubebuilder:rbac:groups=multigres.com,resources=multigresclusters,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=multigres.com,resources=multigresclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=multigres.com,resources=multigresclusters/finalizers,verbs=update
+// +kubebuilder:rbac:groups=multigres.com,resources=coretemplates;celltemplates;shardtemplates,verbs=get;list;watch
+// +kubebuilder:rbac:groups=multigres.com,resources=cells;tablegroups;toposervers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+
+// ============================================================================
 // MultigresClusterSpec Spec (User-editable API)
 // ============================================================================
 

--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -22,6 +22,21 @@ import (
 )
 
 // ============================================================================
+// RBAC Markers (Temporary Location)
+// ============================================================================
+//
+// TODO: Move these RBAC markers to the controller implementation
+// (pkg/resource-handler/controller/shard/shard_controller.go)
+// to follow kubebuilder conventions. They are temporarily placed here because
+// controller-gen cannot process files in go.work modules.
+//
+// +kubebuilder:rbac:groups=multigres.com,resources=shards,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=multigres.com,resources=shards/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=multigres.com,resources=shards/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+
+// ============================================================================
 // Shard Component Specs (Reusable)
 // ============================================================================
 //

--- a/api/v1alpha1/tablegroup_types.go
+++ b/api/v1alpha1/tablegroup_types.go
@@ -21,6 +21,19 @@ import (
 )
 
 // ============================================================================
+// RBAC Markers (Temporary Location)
+// ============================================================================
+//
+// TODO: Move these RBAC markers to the controller implementation
+// (pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go)
+// to follow kubebuilder conventions. They are temporarily placed here because
+// controller-gen cannot process files in go.work modules.
+//
+// +kubebuilder:rbac:groups=multigres.com,resources=tablegroups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=multigres.com,resources=tablegroups/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=multigres.com,resources=shards,verbs=get;list;watch;create;update;patch;delete
+
+// ============================================================================
 // TableGroup Spec (Read-only API)
 // ============================================================================
 //

--- a/api/v1alpha1/toposerver_types.go
+++ b/api/v1alpha1/toposerver_types.go
@@ -22,6 +22,21 @@ import (
 )
 
 // ============================================================================
+// RBAC Markers (Temporary Location)
+// ============================================================================
+//
+// TODO: Move these RBAC markers to the controller implementation
+// (pkg/resource-handler/controller/toposerver/toposerver_controller.go)
+// to follow kubebuilder conventions. They are temporarily placed here because
+// controller-gen cannot process files in go.work modules.
+//
+// +kubebuilder:rbac:groups=multigres.com,resources=toposervers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=multigres.com,resources=toposervers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=multigres.com,resources=toposervers/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+
+// ============================================================================
 // TopoServer Spec (Read-only API)
 // ============================================================================
 //

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/numtide/multigres-operator
-  newTag: 84cd6d9-dirty
+  newTag: 9d6dd13-dirty

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,7 +33,9 @@ rules:
   - multigres.com
   resources:
   - cells
+  - multigresclusters
   - shards
+  - tablegroups
   - toposervers
   verbs:
   - create
@@ -47,6 +49,7 @@ rules:
   - multigres.com
   resources:
   - cells/finalizers
+  - multigresclusters/finalizers
   - shards/finalizers
   - toposervers/finalizers
   verbs:
@@ -55,9 +58,21 @@ rules:
   - multigres.com
   resources:
   - cells/status
+  - multigresclusters/status
   - shards/status
+  - tablegroups/status
   - toposervers/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - multigres.com
+  resources:
+  - celltemplates
+  - coretemplates
+  - shardtemplates
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This is a temporary solution to ensure controller-gen can pick up the
marker and create the CRDs. This should be coming from the controller
code, and will be corrected in the near future.