### PR TITLE
fix(pkg/name): replace md5 with fnv-1a

### DIFF
--- a/pkg/util/name/name.go
+++ b/pkg/util/name/name.go
@@ -26,9 +26,9 @@ limitations under the License.
 package name
 
 import (
-	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"strings"
 	"unicode"
 )
@@ -93,7 +93,7 @@ var (
 
 // Hash computes a hash suffix for the given name parts.
 func Hash(parts []string) string {
-	h := md5.New()
+	h := fnv.New32a()
 	for _, part := range parts {
 		h.Write([]byte(part))
 		// It doesn't matter if the parts have nulls in them somehow.
@@ -103,12 +103,12 @@ func Hash(parts []string) string {
 		h.Write([]byte{0})
 	}
 	sum := h.Sum(nil)
-	// We don't need the whole sum; just take the first 32 bits.
+	// FNV-1a 32-bit produces exactly 4 bytes, which hex-encodes to 8 characters.
 	// We only care about avoiding collisions in the case when
 	// the concatenated parts without the hash match exactly.
 	// That leaves almost no degrees of freedom even if you're
 	// trying to collide on purpose.
-	return hex.EncodeToString(sum[:hashBytes])
+	return hex.EncodeToString(sum)
 }
 
 // JoinWithConstraints builds a name by concatenating a number of parts with '-' as

--- a/pkg/util/name/name_test.go
+++ b/pkg/util/name/name_test.go
@@ -78,7 +78,7 @@ func TestJoin(t *testing.T) {
 // TestJoinHash checks that the hash function produces expected values.
 func TestJoinHash(t *testing.T) {
 	parts := []string{"hello", "world"}
-	want := "hello-world-1dd41005"
+	want := "hello-world-344ce285"
 	if got := JoinWithConstraints(DefaultConstraints, parts...); got != want {
 		t.Fatalf("JoinWithConstraints(%v) = %q, want %q", parts, got, want)
 	}
@@ -217,7 +217,7 @@ func TestMultigresResourceNaming(t *testing.T) {
 		},
 		{
 			name:     "shard name",
-			parts:    []string{"production-mydb-default-1dd41005", "0"},
+			parts:    []string{"production-mydb-default-5c6a71f9", "0"},
 			wantLen:  -1,
 			wantHash: true,
 		},


### PR DESCRIPTION
The usage of MD5 for resource name hashing triggers security audit flags and prevents FIPS compliance, despite being used for non-cryptographic purposes. It's also faster than md5

* Replaced `crypto/md5` with `hash/fnv` in `pkg/util/name`.
* Updated `Hash` to use `fnv.New32a()`, removing manual truncation logic.
* Updated expected test values to match the new hashing algorithm.

This ensures FIPS compliance and eliminates false positives in security scans while maintaining deterministic unique naming.