### PR TITLE
perf(controller): replace polling with event-driven reconciliation

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/integration_lifecycle_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_lifecycle_test.go
@@ -499,4 +499,5 @@ func TestMultigresCluster_Lifecycle(t *testing.T) {
 			t.Errorf("Deployment failed to update to v2: %v", err)
 		}
 	})
+
 }

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -3,7 +3,6 @@ package tablegroup
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -149,7 +148,7 @@ func (r *TableGroupReconciler) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 	}
 
-	return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
The `MultigresCluster` and `TableGroup` controllers previously relied on a fixed 1-minute polling interval, causing unnecessary API traffic and delaying updates when shared templates changed.

* Removed `RequeueAfter` from reconciliation loops in `multigrescluster_controller.go` and `tablegroup_controller.go` to stop busy-looping
* Added `Watches` for `CoreTemplate`, `CellTemplate`, and `ShardTemplate` to the `MultigresCluster` controller
* Implemented `enqueueRequestsFromTemplate` handler to trigger reconciliation for all clusters in a namespace when a referenced template is updated

This eliminates idle CPU and network usage while ensuring immediate propagation of configuration changes to all affected clusters.