### PR TITLE
feat(observability): add pool and topology labels to resources

### DIFF
--- a/pkg/resource-handler/controller/cell/integration_test.go
+++ b/pkg/resource-handler/controller/cell/integration_test.go
@@ -92,17 +92,17 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "test-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "test-cell-multigateway", "multigateway", "zone1"),
+						Labels:          cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
 						OwnerReferences: cellOwnerRefs(t, "test-cell"),
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas: ptr.To(int32(2)),
 						Selector: &metav1.LabelSelector{
-							MatchLabels: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1"),
+							MatchLabels: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
-								Labels: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1"),
+								Labels: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -133,7 +133,7 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "test-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "test-cell-multigateway", "multigateway", "zone1"),
+						Labels:          cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
 						OwnerReferences: cellOwnerRefs(t, "test-cell"),
 					},
 					Spec: corev1.ServiceSpec{
@@ -143,7 +143,7 @@ func TestCellReconciliation(t *testing.T) {
 							tcpServicePort(t, "grpc", 15170),
 							tcpServicePort(t, "postgres", 15432),
 						},
-						Selector: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1"),
+						Selector: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
 					},
 				},
 			},
@@ -179,17 +179,17 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "custom-replicas-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2"),
+						Labels:          cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
 						OwnerReferences: cellOwnerRefs(t, "custom-replicas-cell"),
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas: ptr.To(int32(3)),
 						Selector: &metav1.LabelSelector{
-							MatchLabels: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2"),
+							MatchLabels: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
-								Labels: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2"),
+								Labels: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -220,7 +220,7 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "custom-replicas-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2"),
+						Labels:          cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
 						OwnerReferences: cellOwnerRefs(t, "custom-replicas-cell"),
 					},
 					Spec: corev1.ServiceSpec{
@@ -230,7 +230,7 @@ func TestCellReconciliation(t *testing.T) {
 							tcpServicePort(t, "grpc", 15170),
 							tcpServicePort(t, "postgres", 15432),
 						},
-						Selector: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2"),
+						Selector: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
 					},
 				},
 			},
@@ -266,17 +266,17 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "custom-images-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3"),
+						Labels:          cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
 						OwnerReferences: cellOwnerRefs(t, "custom-images-cell"),
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas: ptr.To(int32(2)),
 						Selector: &metav1.LabelSelector{
-							MatchLabels: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3"),
+							MatchLabels: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
-								Labels: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3"),
+								Labels: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -307,7 +307,7 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "custom-images-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3"),
+						Labels:          cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
 						OwnerReferences: cellOwnerRefs(t, "custom-images-cell"),
 					},
 					Spec: corev1.ServiceSpec{
@@ -317,7 +317,7 @@ func TestCellReconciliation(t *testing.T) {
 							tcpServicePort(t, "grpc", 15170),
 							tcpServicePort(t, "postgres", 15432),
 						},
-						Selector: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3"),
+						Selector: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
 					},
 				},
 			},
@@ -370,17 +370,17 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "affinity-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4"),
+						Labels:          cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
 						OwnerReferences: cellOwnerRefs(t, "affinity-cell"),
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas: ptr.To(int32(2)),
 						Selector: &metav1.LabelSelector{
-							MatchLabels: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4"),
+							MatchLabels: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
-								Labels: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4"),
+								Labels: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -428,7 +428,7 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "affinity-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4"),
+						Labels:          cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
 						OwnerReferences: cellOwnerRefs(t, "affinity-cell"),
 					},
 					Spec: corev1.ServiceSpec{
@@ -438,7 +438,7 @@ func TestCellReconciliation(t *testing.T) {
 							tcpServicePort(t, "grpc", 15170),
 							tcpServicePort(t, "postgres", 15432),
 						},
-						Selector: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4"),
+						Selector: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
 					},
 				},
 			},
