### PR TITLE
fix(rbac): scope webhook permissions to owned resources

### DIFF
--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -37,7 +37,8 @@ import (
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,resourceNames=multigres-operator-mutating-webhook-configuration,verbs=get;update;patch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,resourceNames=multigres-operator-validating-webhook-configuration,verbs=get;update;patch
 
 // ============================================================================
 // MultigresClusterSpec Spec (User-editable API)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -28,15 +28,24 @@ rules:
   - patch
 - apiGroups:
   - admissionregistration.k8s.io
+  resourceNames:
+  - multigres-operator-mutating-webhook-configuration
   resources:
   - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - multigres-operator-validating-webhook-configuration
+  resources:
   - validatingwebhookconfigurations
   verbs:
   - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
The operator previously possessed broad cluster-wide permissions to list, watch, and update all `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` resources, creating a significant privilege escalation vector.

* Modified RBAC markers in `api/v1alpha1/multigrescluster_types.go` to explicitly list allowed resource names (`multigres-operator-mutating-webhook-configuration` and `multigres-operator-validating-webhook-configuration`)
* Removed `list` and `watch` verbs from webhook configuration permissions

This enforces the principle of least privilege, preventing a compromised operator from modifying or hijacking unauthorized admission controllers.