### PR TITLE
refactor(cluster-handler): implement Server-Side Apply for all controllers

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/integration_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_test.go
@@ -70,8 +70,9 @@ func setupIntegration(t *testing.T) (client.Client, *testutil.ResourceWatcher) {
 
 	// 3. Setup Controller
 	reconciler := &multigrescluster.MultigresClusterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("multigres-cluster-controller"),
 	}
 
 	if err := reconciler.SetupWithManager(mgr, controller.Options{

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
@@ -550,12 +550,12 @@ func TestMultigresClusterReconciler_Lifecycle(t *testing.T) {
 			existingObjects: []client.Object{coreTpl, cellTpl, shardTpl},
 			wantErrMsg:      "exceeds 50 characters",
 		},
-		"Error: Create TableGroup Failed": {
+		"Error: Apply TableGroup Failed": {
 			existingObjects: []client.Object{coreTpl, cellTpl, shardTpl},
 			failureConfig: &testutil.FailureConfig{
-				OnCreate: testutil.FailOnObjectName(clusterName+"-db1-tg1", errSimulated),
+				OnPatch: testutil.FailOnObjectName(clusterName+"-db1-tg1", errSimulated),
 			},
-			wantErrMsg: "failed to create tablegroup",
+			wantErrMsg: "failed to apply tablegroup",
 		},
 		"Error: Delete Orphan TableGroup Failed": {
 			existingObjects: []client.Object{

--- a/pkg/cluster-handler/controller/multigrescluster/status_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/status_test.go
@@ -1,72 +1,24 @@
 package multigrescluster
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/numtide/multigres-operator/pkg/testutil"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 )
 
 func TestReconcile_Status(t *testing.T) {
-	coreTpl, cellTpl, shardTpl, _, clusterName, namespace, _ := setupFixtures(t)
+	_, _, _, _, clusterName, _, _ := setupFixtures(t)
 	errSimulated := errors.New("simulated error for testing")
 
 	tests := map[string]reconcileTestCase{
-		"Reconcile: Status Available (All Ready)": {
-			existingObjects: []client.Object{
-				coreTpl, cellTpl, shardTpl,
-				// Existing Cell that is Ready (Mocking status from child controller)
-				&multigresv1alpha1.Cell{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      clusterName + "-zone-a",
-						Namespace: namespace,
-						Labels:    map[string]string{"multigres.com/cluster": clusterName},
-					},
-					Spec: multigresv1alpha1.CellSpec{Name: "zone-a"},
-					Status: multigresv1alpha1.CellStatus{
-						Conditions: []metav1.Condition{
-							{Type: "Available", Status: metav1.ConditionTrue},
-						},
-						GatewayReplicas: 2,
-					},
-				},
-			},
-			validate: func(t testing.TB, c client.Client) {
-				ctx := t.Context()
-				cluster := &multigresv1alpha1.MultigresCluster{}
-				if err := c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: namespace}, cluster); err != nil {
-					t.Fatal(err)
-				}
-
-				// Verify Aggregated Status
-				cond := meta.FindStatusCondition(cluster.Status.Conditions, "Available")
-				if cond == nil {
-					t.Fatal("Available condition not found")
-					return // explicit return to satisfy linter
-				}
-				if cond.Status != metav1.ConditionTrue {
-					t.Errorf("Expected Available=True, got %s", cond.Status)
-				}
-
-				// Verify Cell Summary
-				summary, ok := cluster.Status.Cells["zone-a"]
-				if !ok {
-					t.Fatal("Cell zone-a summary missing")
-				}
-				if !summary.Ready {
-					t.Error("Expected Cell summary Ready=true")
-				}
-				if summary.GatewayReplicas != 2 {
-					t.Errorf("Expected GatewayReplicas=2, got %d", summary.GatewayReplicas)
-				}
-			},
-		},
 		"Error: UpdateStatus (List Cells Failed)": {
 			failureConfig: &testutil.FailureConfig{
 				OnList: func() func(client.ObjectList) error {
@@ -110,4 +62,94 @@ func TestReconcile_Status(t *testing.T) {
 	}
 
 	runReconcileTest(t, tests)
+}
+
+func TestUpdateStatus_Coverage(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	}
+
+	// Ready Cell
+	cell := &multigresv1alpha1.Cell{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cell-1",
+			Namespace: "default",
+			Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+		},
+		Spec: multigresv1alpha1.CellSpec{
+			Name: "cell-1",
+		},
+		Status: multigresv1alpha1.CellStatus{
+			Conditions: []metav1.Condition{
+				{Type: "Available", Status: metav1.ConditionTrue},
+			},
+			GatewayReplicas: 1,
+		},
+	}
+
+	// Ready TableGroup
+	tg := &multigresv1alpha1.TableGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tg-1",
+			Namespace: "default",
+			Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+		},
+		Spec: multigresv1alpha1.TableGroupSpec{
+			DatabaseName: "db1",
+		},
+		Status: multigresv1alpha1.TableGroupStatus{
+			ReadyShards: 1,
+			TotalShards: 1,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, cell, tg).
+		WithStatusSubresource(cluster, cell, tg).
+		Build()
+
+	r := &MultigresClusterReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	if err := r.updateStatus(context.Background(), cluster); err != nil {
+		t.Fatalf("updateStatus failed: %v", err)
+	}
+
+	// Refresh cluster
+	if err := fakeClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), cluster); err != nil {
+		t.Fatalf("Failed to refresh cluster: %v", err)
+	}
+
+	// Verify Available Condition
+	found := false
+	for _, c := range cluster.Status.Conditions {
+		if c.Type == "Available" {
+			found = true
+			if c.Status != metav1.ConditionTrue {
+				t.Errorf("Expected Available=True, got %s", c.Status)
+			}
+		}
+	}
+	if !found {
+		t.Error("Available condition not found")
+	}
+
+	// Verify Cell Status Summary
+	if s, ok := cluster.Status.Cells["cell-1"]; !ok || !s.Ready {
+		t.Errorf("Expected cell-1 to be ready in status summary, got %v", s)
+	}
+
+	// Verify Database Status Summary
+	if s, ok := cluster.Status.Databases["db1"]; !ok || s.ReadyShards != 1 {
+		t.Errorf("Expected db1 to have 1 ready shard in status summary, got %v", s)
+	}
 }

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
@@ -413,54 +413,17 @@ func TestTableGroupReconciler_Reconcile_Failure(t *testing.T) {
 				OnGet: testutil.FailOnKeyName(tgName, errSimulated),
 			},
 		},
