### PR TITLE
fix(webhook): validate GlobalTopoServer template ref

### DIFF
--- a/pkg/webhook/handlers/validator.go
+++ b/pkg/webhook/handlers/validator.go
@@ -94,6 +94,11 @@ func (v *MultigresClusterValidator) validateTemplatesExist(
 			return err
 		}
 	}
+	if cluster.Spec.GlobalTopoServer != nil && cluster.Spec.GlobalTopoServer.TemplateRef != "" {
+		if err := res.ValidateCoreTemplateReference(ctx, cluster.Spec.GlobalTopoServer.TemplateRef); err != nil {
+			return err
+		}
+	}
 
 	// 2. Validate Cell Templates
 	if err := res.ValidateCellTemplateReference(ctx, cluster.Spec.TemplateDefaults.CellTemplate); err != nil {

--- a/pkg/webhook/handlers/validator_test.go
+++ b/pkg/webhook/handlers/validator_test.go
@@ -94,6 +94,18 @@ func TestMultigresClusterValidator(t *testing.T) {
 			wantAllowed: false,
 			wantMessage: "referenced ShardTemplate 'missing-shard' not found",
 		},
+		"Denied: Missing GlobalTopoServer Template": {
+			object: func() *multigresv1alpha1.MultigresCluster {
+				c := baseCluster.DeepCopy()
+				c.Spec.GlobalTopoServer = &multigresv1alpha1.GlobalTopoServerSpec{
+					TemplateRef: "missing-topo",
+				}
+				return c
+			}(),
+			operation:   "Create",
+			wantAllowed: false,
+			wantMessage: "referenced CoreTemplate 'missing-topo' not found",
+		},
 		"Error: Client Error (CoreTemplate)": {
 			object:    baseCluster.DeepCopy(),
 			operation: "Create",


### PR DESCRIPTION
The validation webhook previously enforced existence for Core, Cell, and Shard templates but failed to verify the GlobalTopoServer template reference. This allowed invalid configurations to pass admission, causing failures later in the reconciliation loop.

* Added validation logic to `pkg/webhook/handlers/validator.go` to check `GlobalTopoServer.TemplateRef`.
* Added a test case to `pkg/webhook/handlers/validator_test.go` ensuring rejection of missing GlobalTopo templates.

Ensures referential integrity for global topology settings at admission time, preventing invalid cluster states.