### PR TITLE
fix(api): enforce stricter character limits on resource names

### DIFF
--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -170,18 +170,18 @@ type MultiAdminConfig struct {
 type CellConfig struct {
 	// Name is the logical name of the cell.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MaxLength=30
 	Name string `json:"name"`
 
 	// Zone indicates the physical availability zone.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MaxLength=30
 	Zone string `json:"zone,omitempty"`
 	// Region indicates the physical region (mutually exclusive with zone typically, but allowed here).
 	// +optional
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MaxLength=30
 	Region string `json:"region,omitempty"`
 
 	// CellTemplate refers to a CellTemplate CR.
@@ -225,7 +225,7 @@ type CellInlineSpec struct {
 type DatabaseConfig struct {
 	// Name is the logical name of the database.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MaxLength=30
 	Name string `json:"name"`
 
 	// Default indicates if this is the system default database.
@@ -246,7 +246,7 @@ type DatabaseConfig struct {
 type TableGroupConfig struct {
 	// Name is the logical name of the table group.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MaxLength=25
 	Name string `json:"name"`
 
 	// Default indicates if this is the default/unsharded group.
@@ -267,7 +267,7 @@ type TableGroupConfig struct {
 type ShardConfig struct {
 	// Name is the identifier of the shard (e.g., "0", "1").
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MaxLength=25
 	Name string `json:"name"`
 
 	// ShardTemplate refers to a ShardTemplate CR.
@@ -294,7 +294,7 @@ type ShardOverrides struct {
 	// Pools overrides. Keyed by pool name.
 	// +optional
 	// +kubebuilder:validation:MaxProperties=8
-	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) < 63)",message="pool names must be < 63 chars"
+	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) <= 25)",message="pool names must be <= 25 chars"
 	Pools map[string]PoolSpec `json:"pools,omitempty"`
 }
 
@@ -307,7 +307,7 @@ type ShardInlineSpec struct {
 	// Pools configuration. Keyed by pool name.
 	// +optional
 	// +kubebuilder:validation:MaxProperties=8
-	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) < 63)",message="pool names must be < 63 chars"
+	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) <= 25)",message="pool names must be <= 25 chars"
 	Pools map[string]PoolSpec `json:"pools,omitempty"`
 }
 
@@ -327,13 +327,13 @@ type MultigresClusterStatus struct {
 	// Cells status summary.
 	// +optional
 	// +kubebuilder:validation:MaxProperties=50
-	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) < 63)",message="cell names must be < 63 chars"
+	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) <= 30)",message="cell names must be <= 30 chars"
 	Cells map[string]CellStatusSummary `json:"cells,omitempty"`
 
 	// Databases status summary.
 	// +optional
 	// +kubebuilder:validation:MaxProperties=50
-	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) < 63)",message="database names must be < 63 chars"
+	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) <= 30)",message="database names must be <= 30 chars"
 	Databases map[string]DatabaseStatusSummary `json:"databases,omitempty"`
 }
 
