### PR TITLE
fix(pkg/webhook): check global topo template usage

### DIFF
--- a/pkg/webhook/handlers/validator.go
+++ b/pkg/webhook/handlers/validator.go
@@ -315,6 +315,10 @@ func (v *TemplateValidator) isTemplateInUse(
 		if cluster.Spec.MultiAdmin != nil && cluster.Spec.MultiAdmin.TemplateRef == name {
 			return true
 		}
+		if cluster.Spec.GlobalTopoServer != nil &&
+			cluster.Spec.GlobalTopoServer.TemplateRef == name {
+			return true
+		}
 	case "CellTemplate":
 		if cluster.Spec.TemplateDefaults.CellTemplate == name {
 			return true

--- a/pkg/webhook/handlers/validator_test.go
+++ b/pkg/webhook/handlers/validator_test.go
@@ -658,6 +658,21 @@ func TestTemplateValidator(t *testing.T) {
 			existing:    []client.Object{configUsingCoreAdmin},
 			wantAllowed: false,
 		},
+		"Denied: Delete In-Use CoreTemplate (GlobalTopoServer)": {
+			kind:       "CoreTemplate",
+			targetName: "prod-core",
+			existing: []client.Object{
+				&multigresv1alpha1.MultigresCluster{
+					ObjectMeta: metav1.ObjectMeta{Name: "c-topo", Namespace: "default"},
+					Spec: multigresv1alpha1.MultigresClusterSpec{
+						GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+							TemplateRef: "prod-core",
+						},
+					},
+				},
+			},
+			wantAllowed: false,
+		},
 		"Denied: Delete In-Use CellTemplate (Inline)": {
 			kind:        "CellTemplate",
 			targetName:  "prod-cell",


### PR DESCRIPTION
The admission webhook failed to detect when a `CoreTemplate` was actively referenced by a `GlobalTopoServer`, allowing users to delete the template and orphan the cluster's topology configuration.

* Updated `isTemplateInUse` validation logic to explicitly check `spec.globalTopoServer.templateRef` against the template being deleted.
* Added a regression test case to verify `CoreTemplate` deletion is blocked when referenced by the global topology server.

This prevents accidental deletion of critical infrastructure templates and ensures referential integrity for all cluster components.