### PR TITLE
fix(resolver): implement dynamic cell defaulting and validation

### DIFF
--- a/config/samples/overrides.yaml
+++ b/config/samples/overrides.yaml
@@ -35,13 +35,13 @@ spec:
         - name: "default"
           default: true
           shards:
-            - name: "0"
+            - name: "0-inf"
               overrides:
                 pools:
                   "main-app":
                     storage:
                       size: "200Gi" # Override: Increase from 100Gi (template) to 200Gi
-                    # Define a new pool not in template
+                    # Define a new pool not in template. This will produce a warning in case it's a typo.
                   "analytics":
                     type: "readOnly"
                     replicasPerCell: 1

--- a/config/samples/templated-cluster.yaml
+++ b/config/samples/templated-cluster.yaml
@@ -27,7 +27,7 @@ spec:
         - name: "default" # MUST be named 'default' for Gateway routing
           default: true
           shards:
-            - name: "0"
+            - name: "0-inf"
               # Inherits 'standard-shard' template automatically via defaults
               overrides:
                 pools:

--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestBuildCell(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
+	scheme := setupScheme()
 
 	cluster := &multigresv1alpha1.MultigresCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
@@ -45,10 +45,7 @@ type reconcileTestCase struct {
 func runReconcileTest(t *testing.T, tests map[string]reconcileTestCase) {
 	t.Helper()
 
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := setupScheme()
 
 	coreTpl, cellTpl, shardTpl, baseCluster, _, _, _ := setupFixtures(t)
 
@@ -173,6 +170,15 @@ func runReconcileTest(t *testing.T, tests map[string]reconcileTestCase) {
 			}
 		})
 	}
