### PR TITLE
refactor(pkg/util): centralize resource labeling logic

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
@@ -6,6 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
 	"github.com/numtide/multigres-operator/pkg/util/name"
 )
 
@@ -19,6 +20,10 @@ func BuildCell(
 	allCellNames []multigresv1alpha1.CellName,
 	scheme *runtime.Scheme,
 ) (*multigresv1alpha1.Cell, error) {
+	labels := metadata.BuildStandardLabels(cluster.Name, metadata.ComponentCell)
+	metadata.AddClusterLabel(labels, cluster.Name)
+	metadata.AddCellLabel(labels, cellCfg.Name)
+
 	cellCR := &multigresv1alpha1.Cell{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name.JoinWithConstraints(
@@ -27,10 +32,7 @@ func BuildCell(
 				cellCfg.Name,
 			),
 			Namespace: cluster.Namespace,
-			Labels: map[string]string{
-				"multigres.com/cluster": cluster.Name,
-				"multigres.com/cell":    cellCfg.Name,
-			},
+			Labels:    labels,
 		},
 		Spec: multigresv1alpha1.CellSpec{
 			Name:   cellCfg.Name,

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
@@ -6,6 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
 	"github.com/numtide/multigres-operator/pkg/util/name"
 )
 
@@ -25,15 +26,16 @@ func BuildTableGroup(
 		tgCfg.Name,
 	)
 
+	labels := metadata.BuildStandardLabels(cluster.Name, metadata.ComponentTableGroup)
+	metadata.AddClusterLabel(labels, cluster.Name)
+	metadata.AddDatabaseLabel(labels, dbName)
+	metadata.AddTableGroupLabel(labels, tgCfg.Name)
+
 	tgCR := &multigresv1alpha1.TableGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tgNameFull,
 			Namespace: cluster.Namespace,
-			Labels: map[string]string{
-				"multigres.com/cluster":    cluster.Name,
-				"multigres.com/database":   dbName,
-				"multigres.com/tablegroup": tgCfg.Name,
-			},
+			Labels:    labels,
 		},
 		Spec: multigresv1alpha1.TableGroupSpec{
 			DatabaseName:   dbName,

--- a/pkg/cluster-handler/controller/tablegroup/builders.go
+++ b/pkg/cluster-handler/controller/tablegroup/builders.go
@@ -6,6 +6,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
 	"github.com/numtide/multigres-operator/pkg/util/name"
 )
 
@@ -17,24 +18,27 @@ func BuildShard(
 ) (*multigresv1alpha1.Shard, error) {
 	// Build shard name from logical parts (cluster, database, tablegroup, shard)
 	// NOT using tg.Name which includes the parent's hash
+	clusterName := tg.Labels[metadata.LabelMultigresCluster]
+
 	shardNameFull := name.JoinWithConstraints(
 		name.DefaultConstraints,
-		tg.Labels["multigres.com/cluster"],
+		clusterName,
 		tg.Spec.DatabaseName,
 		tg.Spec.TableGroupName,
 		shardSpec.Name,
 	)
 
+	labels := metadata.BuildStandardLabels(clusterName, metadata.ComponentShard)
+	metadata.AddClusterLabel(labels, clusterName)
+	metadata.AddDatabaseLabel(labels, tg.Spec.DatabaseName)
+	metadata.AddTableGroupLabel(labels, tg.Spec.TableGroupName)
+	metadata.AddShardLabel(labels, shardSpec.Name)
+
 	shardCR := &multigresv1alpha1.Shard{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      shardNameFull,
 			Namespace: tg.Namespace,
-			Labels: map[string]string{
-				"multigres.com/cluster":    tg.Labels["multigres.com/cluster"],
-				"multigres.com/database":   tg.Spec.DatabaseName,
-				"multigres.com/tablegroup": tg.Spec.TableGroupName,
-				"multigres.com/shard":      shardSpec.Name,
-			},
+			Labels:    labels,
 		},
 		Spec: multigresv1alpha1.ShardSpec{
 			DatabaseName:     tg.Spec.DatabaseName,

--- a/pkg/cluster-handler/controller/tablegroup/integration_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/integration_test.go
@@ -19,6 +19,7 @@ import (
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/cluster-handler/controller/tablegroup"
 	"github.com/numtide/multigres-operator/pkg/testutil"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
 	nameutil "github.com/numtide/multigres-operator/pkg/util/name"
 )
 
@@ -144,14 +145,9 @@ func TestTableGroupReconciliation(t *testing.T) {
 				// Shard 1
 				&multigresv1alpha1.Shard{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tg-test-simple-s1",
-						Namespace: "default",
-						Labels: map[string]string{
-							"multigres.com/cluster":    "test-cluster",
-							"multigres.com/database":   "db1",
-							"multigres.com/tablegroup": "tg1",
-							"multigres.com/shard":      "s1",
-						},
+						Name:            "tg-test-simple-s1",
+						Namespace:       "default",
+						Labels:          shardLabels("test-cluster", "db1", "tg1", "s1"),
 						OwnerReferences: tgOwnerRefs(t, "tg-test-simple"),
 					},
 					Spec: multigresv1alpha1.ShardSpec{
@@ -184,14 +180,9 @@ func TestTableGroupReconciliation(t *testing.T) {
 				// Shard 2
 				&multigresv1alpha1.Shard{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "tg-test-simple-s2",
-						Namespace: "default",
-						Labels: map[string]string{
-							"multigres.com/cluster":    "test-cluster",
-							"multigres.com/database":   "db1",
-							"multigres.com/tablegroup": "tg1",
-							"multigres.com/shard":      "s2",
-						},
+						Name:            "tg-test-simple-s2",
+						Namespace:       "default",
+						Labels:          shardLabels("test-cluster", "db1", "tg1", "s2"),
 						OwnerReferences: tgOwnerRefs(t, "tg-test-simple"),
 					},
 					Spec: multigresv1alpha1.ShardSpec{
@@ -291,6 +282,15 @@ func TestTableGroupReconciliation(t *testing.T) {
 }
 
 // Helpers
+
+func shardLabels(clusterName, db, tg, shard string) map[string]string {
+	labels := metadata.BuildStandardLabels(clusterName, "shard")
+	metadata.AddClusterLabel(labels, clusterName)
+	metadata.AddDatabaseLabel(labels, db)
+	metadata.AddTableGroupLabel(labels, tg)
+	metadata.AddShardLabel(labels, shard)
+	return labels
+}
 
 func tgOwnerRefs(t testing.TB, tgName string) []metav1.OwnerReference {
 	t.Helper()

--- a/pkg/util/metadata/doc.go
+++ b/pkg/util/metadata/doc.go
@@ -1,0 +1,6 @@
+// Package metadata provides utilities for building Kubernetes resource metadata
+// such as labels, annotations, and owner references used across all Multigres components.
+//
+// This package contains generic, reusable functions that are component-agnostic.
+// Component-specific logic should be provided by callers through function parameters.
+package metadata

--- a/pkg/util/metadata/labels.go
+++ b/pkg/util/metadata/labels.go
@@ -1,0 +1,145 @@
+package metadata
+
+import "maps"
+
+// Standard Kubernetes label keys following kubernetes.io conventions.
+//
+// See: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
+const (
+	// LabelAppName is the standard label key for the application name.
+	LabelAppName = "app.kubernetes.io/name"
+
+	// LabelAppInstance is the standard label key for the unique instance name.
+	LabelAppInstance = "app.kubernetes.io/instance"
+
+	// LabelAppVersion is the standard label key for the application version.
+	LabelAppVersion = "app.kubernetes.io/version"
+
+	// LabelAppComponent is the standard label key for the component within the
+	// application.
+	LabelAppComponent = "app.kubernetes.io/component"
+
+	// LabelAppPartOf is the standard label key for the name of a higher level
+	// application this one is part of.
+	LabelAppPartOf = "app.kubernetes.io/part-of"
+
+	// LabelAppManagedBy is the standard label key for the tool managing the
+	// resource.
+	LabelAppManagedBy = "app.kubernetes.io/managed-by"
+)
+
+const (
+	// AppNameMultigres is the fixed application name for all Multigres resources.
+	AppNameMultigres = "multigres"
+
+	// ManagedByMultigres identifies the operator managing these resources.
+	ManagedByMultigres = "multigres-operator"
+)
+
+const (
+	// ComponentMultiAdmin identifies the multiadmin component.
+	ComponentMultiAdmin = "multiadmin"
+
+	// ComponentGlobalTopo identifies the global-topo component.
+	ComponentGlobalTopo = "global-topo"
+
+	// ComponentCell identifies the cell component.
+	ComponentCell = "cell"
+
+	// ComponentShard identifies the shard component.
+	ComponentShard = "shard"
+
+	// ComponentTableGroup identifies the table group component.
+	ComponentTableGroup = "tablegroup"
+)
+
+const (
+	// LabelMultigresCell identifies which cell a resource belongs to.
+	LabelMultigresCell = "multigres.com/cell"
+
+	// LabelMultigresCluster identifies which cluster a resource belongs to.
+	LabelMultigresCluster = "multigres.com/cluster"
+
+	// LabelMultigresShard identifies which shard a resource belongs to.
+	LabelMultigresShard = "multigres.com/shard"
+
+	// LabelMultigresDatabase identifies which database a resource belongs to.
+	LabelMultigresDatabase = "multigres.com/database"
+
+	// LabelMultigresTableGroup identifies which table group a resource belongs to.
+	LabelMultigresTableGroup = "multigres.com/tablegroup"
+
+	// DefaultCellName is the default cell name when none is specified.
+	DefaultCellName = "multigres-global-topo"
+)
+
+const (
+	// LabelMultigresCellTemplate identifies which cell template was used for
+	// the given resource. This is needed for the operator to efficiently find
+	// all the relevant resources using the CellTemplate.
+	LabelMultigresCellTemplate = "multigres.com/cell-template"
+
+	// LabelMultigresShardTemplate identifies which cell template was used for
+	// the given resource. This is needed for the operator to efficiently find
+	// all the relevant resources using the ShardTemplate.
+	LabelMultigresShardTemplate = "multigres.com/shard-template"
+)
+
+// BuildStandardLabels returns a map of standard kubernetes labels.
+// clusterName should be the name of the MultigresCluster CR (used for instance label).
+// component is the name of the component (e.g. multigateway, multiorch, pool).
+func BuildStandardLabels(clusterName, component string) map[string]string {
+	return map[string]string{
+		LabelAppName:      AppNameMultigres,
+		LabelAppInstance:  clusterName,
+		LabelAppComponent: component,
+		LabelAppPartOf:    AppNameMultigres,
+		LabelAppManagedBy: ManagedByMultigres,
+	}
+}
+
+// AddCellLabel adds the cell label to the provided labels map.
+func AddCellLabel(labels map[string]string, cellName string) map[string]string {
+	labels[LabelMultigresCell] = cellName
+	return labels
+}
+
+// AddClusterLabel adds the cluster label to the provided labels map.
+func AddClusterLabel(labels map[string]string, clusterName string) map[string]string {
+	labels[LabelMultigresCluster] = clusterName
+	return labels
+}
+
+// AddShardLabel adds the shard label to the provided labels map.
+func AddShardLabel(labels map[string]string, shardName string) map[string]string {
+	labels[LabelMultigresShard] = shardName
+	return labels
+}
+
+// AddDatabaseLabel adds the database label to the provided labels map.
+func AddDatabaseLabel(labels map[string]string, databaseName string) map[string]string {
+	labels[LabelMultigresDatabase] = databaseName
+	return labels
+}
+
+// AddTableGroupLabel adds the table group label to the provided labels map.
+func AddTableGroupLabel(labels map[string]string, tableGroupName string) map[string]string {
+	labels[LabelMultigresTableGroup] = tableGroupName
+	return labels
+}
+
+// MergeLabels merges custom labels with standard labels.
+//
+// Note that standard labels take precedence over custom labels to prevent users
+// from overriding critical operator-managed labels.
+func MergeLabels(standardLabels, customLabels map[string]string) map[string]string {
+	merged := make(map[string]string)
+
+	// Copy custom labels first (if provided)
+	maps.Copy(merged, customLabels)
+
+	// Copy standard labels (overwriting any duplicates from custom)
+	maps.Copy(merged, standardLabels)
+
+	return merged
+}

--- a/pkg/util/metadata/labels_test.go
+++ b/pkg/util/metadata/labels_test.go
@@ -1,0 +1,323 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
+)
+
+func TestBuildStandardLabels(t *testing.T) {
+	tests := map[string]struct {
+		clusterName   string
+		componentName string
+		want          map[string]string
+	}{
+		"typical case": {
+			clusterName:   "my-etcd-cluster",
+			componentName: "etcd",
+			want: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "my-etcd-cluster",
+				"app.kubernetes.io/component":  "etcd",
+				"app.kubernetes.io/part-of":    "multigres",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+			},
+		},
+		"empty strings allowed": {
+			clusterName:   "",
+			componentName: "",
+			want: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "",
+				"app.kubernetes.io/component":  "",
+				"app.kubernetes.io/part-of":    "multigres",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := metadata.BuildStandardLabels(tc.clusterName, tc.componentName)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("BuildStandardLabels() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMergeLabels(t *testing.T) {
+	tests := map[string]struct {
+		standardLabels map[string]string
+		customLabels   map[string]string
+		want           map[string]string
+	}{
+		"standard labels win on conflicts": {
+			standardLabels: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "my-resource",
+				"app.kubernetes.io/component":  "etcd",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+			},
+			customLabels: map[string]string{
+				"app.kubernetes.io/name":      "user-app",      // conflict
+				"app.kubernetes.io/component": "user-override", // conflict
+				"env":                         "production",    // no conflict
+				"team":                        "platform",      // no conflict
+			},
+			want: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "my-resource",
+				"app.kubernetes.io/component":  "etcd",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+				"env":                          "production",
+				"team":                         "platform",
+			},
+		},
+		"nil maps handled correctly": {
+			standardLabels: nil,
+			customLabels:   nil,
+			want:           map[string]string{},
+		},
+		"only custom labels": {
+			standardLabels: nil,
+			customLabels: map[string]string{
+				"env":  "dev",
+				"team": "platform",
+			},
+			want: map[string]string{
+				"env":  "dev",
+				"team": "platform",
+			},
+		},
+		"only standard labels": {
+			standardLabels: map[string]string{
+				"app.kubernetes.io/name":      "multigres",
+				"app.kubernetes.io/component": "gateway",
+			},
+			customLabels: nil,
+			want: map[string]string{
+				"app.kubernetes.io/name":      "multigres",
+				"app.kubernetes.io/component": "gateway",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := metadata.MergeLabels(tc.standardLabels, tc.customLabels)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("MergeLabels() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAddMultigresLabels(t *testing.T) {
+	tests := map[string]struct {
+		addFunc func(map[string]string, string) map[string]string
+		value   string
+		key     string
+	}{
+		"AddCellLabel": {
+			addFunc: metadata.AddCellLabel,
+			value:   "zone1",
+			key:     "multigres.com/cell",
+		},
+		"AddClusterLabel": {
+			addFunc: metadata.AddClusterLabel,
+			value:   "prod-cluster",
+			key:     "multigres.com/cluster",
+		},
+		"AddShardLabel": {
+			addFunc: metadata.AddShardLabel,
+			value:   "shard-0",
+			key:     "multigres.com/shard",
+		},
+		"AddDatabaseLabel": {
+			addFunc: metadata.AddDatabaseLabel,
+			value:   "proddb",
+			key:     "multigres.com/database",
+		},
+		"AddTableGroupLabel": {
+			addFunc: metadata.AddTableGroupLabel,
+			value:   "orders",
+			key:     "multigres.com/tablegroup",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			labels := map[string]string{
+				"app.kubernetes.io/name": "multigres",
+			}
+			result := tc.addFunc(labels, tc.value)
+
+			want := map[string]string{
+				"app.kubernetes.io/name": "multigres",
+				tc.key:                   tc.value,
+			}
+
+			if diff := cmp.Diff(want, result); diff != "" {
+				t.Errorf("%s mismatch (-want +got):\n%s", name, diff)
+			}
+
+			// Verify it modified the original map
+			if labels[tc.key] != tc.value {
+				t.Errorf("%s should modify the original map", name)
+			}
+		})
+	}
+}
+
+func TestLabelOperations_ComplexScenarios(t *testing.T) {
+	tests := map[string]struct {
+		setupFunc func() map[string]string
+		want      map[string]string
+	}{
+		"build standard labels then add all multigres labels": {
+			setupFunc: func() map[string]string {
+				labels := metadata.BuildStandardLabels("my-cluster", "shard-pool")
+				metadata.AddCellLabel(labels, "zone1")
+				metadata.AddClusterLabel(labels, "prod-cluster")
+				metadata.AddShardLabel(labels, "shard-0")
+				metadata.AddDatabaseLabel(labels, "proddb")
+				metadata.AddTableGroupLabel(labels, "orders")
+				return labels
+			},
+			want: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "my-cluster",
+				"app.kubernetes.io/component":  "shard-pool",
+				"app.kubernetes.io/part-of":    "multigres",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+				"multigres.com/cell":           "zone1",
+				"multigres.com/cluster":        "prod-cluster",
+				"multigres.com/shard":          "shard-0",
+				"multigres.com/database":       "proddb",
+				"multigres.com/tablegroup":     "orders",
+			},
+		},
+		"merge custom labels then add multigres labels": {
+			setupFunc: func() map[string]string {
+				standard := metadata.BuildStandardLabels("etcd-1", "etcd")
+				custom := map[string]string{
+					"env":  "production",
+					"team": "platform",
+				}
+				labels := metadata.MergeLabels(standard, custom)
+				metadata.AddCellLabel(labels, "zone2")
+				metadata.AddClusterLabel(labels, "main-cluster")
+				return labels
+			},
+			want: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "etcd-1",
+				"app.kubernetes.io/component":  "etcd",
+				"app.kubernetes.io/part-of":    "multigres",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+				"multigres.com/cell":           "zone2",
+				"multigres.com/cluster":        "main-cluster",
+				"env":                          "production",
+				"team":                         "platform",
+			},
+		},
+		"chain all label operations for shard pool": {
+			setupFunc: func() map[string]string {
+				poolName := "shard-0-pool-primary"
+				labels := metadata.BuildStandardLabels(poolName, "shard-pool")
+				metadata.AddCellLabel(labels, "us-east-1a")
+				metadata.AddClusterLabel(labels, "production")
+				metadata.AddShardLabel(labels, "0")
+				metadata.AddDatabaseLabel(labels, "orders_db")
+				metadata.AddTableGroupLabel(labels, "orders_tg")
+
+				custom := map[string]string{
+					"monitoring": "prometheus",
+					"backup":     "enabled",
+				}
+				return metadata.MergeLabels(labels, custom)
+			},
+			want: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "shard-0-pool-primary",
+				"app.kubernetes.io/component":  "shard-pool",
+				"app.kubernetes.io/part-of":    "multigres",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+				"multigres.com/cell":           "us-east-1a",
+				"multigres.com/cluster":        "production",
+				"multigres.com/shard":          "0",
+				"multigres.com/database":       "orders_db",
+				"multigres.com/tablegroup":     "orders_tg",
+				"monitoring":                   "prometheus",
+				"backup":                       "enabled",
+			},
+		},
+		"merge with conflicting multigres labels - standard wins": {
+			setupFunc: func() map[string]string {
+				labels := metadata.BuildStandardLabels("resource", "component")
+				metadata.AddCellLabel(labels, "zone1")
+				metadata.AddShardLabel(labels, "shard-0")
+
+				conflicting := map[string]string{
+					"multigres.com/cell":  "zone-override",
+					"multigres.com/shard": "shard-override",
+					"custom":              "value",
+				}
+				return metadata.MergeLabels(labels, conflicting)
+			},
+			want: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "resource",
+				"app.kubernetes.io/component":  "component",
+				"app.kubernetes.io/part-of":    "multigres",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+				"multigres.com/cell":           "zone1",
+				"multigres.com/shard":          "shard-0",
+				"custom":                       "value",
+			},
+		},
+		"add labels to empty map": {
+			setupFunc: func() map[string]string {
+				labels := make(map[string]string)
+				metadata.AddCellLabel(labels, "zone3")
+				metadata.AddShardLabel(labels, "shard-1")
+				metadata.AddDatabaseLabel(labels, "testdb")
+				return labels
+			},
+			want: map[string]string{
+				"multigres.com/cell":     "zone3",
+				"multigres.com/shard":    "shard-1",
+				"multigres.com/database": "testdb",
+			},
+		},
+		"overwrite cell label multiple times - last wins": {
+			setupFunc: func() map[string]string {
+				labels := metadata.BuildStandardLabels("resource", "component")
+				metadata.AddCellLabel(labels, "zone1")
+				metadata.AddCellLabel(labels, "zone2")
+				metadata.AddCellLabel(labels, "zone3")
+				return labels
+			},
+			want: map[string]string{
+				"app.kubernetes.io/name":       "multigres",
+				"app.kubernetes.io/instance":   "resource",
+				"app.kubernetes.io/component":  "component",
+				"app.kubernetes.io/part-of":    "multigres",
+				"app.kubernetes.io/managed-by": "multigres-operator",
+				"multigres.com/cell":           "zone3",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := tc.setupFunc()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Label operations mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, resource labels are manually constructed across multiple builders, leading to code duplication and potential inconsistency.

- Created `pkg/util/metadata` to standardize label generation for all Multigres resources.
- Refactored Global, Cell, and TableGroup builders in `pkg/cluster-handler` to use the new metadata package.
- Updated integration tests to leverage shared label helpers for validation.

This change guarantees consistent labeling across all generated Kubernetes resources and significantly reduces boilerplate code.