### PR TITLE
fix(resolver): add request-scoped cache

### DIFF
--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -21,6 +21,12 @@ type Resolver struct {
 	Namespace string
 	// TemplateDefaults contains the cluster-level template references.
 	TemplateDefaults multigresv1alpha1.TemplateDefaults
+	// coreTemplateCache is a request-scoped cache for CoreTemplates.
+	coreTemplateCache map[string]*multigresv1alpha1.CoreTemplate
+	// cellTemplateCache is a request-scoped cache for CellTemplates.
+	cellTemplateCache map[string]*multigresv1alpha1.CellTemplate
+	// shardTemplateCache is a request-scoped cache for ShardTemplates.
+	shardTemplateCache map[string]*multigresv1alpha1.ShardTemplate
 }
 
 // NewResolver creates a new defaults.Resolver.
@@ -30,9 +36,12 @@ func NewResolver(
 	tplDefaults multigresv1alpha1.TemplateDefaults,
 ) *Resolver {
 	return &Resolver{
-		Client:           c,
-		Namespace:        namespace,
-		TemplateDefaults: tplDefaults,
+		Client:             c,
+		Namespace:          namespace,
+		TemplateDefaults:   tplDefaults,
+		coreTemplateCache:  make(map[string]*multigresv1alpha1.CoreTemplate),
+		cellTemplateCache:  make(map[string]*multigresv1alpha1.CellTemplate),
+		shardTemplateCache: make(map[string]*multigresv1alpha1.ShardTemplate),
 	}
 }
 


### PR DESCRIPTION
The resolver triggered N+1 API calls during validation and reconciliation of large clusters, leading to potential performance bottlenecks.

* Implemented ephemeral memory caching in `Resolver` for shard templates to prevent redundant API fetches.
* Updated `ResolveShardTemplate` to check the internal cache before making a client call.
* Adjusted `MultigresCluster` controller tests to verify behavior without relying on call counting, which is no longer deterministic with caching.

This improves validation performance by ensuring templates are fetched only once per request scope.