+}
+
+// setupScheme creates a new scheme with all required types registered
+func setupScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	return scheme
 }
 
 // setupFixtures provides fresh test data

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_cells_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_cells_test.go
@@ -7,7 +7,6 @@ import (
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/resolver"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -17,9 +16,7 @@ import (
 )
 
 func TestReconcileCells_ErrorPaths(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := setupScheme()
 
 	t.Run("Error: Get Global Topo Ref Failed", func(t *testing.T) {
 		// Use explicit invalid core template to force GetGlobalTopoRef to fail
@@ -219,9 +216,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 }
 
 func TestReconcileCells_HappyPath(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := setupScheme()
 
 	t.Run("Happy Path: Create and Prune Cells", func(t *testing.T) {
 		cluster := &multigresv1alpha1.MultigresCluster{

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/numtide/multigres-operator/pkg/testutil"
 	"github.com/numtide/multigres-operator/pkg/util/name"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,9 +22,7 @@ import (
 )
 
 func TestReconcileGlobal_ErrorPaths(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+	scheme := setupScheme()
 
 	t.Run("Error: Resolve Global Topo Failed", func(t *testing.T) {
 		cluster := &multigresv1alpha1.MultigresCluster{

--- a/pkg/resolver/cluster.go
+++ b/pkg/resolver/cluster.go
@@ -92,7 +92,9 @@ func (r *Resolver) PopulateClusterDefaults(
 				if len(defaultCells) > 0 {
 					shardCfg.Spec = &multigresv1alpha1.ShardInlineSpec{
 						MultiOrch: multigresv1alpha1.MultiOrchSpec{
-							Cells: defaultCells,
+							// Clean Spec: Do not inject default cells statically.
+							// This allows dynamic contextual resolution later.
+							// Cells: defaultCells,
 						},
 						Pools: make(map[string]multigresv1alpha1.PoolSpec),
 					}
@@ -100,8 +102,9 @@ func (r *Resolver) PopulateClusterDefaults(
 					// Apply the decision made above
 					if shouldInjectDefaults {
 						shardCfg.Spec.Pools["default"] = multigresv1alpha1.PoolSpec{
-							Type:  "readWrite",
-							Cells: defaultCells,
+							Type: "readWrite",
+							// Clean Spec: Do not inject default cells.
+							// Cells: defaultCells,
 						}
 					}
 				}

--- a/pkg/resolver/cluster_test.go
+++ b/pkg/resolver/cluster_test.go
@@ -164,19 +164,10 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 										{
 											Name: "0-inf",
 											Spec: &multigresv1alpha1.ShardInlineSpec{
-												MultiOrch: multigresv1alpha1.MultiOrchSpec{
-													Cells: []multigresv1alpha1.CellName{
-														"zone-a",
-														"zone-b",
-													},
-												},
+												MultiOrch: multigresv1alpha1.MultiOrchSpec{},
 												Pools: map[string]multigresv1alpha1.PoolSpec{
 													"default": {
 														Type: "readWrite",
-														Cells: []multigresv1alpha1.CellName{
-															"zone-a",
-															"zone-b",
-														},
 													},
 												},
 											},
@@ -234,9 +225,7 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 										{
 											Name: "0-inf",
 											Spec: &multigresv1alpha1.ShardInlineSpec{
-												MultiOrch: multigresv1alpha1.MultiOrchSpec{
-													Cells: []multigresv1alpha1.CellName{"zone-a"},
-												},
+												MultiOrch: multigresv1alpha1.MultiOrchSpec{},
 												// KEY: Pools is empty because implicit template takes over
 												Pools: map[string]multigresv1alpha1.PoolSpec{},
 											},

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -82,11 +82,17 @@ func TestNewResolver(t *testing.T) {
 	}
 }
 
+// setupScheme creates a new scheme with all required types registered
+func setupScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	return scheme
+}
+
 // TestResolver_TemplateExists covers the helpers called by the Defaulter/Validator.
 func TestResolver_TemplateExists(t *testing.T) {
 	t.Parallel()
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
+	scheme := setupScheme()
 
 	coreTpl, cellTpl, shardTpl, ns := setupFixtures(t)
 	objs := []client.Object{coreTpl, cellTpl, shardTpl}
@@ -162,8 +168,7 @@ func TestResolver_TemplateExists(t *testing.T) {
 // TestResolver_ValidateReference checks Validat*TemplateReference logic (including fallback).
 func TestResolver_ValidateReference(t *testing.T) {
 	t.Parallel()
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
+	scheme := setupScheme()
 
 	// Fixtures have names like "default" (FallbackCoreTemplate)
 	coreTpl, cellTpl, shardTpl, ns := setupFixtures(t)

--- a/pkg/webhook/handlers/defaulter.go
+++ b/pkg/webhook/handlers/defaulter.go
@@ -169,7 +169,9 @@ func (d *MultigresClusterDefaulter) Default(ctx context.Context, obj runtime.Obj
 				isUsingTemplate := hasInline || hasGlobalShard || hasImplicitShard
 
 				if !isUsingTemplate {
-					multiOrchSpec, poolsSpec, err := scopedResolver.ResolveShard(ctx, shard)
+					// We pass 'nil' for allCellNames to prevent "Sticky Context Defaults".
+					// We want the Stored Spec to remain empty (dynamic) rather than locking in the current list of cells.
+					multiOrchSpec, poolsSpec, err := scopedResolver.ResolveShard(ctx, shard, nil)
 					if err != nil {
 						return fmt.Errorf("failed to resolve shard '%s': %w", shard.Name, err)
 					}

--- a/pkg/webhook/handlers/defaulter_test.go
+++ b/pkg/webhook/handlers/defaulter_test.go
@@ -117,14 +117,14 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 														Replicas:  ptr.To(int32(1)),
 														Resources: resolver.DefaultResourcesOrch(),
 													},
-													Cells: []multigresv1alpha1.CellName{"c1"},
+													// Cells should be nil to avoid sticky defaults
+													Cells: nil,
 												},
 												Pools: map[string]multigresv1alpha1.PoolSpec{
 													"default": {
 														Type: "readWrite",
-														Cells: []multigresv1alpha1.CellName{
-															"c1",
-														},
+														// Cells should be nil to avoid sticky defaults
+														Cells:           nil,
 														ReplicasPerCell: ptr.To(int32(1)),
 														Storage: multigresv1alpha1.StorageSpec{
 															Size: "1Gi",

--- a/pkg/webhook/integration_test.go
+++ b/pkg/webhook/integration_test.go
@@ -222,7 +222,9 @@ func TestWebhook_Mutation(t *testing.T) {
 				Name:      "mutation-test",
 				Namespace: testNamespace,
 			},
-			Spec: multigresv1alpha1.MultigresClusterSpec{},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+			},
 		}
 
 		if err := k8sClient.Create(ctx, cluster); err != nil {
@@ -264,6 +266,7 @@ func TestWebhook_Validation(t *testing.T) {
 				TemplateDefaults: multigresv1alpha1.TemplateDefaults{
 					CoreTemplate: "non-existent-template",
 				},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
 			},
 		}
 
@@ -289,6 +292,7 @@ func TestWebhook_TemplateProtection(t *testing.T) {
 				TemplateDefaults: multigresv1alpha1.TemplateDefaults{
 					CoreTemplate: "production-core",
 				},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
 			},
 		}
 		if err := k8sClient.Create(ctx, cluster); err != nil {
@@ -348,6 +352,7 @@ func TestWebhook_OverridePrecedence(t *testing.T) {
 				MultiAdmin: &multigresv1alpha1.MultiAdminConfig{
 					Spec: &multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(3))},
 				},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
 			},
 		}
 		if err := k8sClient.Create(ctx, cluster); err != nil {
@@ -383,6 +388,7 @@ func TestWebhook_SpecificRefPrecedence(t *testing.T) {
 				MultiAdmin: &multigresv1alpha1.MultiAdminConfig{
 					TemplateRef: "specific-large",
 				},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
 			},
 		}
 		if err := k8sClient.Create(ctx, cluster); err != nil {
@@ -408,6 +414,7 @@ func TestWebhook_SystemCatalogIdempotency(t *testing.T) {
 		cluster := &multigresv1alpha1.MultigresCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "idempotency-test", Namespace: testNamespace},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
 				Databases: []multigresv1alpha1.DatabaseConfig{
 					{
 						Name:    "postgres",
@@ -453,6 +460,7 @@ func TestWebhook_DeepTemplateProtection(t *testing.T) {
 		cluster := &multigresv1alpha1.MultigresCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "deep-ref-cluster", Namespace: testNamespace},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
 				Databases: []multigresv1alpha1.DatabaseConfig{
 					{
 						Name:    "postgres",


### PR DESCRIPTION
Static injection of cell lists during webhook defaulting caused "sticky" configuration where shards would not adapt to global topology changes (e.g., cell renames).

* Updated `ResolveShard` to accept `allCellNames` and dynamically inject defaults at runtime only when needed.
* Removed static cell population in `PopulateClusterDefaults` to keep `ShardInlineSpec` agnostic of current topology.
* Implemented `validateLogic` in the Webhook to perform dry-run resolution, rejecting invalid cell references and warning on orphan overrides (typos).
* Refactored `ShardReconciler` to pass live cluster context during reconciliation.

Eliminates the "Sticky Default" bug while adding safety rails against invalid or typoed shard configurations.