@@ -536,7 +536,7 @@ func TestCellReconciliation(t *testing.T) {
 // Test helpers
 
 // cellLabels returns standard labels for cell resources in tests
-func cellLabels(t testing.TB, instanceName, component, cellName string) map[string]string {
+func cellLabels(t testing.TB, instanceName, component, cellName, zone string) map[string]string {
 	t.Helper()
 	return map[string]string{
 		"app.kubernetes.io/component":  component,
@@ -544,6 +544,8 @@ func cellLabels(t testing.TB, instanceName, component, cellName string) map[stri
 		"app.kubernetes.io/managed-by": "multigres-operator",
 		"app.kubernetes.io/name":       "multigres",
 		"app.kubernetes.io/part-of":    "multigres",
+		"multigres.com/cell":           cellName,
+		"multigres.com/zone":           zone,
 	}
 }
 

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -77,6 +77,13 @@ func BuildMultiGatewayDeployment(
 	name := BuildMultiGatewayDeploymentName(cell)
 	clusterName := cell.Labels["multigres.com/cluster"]
 	labels := metadata.BuildStandardLabels(clusterName, MultiGatewayComponentName)
+	metadata.AddCellLabel(labels, cell.Spec.Name)
+	if cell.Spec.Zone != "" {
+		metadata.AddZoneLabel(labels, cell.Spec.Zone)
+	}
+	if cell.Spec.Region != "" {
+		metadata.AddRegionLabel(labels, cell.Spec.Region)
+	}
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -148,6 +155,13 @@ func BuildMultiGatewayService(
 	name := BuildMultiGatewayServiceName(cell)
 	clusterName := cell.Labels["multigres.com/cluster"]
 	labels := metadata.BuildStandardLabels(clusterName, MultiGatewayComponentName)
+	metadata.AddCellLabel(labels, cell.Spec.Name)
+	if cell.Spec.Zone != "" {
+		metadata.AddZoneLabel(labels, cell.Spec.Zone)
+	}
+	if cell.Spec.Region != "" {
+		metadata.AddRegionLabel(labels, cell.Spec.Region)
+	}
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resource-handler/controller/shard/integration_test.go
+++ b/pkg/resource-handler/controller/shard/integration_test.go
@@ -1104,7 +1104,7 @@ func TestShardReconciliation(t *testing.T) {
 // shardLabels returns standard labels for shard resources
 func shardLabels(t testing.TB, instanceName, component, cell string) map[string]string {
 	t.Helper()
-	return map[string]string{
+	labels := map[string]string{
 		"app.kubernetes.io/component": component,
 		// In new logic, instance is cluster name.
 		// Tests calling this MUST now pass the correct name (hashed name or cluster name depending on what we want to test).
@@ -1122,6 +1122,12 @@ func shardLabels(t testing.TB, instanceName, component, cell string) map[string]
 		"multigres.com/database":       "testdb",
 		"multigres.com/tablegroup":     "default",
 	}
+
+	if component == "shard-pool" {
+		labels["multigres.com/pool"] = "primary"
+	}
+
+	return labels
 }
 
 // shardOwnerRefs returns owner references for a Shard resource

--- a/pkg/resource-handler/controller/shard/labels.go
+++ b/pkg/resource-handler/controller/shard/labels.go
@@ -17,6 +17,7 @@ func buildPoolLabelsWithCell(
 	clusterName := shard.Labels["multigres.com/cluster"]
 	labels := metadata.BuildStandardLabels(clusterName, PoolComponentName)
 	metadata.AddCellLabel(labels, multigresv1alpha1.CellName(cellName))
+	metadata.AddPoolLabel(labels, multigresv1alpha1.PoolName(poolName))
 	metadata.AddDatabaseLabel(labels, shard.Spec.DatabaseName)
 	metadata.AddTableGroupLabel(labels, shard.Spec.TableGroupName)
 

--- a/pkg/resource-handler/controller/shard/pool_service_test.go
+++ b/pkg/resource-handler/controller/shard/pool_service_test.go
@@ -294,12 +294,12 @@ func TestBuildPoolHeadlessService(t *testing.T) {
 			if tc.want != nil {
 				hashedSvcName := buildPoolHeadlessServiceName(tc.shard, tc.poolName, tc.cellName)
 				tc.want.Name = hashedSvcName
-				// if tc.want.Labels != nil {
-				// 	tc.want.Labels["app.kubernetes.io/instance"] = hashedName
-				// }
-				// if tc.want.Spec.Selector != nil {
-				// 	tc.want.Spec.Selector["app.kubernetes.io/instance"] = hashedName
-				// }
+				if tc.want.Labels != nil {
+					tc.want.Labels["multigres.com/pool"] = tc.poolName
+				}
+				if tc.want.Spec.Selector != nil {
+					tc.want.Spec.Selector["multigres.com/pool"] = tc.poolName
+				}
 			}
 
 			testScheme := scheme

--- a/pkg/resource-handler/controller/shard/pool_statefulset_test.go
+++ b/pkg/resource-handler/controller/shard/pool_statefulset_test.go
@@ -928,15 +928,17 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 
 				tc.want.Name = hashedName
 				tc.want.Spec.ServiceName = hashedSvcName
-				// if tc.want.Labels != nil {
-				// 	tc.want.Labels["app.kubernetes.io/instance"] = hashedName
-				// }
-				// if tc.want.Spec.Selector != nil {
-				// 	tc.want.Spec.Selector.MatchLabels["app.kubernetes.io/instance"] = hashedName
-				// }
-				// if tc.want.Spec.Template.Labels != nil {
-				// 	tc.want.Spec.Template.ObjectMeta.Labels["app.kubernetes.io/instance"] = hashedName
-				// }
+
+				if tc.want.Labels != nil {
+					tc.want.Labels["multigres.com/pool"] = tc.poolName
+				}
+				if tc.want.Spec.Selector != nil && tc.want.Spec.Selector.MatchLabels != nil {
+					tc.want.Spec.Selector.MatchLabels["multigres.com/pool"] = tc.poolName
+				}
+				if tc.want.Spec.Template.Labels != nil {
+					tc.want.Spec.Template.Labels["multigres.com/pool"] = tc.poolName
+				}
+
 				for i, vol := range tc.want.Spec.Template.Spec.Volumes {
 					if vol.Name == "backup-data-vol" && vol.PersistentVolumeClaim != nil {
 						tc.want.Spec.Template.Spec.Volumes[i].PersistentVolumeClaim.ClaimName = hashedBackupPVC
@@ -1207,9 +1209,9 @@ func TestBuildBackupPVC(t *testing.T) {
 			if tc.want != nil {
 				hashedPVCName := buildHashedBackupPVCName(shard, "primary", "zone1")
 				tc.want.Name = hashedPVCName
-				// if tc.want.Labels != nil {
-				// 	tc.want.Labels["app.kubernetes.io/instance"] = hashedPoolName
-				// }
+				if tc.want.Labels != nil {
+					tc.want.Labels["multigres.com/pool"] = "primary"
+				}
 			}
 
 			testScheme := scheme

--- a/pkg/util/metadata/labels.go
+++ b/pkg/util/metadata/labels.go
@@ -73,6 +73,15 @@ const (
 	// LabelMultigresTableGroup identifies which table group a resource belongs to.
 	LabelMultigresTableGroup = "multigres.com/tablegroup"
 
+	// LabelMultigresPool identifies which pool a resource belongs to.
+	LabelMultigresPool = "multigres.com/pool"
+
+	// LabelMultigresZone identifies which zone a resource belongs to.
+	LabelMultigresZone = "multigres.com/zone"
+
+	// LabelMultigresRegion identifies which region a resource belongs to.
+	LabelMultigresRegion = "multigres.com/region"
+
 	// DefaultCellName is the default cell name when none is specified.
 	DefaultCellName = "multigres-global-topo"
 )
@@ -138,6 +147,33 @@ func AddTableGroupLabel(
 	tableGroupName multigresv1alpha1.TableGroupName,
 ) map[string]string {
 	labels[LabelMultigresTableGroup] = string(tableGroupName)
+	return labels
+}
+
+// AddPoolLabel adds the pool label to the provided labels map.
+func AddPoolLabel(
+	labels map[string]string,
+	poolName multigresv1alpha1.PoolName,
+) map[string]string {
+	labels[LabelMultigresPool] = string(poolName)
+	return labels
+}
+
+// AddZoneLabel adds the zone label to the provided labels map.
+func AddZoneLabel(
+	labels map[string]string,
+	zoneName multigresv1alpha1.Zone,
+) map[string]string {
+	labels[LabelMultigresZone] = string(zoneName)
+	return labels
+}
+
+// AddRegionLabel adds the region label to the provided labels map.
+func AddRegionLabel(
+	labels map[string]string,
+	regionName multigresv1alpha1.Region,
+) map[string]string {
+	labels[LabelMultigresRegion] = string(regionName)
 	return labels
 }
 


### PR DESCRIPTION
Added standard `multigres.com/*` labels to generated resources to improve observability and filtering capabilities.

- Added `multigres.com/pool` label to all Pool StatefulSets and Pods.
- Added `multigres.com/cell` label to MultiGateway Deployments and Services.
- Added contextual `multigres.com/zone` or `multigres.com/region` labels to MultiGateway resources based on the Cell configuration.
- Refactored `pkg/util/metadata` to include strongly-typed helpers for these new labels.

This allows operators to easily filter metrics and logs by pool, zone, or region.