### PR TITLE
refactor(resolver): centralize template validation logic

### DIFF
--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,6 +36,34 @@ func NewResolver(
 	}
 }
 
+// ValidateCoreTemplateReference checks if a CoreTemplate reference is valid.
+// It returns nil if:
+// 1. The name is empty (no reference).
+// 2. The name matches the FallbackCoreTemplate (assumed to be a system default or implicitly allowed).
+// 3. The referenced CoreTemplate exists in the Resolver's namespace.
+// Otherwise, it returns an error.
+func (r *Resolver) ValidateCoreTemplateReference(ctx context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	if name == FallbackCoreTemplate {
+		return nil
+	}
+
+	exists, err := r.CoreTemplateExists(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf(
+			"referenced CoreTemplate '%s' not found in namespace '%s'",
+			name,
+			r.Namespace,
+		)
+	}
+	return nil
+}
+
 // CoreTemplateExists checks if a CoreTemplate with the given name exists in the current namespace.
 func (r *Resolver) CoreTemplateExists(ctx context.Context, name string) (bool, error) {
 	if name == "" {
@@ -51,6 +80,30 @@ func (r *Resolver) CoreTemplateExists(ctx context.Context, name string) (bool, e
 	return true, nil
 }
 
+// ValidateCellTemplateReference checks if a CellTemplate reference is valid.
+// See ValidateCoreTemplateReference for logic details.
+func (r *Resolver) ValidateCellTemplateReference(ctx context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	if name == FallbackCellTemplate {
+		return nil
+	}
+
+	exists, err := r.CellTemplateExists(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf(
+			"referenced CellTemplate '%s' not found in namespace '%s'",
+			name,
+			r.Namespace,
+		)
+	}
+	return nil
+}
+
 // CellTemplateExists checks if a CellTemplate with the given name exists in the current namespace.
 func (r *Resolver) CellTemplateExists(ctx context.Context, name string) (bool, error) {
 	if name == "" {
@@ -65,6 +118,30 @@ func (r *Resolver) CellTemplateExists(ctx context.Context, name string) (bool, e
 		return false, err
 	}
 	return true, nil
+}
+
+// ValidateShardTemplateReference checks if a ShardTemplate reference is valid.
+// See ValidateCoreTemplateReference for logic details.
+func (r *Resolver) ValidateShardTemplateReference(ctx context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	if name == FallbackShardTemplate {
+		return nil
+	}
+
+	exists, err := r.ShardTemplateExists(ctx, name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf(
+			"referenced ShardTemplate '%s' not found in namespace '%s'",
+			name,
+			r.Namespace,
+		)
+	}
+	return nil
 }
 
 // ShardTemplateExists checks if a ShardTemplate with the given name exists in the current namespace.

--- a/pkg/webhook/handlers/validator_test.go
+++ b/pkg/webhook/handlers/validator_test.go
@@ -94,7 +94,7 @@ func TestMultigresClusterValidator(t *testing.T) {
 				OnGet: func(key client.ObjectKey) error { return testutil.ErrInjected },
 			},
 			wantAllowed: false,
-			wantMessage: "failed to check CoreTemplate",
+			wantMessage: "injected test error",
 		},
 		"Error: Client Error (CellTemplate)": {
 			object: func() *multigresv1alpha1.MultigresCluster {
@@ -113,7 +113,7 @@ func TestMultigresClusterValidator(t *testing.T) {
 				},
 			},
 			wantAllowed: false,
-			wantMessage: "failed to check CellTemplate",
+			wantMessage: "injected test error",
 		},
 		"Error: Client Error (ShardTemplate)": {
 			object:    baseCluster.DeepCopy(),
@@ -127,7 +127,7 @@ func TestMultigresClusterValidator(t *testing.T) {
 				},
 			},
 			wantAllowed: false,
-			wantMessage: "failed to check ShardTemplate",
+			wantMessage: "injected test error",
 		},
 		"Error: Client Error (MultiAdmin)": {
 			object: func() *multigresv1alpha1.MultigresCluster {
@@ -145,7 +145,7 @@ func TestMultigresClusterValidator(t *testing.T) {
 				},
 			},
 			wantAllowed: false,
-			wantMessage: "failed to check CoreTemplate",
+			wantMessage: "injected test error",
 		},
 		"Error: Client Error (Inline Cell)": {
 			object: func() *multigresv1alpha1.MultigresCluster {
@@ -165,7 +165,7 @@ func TestMultigresClusterValidator(t *testing.T) {
 				},
 			},
 			wantAllowed: false,
-			wantMessage: "failed to check CellTemplate",
+			wantMessage: "injected test error",
 		},
 		"Error: Client Error (Inline Shard)": {
 			object: func() *multigresv1alpha1.MultigresCluster {
@@ -189,7 +189,7 @@ func TestMultigresClusterValidator(t *testing.T) {
 				},
 			},
 			wantAllowed: false,
-			wantMessage: "failed to check ShardTemplate",
+			wantMessage: "injected test error",
 		},
 		"Allowed: Missing Fallback Templates": {
 			object: func() *multigresv1alpha1.MultigresCluster {


### PR DESCRIPTION
Refactors the validation of Core, Cell, and Shard templates to centralize "existence checks" within the `pkg/resolver` package, eliminating logic duplication in the Webhook.

**Changes:**
- **`pkg/resolver`**: Added `Validate*TemplateReference` methods. These methods now act as the single source of truth for validation, encapsulating rules such as "allow empty" and "allow 'default' (system fallback)".
- **`pkg/webhook`**: Refactored `validator.go` to delegate all template existence checks to the Resolver. Removed manual `check` functions and hardcoded fallback logic (e.g., `if name == "default"`).
- **Tests**: Updated unit tests in both `pkg/resolver` and `pkg/webhook` to cover the new methods and error propagation paths, maintaining 100% code coverage.

**Benefits:**
- **DRY Principle**: Removed ~40 lines of duplicate validation logic from the Webhook.
- **Consistency**: Ensures that both the Webhook (validating/mutating) and the Controller (reconciling) use the exact same logic for determining if a template reference is valid.
- **Maintainability**: Future changes to fallback strategies (e.g., adding `system-default` aliases) only need to be implemented in one place.