### PR TITLE
feat(controller): add event recording to resource handlers

### DIFF
--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -299,24 +299,27 @@ func main() {
 	}
 
 	if err = (&cellcontroller.CellReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("cell-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cell")
 		os.Exit(1)
 	}
 
 	if err = (&toposervercontroller.TopoServerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("toposerver-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TopoServer")
 		os.Exit(1)
 	}
 
 	if err = (&shardcontroller.ShardReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("shard-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Shard")
 		os.Exit(1)

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -65,24 +65,29 @@ func (r *MultigresClusterReconciler) Reconcile(
 
 	if err := r.reconcileGlobalComponents(ctx, cluster, res); err != nil {
 		l.Error(err, "Failed to reconcile global components")
+		r.Recorder.Eventf(cluster, "Warning", "FailedApply", "Failed to reconcile global components: %v", err)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.reconcileCells(ctx, cluster, res); err != nil {
 		l.Error(err, "Failed to reconcile cells")
+		r.Recorder.Eventf(cluster, "Warning", "FailedApply", "Failed to reconcile cells: %v", err)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.reconcileDatabases(ctx, cluster, res); err != nil {
 		l.Error(err, "Failed to reconcile databases")
+		r.Recorder.Eventf(cluster, "Warning", "FailedApply", "Failed to reconcile databases: %v", err)
 		return ctrl.Result{}, err
 	}
 
 	if err := r.updateStatus(ctx, cluster); err != nil {
 		l.Error(err, "Failed to update status")
+		r.Recorder.Eventf(cluster, "Warning", "FailedApply", "Failed to update status: %v", err)
 		return ctrl.Result{}, err
 	}
 
+	r.Recorder.Event(cluster, "Normal", "Synced", "Successfully reconciled MultigresCluster")
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -57,6 +57,9 @@ func (r *TableGroupReconciler) Reconcile(
 		desired, err := BuildShard(tg, &shardSpec, r.Scheme)
 		if err != nil {
 			l.Error(err, "Failed to build shard", "shard", shardSpec.Name)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(tg, "Warning", "FailedApply", "Failed to build shard %s: %v", shardSpec.Name, err)
+			}
 			return ctrl.Result{}, fmt.Errorf("failed to build shard: %w", err)
 		}
 
@@ -73,6 +76,9 @@ func (r *TableGroupReconciler) Reconcile(
 			client.FieldOwner("multigres-operator"),
 		); err != nil {
 			l.Error(err, "Failed to apply shard", "shard", desired.Name)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(tg, "Warning", "FailedApply", "Failed to apply shard %s: %v", desired.Name, err)
+			}
 			return ctrl.Result{}, fmt.Errorf("failed to apply shard: %w", err)
 		}
 
@@ -88,19 +94,27 @@ func (r *TableGroupReconciler) Reconcile(
 		"multigres.com/database":   string(tg.Spec.DatabaseName),
 		"multigres.com/tablegroup": string(tg.Spec.TableGroupName),
 	}); err != nil {
+		if r.Recorder != nil {
+			r.Recorder.Eventf(tg, "Warning", "CleanUpError", "Failed to list shards for pruning: %v", err)
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to list shards for pruning: %w", err)
 	}
 
 	for _, s := range existingShards.Items {
 		if !activeShardNames[s.Name] {
 			if err := r.Delete(ctx, &s); err != nil {
+				if r.Recorder != nil {
+					r.Recorder.Eventf(tg, "Warning", "CleanUpError", "Failed to delete orphan shard %s: %v", s.Name, err)
+				}
 				return ctrl.Result{}, fmt.Errorf(
 					"failed to delete orphan shard '%s': %w",
 					s.Name,
 					err,
 				)
 			}
-			r.Recorder.Eventf(tg, "Normal", "Deleted", "Deleted orphaned Shard %s", s.Name)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(tg, "Normal", "Deleted", "Deleted orphaned Shard %s", s.Name)
+			}
 		}
 	}
 
@@ -114,6 +128,9 @@ func (r *TableGroupReconciler) Reconcile(
 		"multigres.com/database":   string(tg.Spec.DatabaseName),
 		"multigres.com/tablegroup": string(tg.Spec.TableGroupName),
 	}); err != nil {
+		if r.Recorder != nil {
+			r.Recorder.Eventf(tg, "Warning", "StatusError", "Failed to list shards for status: %v", err)
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to list shards for status: %w", err)
 	}
 
@@ -145,9 +162,15 @@ func (r *TableGroupReconciler) Reconcile(
 	})
 
 	if err := r.Status().Update(ctx, tg); err != nil {
+		if r.Recorder != nil {
+			r.Recorder.Eventf(tg, "Warning", "StatusError", "Failed to update status: %v", err)
+		}
 		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
 	}
 
+	if r.Recorder != nil {
+		r.Recorder.Event(tg, "Normal", "Synced", "Successfully reconciled TableGroup")
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/resource-handler/controller/cell/cell_controller_test.go
+++ b/pkg/resource-handler/controller/cell/cell_controller_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -567,8 +568,9 @@ func TestCellReconciler_Reconcile(t *testing.T) {
 			fakeClient := testutil.NewFakeClientWithFailures(baseClient, tc.failureConfig)
 
 			reconciler := &cell.CellReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:   fakeClient,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
 			}
 
 			// Create the Cell resource if not in existing objects
@@ -625,8 +627,9 @@ func TestCellReconciler_ReconcileNotFound(t *testing.T) {
 		Build()
 
 	reconciler := &cell.CellReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
 	}
 
 	// Reconcile non-existent resource

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1109,8 +1110,9 @@ func TestShardReconciler_Reconcile(t *testing.T) {
 			}
 
 			reconciler := &ShardReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:   fakeClient,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
 			}
 			if tc.reconcilerScheme != nil {
 				reconciler.Scheme = tc.reconcilerScheme
@@ -1170,8 +1172,9 @@ func TestShardReconciler_ReconcileNotFound(t *testing.T) {
 		Build()
 
 	reconciler := &ShardReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
 	}
 
 	// Reconcile non-existent resource

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller_test.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -382,8 +383,9 @@ func TestTopoServerReconciler_Reconcile(t *testing.T) {
 			}
 
 			reconciler := &TopoServerReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
+				Client:   fakeClient,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
 			}
 
 			// Create the TopoServer resource if not in existing objects
@@ -445,8 +447,9 @@ func TestTopoServerReconciler_ReconcileNotFound(t *testing.T) {
 		Build()
 
 	reconciler := &TopoServerReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
 	}
 
 	// Reconcile non-existent resource
@@ -509,8 +512,9 @@ func TestTopoServerReconciler_UpdateStatus(t *testing.T) {
 			Build()
 
 		r := &TopoServerReconciler{
-			Client: fakeClient,
-			Scheme: scheme,
+			Client:   fakeClient,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(10),
 		}
 
 		if err := r.updateStatus(t.Context(), toposerver); err != nil {


### PR DESCRIPTION
Resource reconcilers (Cell, Shard, TopoServer) previously operated silently, making troubleshooting difficult without checking operator logs. This change introduces comprehensive Kubernetes event recording to expose reconciliation state directly on the resources.

- Injected named EventRecorder instances into Cell, Shard, and TopoServer reconcilers in main.go
- Added Recorder field to controller structs and imported client-go/tools/record
- Implemented event emission for successful syncs (Synced), failures (FailedApply, ConfigError), and lifecycle events (Finalizer, Deleted)
- Updated unit tests to utilize NewFakeRecorder to support the new struct fields

Enables users to debug resource state and reconciliation errors via kubectl describe.