### PR TITLE
refactor(webhook): implement "dumb webhook, smart resolver" validation pattern

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global.go
@@ -12,6 +12,13 @@ import (
 	"github.com/numtide/multigres-operator/pkg/resolver"
 )
 
+// Builder function variables to allow mocking in tests
+var (
+	buildMultiAdminService       = BuildMultiAdminService
+	buildMultiAdminWebDeployment = BuildMultiAdminWebDeployment
+	buildMultiAdminWebService    = BuildMultiAdminWebService
+)
+
 func (r *MultigresClusterReconciler) reconcileGlobalComponents(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
@@ -112,7 +119,7 @@ func (r *MultigresClusterReconciler) reconcileMultiAdmin(
 	)
 
 	// Reconcile Service
-	desiredSvc, err := BuildMultiAdminService(cluster, r.Scheme)
+	desiredSvc, err := buildMultiAdminService(cluster, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to build multiadmin service: %w", err)
 	}
@@ -178,7 +185,7 @@ func (r *MultigresClusterReconciler) reconcileMultiAdminWeb(
 	}
 
 	// 1. Reconcile Deployment
-	desiredDeploy, err := BuildMultiAdminWebDeployment(cluster, spec, r.Scheme)
+	desiredDeploy, err := buildMultiAdminWebDeployment(cluster, spec, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to build multiadmin-web deployment: %w", err)
 	}
@@ -203,7 +210,7 @@ func (r *MultigresClusterReconciler) reconcileMultiAdminWeb(
 	)
 
 	// 2. Reconcile Service
-	desiredSvc, err := BuildMultiAdminWebService(cluster, r.Scheme)
+	desiredSvc, err := buildMultiAdminWebService(cluster, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to build multiadmin-web service: %w", err)
 	}

--- a/pkg/resolver/doc.go
+++ b/pkg/resolver/doc.go
@@ -32,15 +32,26 @@
 //     They fetch external templates from the API server and determine the effective
 //     configuration by checking for inline definitions vs. template references.
 //
+//  3. Validation (Webhook):
+//     The 'Validate...' methods (e.g. ValidateClusterIntegrity) are used during admission
+//     to enforce strict referential integrity and logical consistency. They simulate the
+//     resolution process to catch configuration errors (like referencing missing templates
+//     or invalid overrides) before the cluster is persisted.
+//
 // Usage:
 //
-//	// Create a resolver
-//	res := resolver.NewResolver(client, namespace, cluster.Spec.TemplateDefaults)
+//		// Create a resolver
+//		res := resolver.NewResolver(client, namespace, cluster.Spec.TemplateDefaults)
 //
-//	// Webhook: Apply static and smart defaults to the object
-//	res.PopulateClusterDefaults(cluster)
+//		// Webhook: Apply static and smart defaults to the object
+//		res.PopulateClusterDefaults(cluster)
 //
-//	// Controller: Calculate final config for a specific component
-//	// This handles the Inline > Template > Default precedence logic
-//	globalTopoSpec, err := res.ResolveGlobalTopo(ctx, cluster)
+//	 // Webhook: Validate the cluster structure
+//	 if err := res.ValidateClusterIntegrity(ctx, cluster); err != nil {
+//	     return err
+//	 }
+//
+//		// Controller: Calculate final config for a specific component
+//		// This handles the Inline > Template > Default precedence logic
+//		globalTopoSpec, err := res.ResolveGlobalTopo(ctx, cluster)
 package resolver

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -1,0 +1,399 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
+	"github.com/numtide/multigres-operator/pkg/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestResolver_ValidateClusterIntegrity verifies checking template existence.
+func TestResolver_ValidateClusterIntegrity(t *testing.T) {
+	t.Parallel()
+	scheme := setupScheme()
+
+	// Setup Base Objects
+	coreTpl := &multigresv1alpha1.CoreTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-core", Namespace: "default"},
+	}
+	cellTpl := &multigresv1alpha1.CellTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-cell", Namespace: "default"},
+	}
+	shardTpl := &multigresv1alpha1.ShardTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-shard", Namespace: "default"},
+	}
+
+	objs := []client.Object{coreTpl, cellTpl, shardTpl}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	tests := map[string]struct {
+		cluster *multigresv1alpha1.MultigresCluster
+		wantErr string
+	}{
+		"Valid": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					TemplateDefaults: multigresv1alpha1.TemplateDefaults{
+						CoreTemplate:  "prod-core",
+						CellTemplate:  "prod-cell",
+						ShardTemplate: "prod-shard",
+					},
+					MultiAdmin: &multigresv1alpha1.MultiAdminConfig{TemplateRef: "prod-core"},
+					GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+						TemplateRef: "prod-core",
+					},
+				},
+			},
+		},
+		"Missing Core": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					TemplateDefaults: multigresv1alpha1.TemplateDefaults{CoreTemplate: "missing"},
+				},
+			},
+			wantErr: "referenced CoreTemplate 'missing' not found",
+		},
+		"Missing Cell (Inline)": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{{Name: "c1", CellTemplate: "missing"}},
+				},
+			},
+			wantErr: "referenced CellTemplate 'missing' not found",
+		},
+		"Missing MultiAdminWeb": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					MultiAdminWeb: &multigresv1alpha1.MultiAdminWebConfig{TemplateRef: "missing"},
+				},
+			},
+			wantErr: "referenced CoreTemplate 'missing' not found",
+		},
+		"Missing MultiAdmin": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					MultiAdmin: &multigresv1alpha1.MultiAdminConfig{TemplateRef: "missing"},
+				},
+			},
+			wantErr: "referenced CoreTemplate 'missing' not found",
+		},
+		"Missing GlobalTopoServer": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+						TemplateRef: "missing",
+					},
+				},
+			},
+			wantErr: "referenced CoreTemplate 'missing' not found",
+		},
+		"Missing CellTemplate Default": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					TemplateDefaults: multigresv1alpha1.TemplateDefaults{CellTemplate: "missing"},
+				},
+			},
+			wantErr: "referenced CellTemplate 'missing' not found",
+		},
+		"Missing ShardTemplate Default": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					TemplateDefaults: multigresv1alpha1.TemplateDefaults{ShardTemplate: "missing"},
+				},
+			},
+			wantErr: "referenced ShardTemplate 'missing' not found",
+		},
+		"Missing ShardTemplate Inline": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "invalid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "missing",
+							}},
+						}},
+					}},
+				},
+			},
+			wantErr: "referenced ShardTemplate 'missing' not found",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := NewResolver(fakeClient, "default", tc.cluster.Spec.TemplateDefaults)
+			err := r.ValidateClusterIntegrity(t.Context(), tc.cluster)
+
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Expected nil error, got %v", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("Expected error containing '%s', got %v", tc.wantErr, err)
+				}
+			}
+		})
+	}
+}
+
+// TestResolver_ValidateClusterLogic verifies complex logical validations.
+func TestResolver_ValidateClusterLogic(t *testing.T) {
+	t.Parallel()
+	scheme := setupScheme()
+
+	// Setup Base Objects
+	shardTpl := &multigresv1alpha1.ShardTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-shard", Namespace: "default"},
+		Spec: multigresv1alpha1.ShardTemplateSpec{
+			Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"default": {Type: "readWrite"},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shardTpl).Build()
+
+	tests := map[string]struct {
+		cluster        *multigresv1alpha1.MultigresCluster
+		wantWarnings   []string
+		wantErr        string
+		clientFailures *testutil.FailureConfig
+	}{
+		"Valid Logic": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1", CellTemplate: "prod-cell"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+		},
+		"Orphan Override Warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1", CellTemplate: "prod-cell"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"ghost": {Type: "read"},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			wantWarnings: []string{"does not exist in template 'prod-shard'"},
+		},
+		"Invalid Cell Reference (Orch)": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1", CellTemplate: "prod-cell"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									MultiOrch: &multigresv1alpha1.MultiOrchSpec{
+										Cells: []multigresv1alpha1.CellName{"zone-missing"},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			wantErr: "assigned to non-existent cell 'zone-missing'",
+		},
+		"Invalid Cell Reference (Pool)": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1", CellTemplate: "prod-cell"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"default": {
+											Cells: []multigresv1alpha1.CellName{"zone-missing"},
+										},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			wantErr: "pool 'default' in shard 's0' is assigned to non-existent cell 'zone-missing'",
+		},
+		"Empty Cells (Orphan Shard)": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{}, // No cells
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			wantErr: "matches NO cells",
+		},
+		"Empty Cells (Pool)": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{}, // No cluster cells prevents defaulting
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Spec: &multigresv1alpha1.ShardInlineSpec{
+									MultiOrch: multigresv1alpha1.MultiOrchSpec{
+										Cells: []multigresv1alpha1.CellName{
+											"ghost",
+										}, // Bypass Check 1
+									},
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"default": {
+											Cells: []multigresv1alpha1.CellName{}, // Explicit empty
+										},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			wantErr: "pool 'default' in shard 's0' matches NO cells",
+		},
+		"Resolution Error": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "missing-template",
+							}},
+						}},
+					}},
+				},
+			},
+			wantErr: "cannot resolve shard 's0'",
+		},
+		"Orphan Check Resolution Error": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"ghost": {},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			clientFailures: &testutil.FailureConfig{
+				OnGet: func(key client.ObjectKey) error {
+					return testutil.ErrInjected
+				},
+			},
+			wantErr: "failed to resolve template for orphan check",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var c client.Client = fakeClient
+			if tc.clientFailures != nil {
+				c = testutil.NewFakeClientWithFailures(fakeClient, tc.clientFailures)
+			}
+			r := NewResolver(c, "default", tc.cluster.Spec.TemplateDefaults)
+			warnings, err := r.ValidateClusterLogic(t.Context(), tc.cluster)
+
+			// Check Error
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Expected nil error, got %v", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("Expected error containing '%s', got %v", tc.wantErr, err)
+				}
+			}
+
+			// Check Warnings
+			if len(tc.wantWarnings) > 0 {
+				if len(warnings) == 0 {
+					t.Errorf("Expected warnings containing %v, got none", tc.wantWarnings)
+				}
+				for _, want := range tc.wantWarnings {
+					found := false
+					for _, got := range warnings {
+						if strings.Contains(got, want) {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("Expected warning containing '%s', got %v", want, warnings)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The webhook previously contained detailed knowledge of the `MultigresCluster` API structure, manually checking fields like `MultiAdmin` and `GlobalTopoServer`. This violated the Open/Closed principle, as adding any new component required modifying the webhook's validation logic alongside the resolver.

* Moved referential integrity checks (Core/Cell/Shard templates) from `pkg/webhook/handlers/validator.go` to a new `ValidateClusterIntegrity` method in `pkg/resolver/resolver.go`
* Moved logical simulation checks (orphaned overrides, valid cells) from `validator.go` to a new `ValidateClusterLogic` method in `resolver.go`
* Updated `MultigresClusterValidator` to simply delegate validation to the resolver methods
* Updated resolver documentation to explicitly define its role in admission validation
* Reached 100% test coverage in cluster handler that was missing.

Significantly improves maintainability by centralizing all domain logic in the resolver, allowing the webhook to remain stable and generic when new API fields are added.