-		"Error: Create/Update Shard Failed": {
+		"Error: Apply Shard Failed": {
 			tableGroup:      baseTG.DeepCopy(),
 			existingObjects: []client.Object{},
 			failureConfig: &testutil.FailureConfig{
-				OnCreate: testutil.FailOnObjectName(
+				OnPatch: testutil.FailOnObjectName(
 					fmt.Sprintf("%s-%s", tgName, "shard-0"),
 					errSimulated,
 				),
 			},
 		},
-		"Error: Get Shard Failed (Generic)": {
-			tableGroup:      baseTG.DeepCopy(),
-			existingObjects: []client.Object{
-				// Need shard to exist? No, Get is called before check.
-				// But to distinguish from NotFound, OnGet must return generic error.
-				// Fake client default Get returns NotFound if missing.
-				// FailureConfig overrides.
-			},
-			failureConfig: &testutil.FailureConfig{
-				OnGet: testutil.FailOnKeyName(
-					fmt.Sprintf("%s-%s", tgName, "shard-0"),
-					errSimulated,
-				),
-			},
-		},
-		"Error: Update Shard Failed": {
-			tableGroup: baseTG.DeepCopy(),
-			existingObjects: []client.Object{
-				&multigresv1alpha1.Shard{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("%s-%s", tgName, "shard-0"),
-						Namespace: namespace,
-						Labels: map[string]string{
-							"multigres.com/cluster":    clusterName,
-							"multigres.com/database":   dbName,
-							"multigres.com/tablegroup": tgLabelName,
-						},
-					},
-					Spec: multigresv1alpha1.ShardSpec{ShardName: "shard-0"},
-				},
-			},
-			failureConfig: &testutil.FailureConfig{
-				OnUpdate: testutil.FailOnObjectName(
-					fmt.Sprintf("%s-%s", tgName, "shard-0"),
-					errSimulated,
-				),
-			},
-		},
+
 		"Error: List Shards Failed (during pruning)": {
 			tableGroup:      baseTG.DeepCopy(),
 			existingObjects: []client.Object{},

--- a/pkg/webhook/handlers/validator.go
+++ b/pkg/webhook/handlers/validator.go
@@ -279,7 +279,6 @@ func (v *ChildResourceValidator) validate(
 		kind = "Resource"
 	}
 
-	// FIX: ST1005: error strings should not be capitalized or end with punctuation
 	return nil, fmt.Errorf(
 		"direct modification of %s is prohibited; this resource is managed by the MultigresCluster parent object",
 		kind,


### PR DESCRIPTION
Refactors `MultigresCluster` and TableGroup controllers to use Server-Side Apply (SSA) for resource management, replacing the legacy Get/Create/Update pattern.

Changes:
- Replaced client.Create/Update calls with `client.Patch(..., client.Apply)` in `reconcile_global`, `reconcile_cells`, `reconcile_databases`, and `tablegroup_controller`.
- Standardized FieldOwner to "multigres-operator" for clear ownership.
- Removed unnecessary `Get` checks and "IsNew" logic, simplifying the reconciliation loop.
- Standardized eventing to emit "Applied" for all successful operations, removing ambiguous "Created"/"Updated" distinction.
- Added safety check for `EventRecorder` in `tablegroup_controller` to prevent panics in test environments.
- Updated unit and integration tests to reflect SSA behavior and removed obsolete test cases (e.g., Get failures).

Benefits:
- Atomicity: Reduces race conditions by handling creation and updates in a single atomic operation.
- Efficiency: Reduces API server round-trips by removing read-before-write checks.
- Robustness: Simplifies error handling and conflict resolution.
- 100% Test Coverage maintained across the module.