@@ -360,6 +360,7 @@ type DatabaseStatusSummary struct {
 
 // MultigresCluster is the Schema for the multigresclusters API
 // +kubebuilder:resource:shortName=mgc
+// +kubebuilder:validation:XValidation:rule="self.metadata.name.size() <= 25",message="MultigresCluster name must be at most 25 characters"
 type MultigresCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -61,7 +61,7 @@ spec:
                       type: string
                     name:
                       description: Name is the logical name of the cell.
-                      maxLength: 63
+                      maxLength: 30
                       minLength: 1
                       type: string
                     overrides:
@@ -1098,7 +1098,7 @@ spec:
                     region:
                       description: Region indicates the physical region (mutually
                         exclusive with zone typically, but allowed here).
-                      maxLength: 63
+                      maxLength: 30
                       minLength: 1
                       type: string
                     spec:
@@ -2284,7 +2284,7 @@ spec:
                       type: object
                     zone:
                       description: Zone indicates the physical availability zone.
-                      maxLength: 63
+                      maxLength: 30
                       minLength: 1
                       type: string
                   required:
@@ -2314,7 +2314,7 @@ spec:
                       type: boolean
                     name:
                       description: Name is the logical name of the database.
-                      maxLength: 63
+                      maxLength: 30
                       minLength: 1
                       type: string
                     tablegroups:
@@ -2329,7 +2329,7 @@ spec:
                             type: boolean
                           name:
                             description: Name is the logical name of the table group.
-                            maxLength: 63
+                            maxLength: 25
                             minLength: 1
                             type: string
                           shards:
@@ -2340,7 +2340,7 @@ spec:
                                 name:
                                   description: Name is the identifier of the shard
                                     (e.g., "0", "1").
-                                  maxLength: 63
+                                  maxLength: 25
                                   minLength: 1
                                   type: string
                                 overrides:
@@ -4634,8 +4634,8 @@ spec:
                                       maxProperties: 8
                                       type: object
                                       x-kubernetes-validations:
-                                      - message: pool names must be < 63 chars
-                                        rule: self.all(key, size(key) < 63)
+                                      - message: pool names must be <= 25 chars
+                                        rule: self.all(key, size(key) <= 25)
                                   type: object
                                 shardTemplate:
                                   description: ShardTemplate refers to a ShardTemplate
@@ -6934,8 +6934,8 @@ spec:
                                       maxProperties: 8
                                       type: object
                                       x-kubernetes-validations:
-                                      - message: pool names must be < 63 chars
-                                        rule: self.all(key, size(key) < 63)
+                                      - message: pool names must be <= 25 chars
+                                        rule: self.all(key, size(key) <= 25)
                                   type: object
                               required:
                               - name
@@ -8255,8 +8255,8 @@ spec:
                 maxProperties: 50
                 type: object
                 x-kubernetes-validations:
-                - message: cell names must be < 63 chars
-                  rule: self.all(key, size(key) < 63)
+                - message: cell names must be <= 30 chars
+                  rule: self.all(key, size(key) <= 30)
               conditions:
                 description: Conditions represent the latest available observations.
                 items:
@@ -8333,14 +8333,17 @@ spec:
                 maxProperties: 50
                 type: object
                 x-kubernetes-validations:
-                - message: database names must be < 63 chars
-                  rule: self.all(key, size(key) < 63)
+                - message: database names must be <= 30 chars
+                  rule: self.all(key, size(key) <= 30)
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed.
                 format: int64
                 type: integer
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: MultigresCluster name must be at most 25 characters
+          rule: self.metadata.name.size() <= 25
     served: true
     storage: true
     subresources:

--- a/config/samples/minimal.yaml
+++ b/config/samples/minimal.yaml
@@ -1,7 +1,7 @@
 apiVersion: multigres.com/v1alpha1
 kind: MultigresCluster
 metadata:
-  name: minimal-cluster
+  name: minimal
   namespace: default
 spec:
   # A minimal cluster requires at least one cell definition.

--- a/pkg/cluster-handler/controller/multigrescluster/integration_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_test.go
@@ -148,7 +148,7 @@ func clusterOwnerRefs(t testing.TB, clusterName string) []metav1.OwnerReference 
 func TestMultigresCluster_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	const clusterName = "test-integration-cluster"
+	const clusterName = "test-cluster"
 
 	tests := map[string]struct {
 		cluster       *multigresv1alpha1.MultigresCluster


### PR DESCRIPTION
Long resource names can cause deployment failures when the operator generates child resources (like Service or Pod names) by concatenating strings, exceeding Kubernetes 63-character DNS limits.

- Added CEL validation rule to limit `MultigresCluster` metadata.name to 25 characters
- Reduced `TableGroup`, `Shard`, and `Pool` name max lengths to 25 characters (was 63)
- Reduced `Cell`, `Zone`, `Region`, and `Database` name max lengths to 30 characters (was 63)
- Updated integration tests to use compliant, shorter resource names

Prevents runtime errors during reconciliation caused by generated resource names exceeding Kubernetes length limits.