### PR TITLE
feat(api): add kubectl shorthands for all custom resources

### DIFF
--- a/api/v1alpha1/cell_types.go
+++ b/api/v1alpha1/cell_types.go
@@ -140,6 +140,7 @@ type CellStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status"
 
 // Cell is the Schema for the cells API
+// +kubebuilder:resource:shortName=cel
 type Cell struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/celltemplate_types.go
+++ b/api/v1alpha1/celltemplate_types.go
@@ -43,6 +43,7 @@ type CellTemplateSpec struct {
 // +kubebuilder:resource:scope=Namespaced
 
 // CellTemplate is the Schema for the celltemplates API
+// +kubebuilder:resource:shortName=cet
 type CellTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/coretemplate_types.go
+++ b/api/v1alpha1/coretemplate_types.go
@@ -44,6 +44,7 @@ type CoreTemplateSpec struct {
 // +kubebuilder:resource:scope=Namespaced
 
 // CoreTemplate is the Schema for the coretemplates API
+// +kubebuilder:resource:shortName=cot
 type CoreTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -357,6 +357,7 @@ type DatabaseStatusSummary struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // MultigresCluster is the Schema for the multigresclusters API
+// +kubebuilder:resource:shortName=mgc
 type MultigresCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -187,6 +187,7 @@ type ShardStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status"
 
 // Shard is the Schema for the shards API
+// +kubebuilder:resource:shortName=srd
 type Shard struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/shardtemplate_types.go
+++ b/api/v1alpha1/shardtemplate_types.go
@@ -44,6 +44,7 @@ type ShardTemplateSpec struct {
 // +kubebuilder:resource:scope=Namespaced
 
 // ShardTemplate is the Schema for the shardtemplates API
+// +kubebuilder:resource:shortName=sht
 type ShardTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/tablegroup_types.go
+++ b/api/v1alpha1/tablegroup_types.go
@@ -104,6 +104,7 @@ type TableGroupStatus struct {
 // +kubebuilder:printcolumn:name="Shards",type="integer",JSONPath=".status.readyShards"
 
 // TableGroup is the Schema for the tablegroups API
+// +kubebuilder:resource:shortName=tbg
 type TableGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/toposerver_types.go
+++ b/api/v1alpha1/toposerver_types.go
@@ -193,6 +193,7 @@ type GlobalTopoServerRef struct {
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status"
 
 // TopoServer is the Schema for the toposervers API
+// +kubebuilder:resource:shortName=tps
 type TopoServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/multigres.com_cells.yaml
+++ b/config/crd/bases/multigres.com_cells.yaml
@@ -11,6 +11,8 @@ spec:
     kind: Cell
     listKind: CellList
     plural: cells
+    shortNames:
+    - cel
     singular: cell
   scope: Namespaced
   versions:

--- a/config/crd/bases/multigres.com_celltemplates.yaml
+++ b/config/crd/bases/multigres.com_celltemplates.yaml
@@ -11,6 +11,8 @@ spec:
     kind: CellTemplate
     listKind: CellTemplateList
     plural: celltemplates
+    shortNames:
+    - cet
     singular: celltemplate
   scope: Namespaced
   versions:

--- a/config/crd/bases/multigres.com_coretemplates.yaml
+++ b/config/crd/bases/multigres.com_coretemplates.yaml
@@ -11,6 +11,8 @@ spec:
     kind: CoreTemplate
     listKind: CoreTemplateList
     plural: coretemplates
+    shortNames:
+    - cot
     singular: coretemplate
   scope: Namespaced
   versions:

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -11,6 +11,8 @@ spec:
     kind: MultigresCluster
     listKind: MultigresClusterList
     plural: multigresclusters
+    shortNames:
+    - mgc
     singular: multigrescluster
   scope: Namespaced
   versions:

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -11,6 +11,8 @@ spec:
     kind: Shard
     listKind: ShardList
     plural: shards
+    shortNames:
+    - srd
     singular: shard
   scope: Namespaced
   versions:

--- a/config/crd/bases/multigres.com_shardtemplates.yaml
+++ b/config/crd/bases/multigres.com_shardtemplates.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ShardTemplate
     listKind: ShardTemplateList
     plural: shardtemplates
+    shortNames:
+    - sht
     singular: shardtemplate
   scope: Namespaced
   versions:

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -11,6 +11,8 @@ spec:
     kind: TableGroup
     listKind: TableGroupList
     plural: tablegroups
+    shortNames:
+    - tbg
     singular: tablegroup
   scope: Namespaced
   versions:

--- a/config/crd/bases/multigres.com_toposervers.yaml
+++ b/config/crd/bases/multigres.com_toposervers.yaml
@@ -11,6 +11,8 @@ spec:
     kind: TopoServer
     listKind: TopoServerList
     plural: toposervers
+    shortNames:
+    - tps
     singular: toposerver
   scope: Namespaced
   versions:


### PR DESCRIPTION
Users required a more efficient way to interact with Multigres resources via kubectl without typing full resource names or relying on potentially ambiguous system defaults.

- Added `+kubebuilder:resource:shortName` markers to all API types in `api/v1alpha1`
- Regenerated CRD manifests to include `shortNames` for `mgc`, `tbg`, `srd`, `cel`, `tps`, `cot`, `cet`, and `sht`

Significantly improves developer experience and speed when listing and managing operator resources from the command line.