### PR TITLE
refactor(controller): enforce server-side apply for status updates

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/status_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/status_test.go
@@ -56,9 +56,9 @@ func TestReconcile_Status(t *testing.T) {
 		},
 		"Error: Update Status Failed (API Error)": {
 			failureConfig: &testutil.FailureConfig{
-				OnStatusUpdate: testutil.FailOnObjectName(clusterName, errSimulated),
+				OnStatusPatch: testutil.FailOnObjectName(clusterName, errSimulated),
 			},
-			wantErrMsg: "failed to update cluster status",
+			wantErrMsg: "failed to patch status",
 		},
 	}
 

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
@@ -615,9 +615,9 @@ func TestTableGroupReconciler_Reconcile_Failure(t *testing.T) {
 			tableGroup:      baseTG.DeepCopy(),
 			existingObjects: []client.Object{},
 			failureConfig: &testutil.FailureConfig{
-				OnStatusUpdate: testutil.FailOnObjectName(tgName, errSimulated),
+				OnStatusPatch: testutil.FailOnObjectName(tgName, errSimulated),
 			},
-			expectedEvents: []string{"Warning StatusError Failed to update status"},
+			expectedEvents: []string{"Warning StatusError Failed to patch status"},
 		},
 	}
 
@@ -641,7 +641,7 @@ func TestTableGroupReconciler_Reconcile_Failure(t *testing.T) {
 				WithStatusSubresource(&multigresv1alpha1.TableGroup{}, &multigresv1alpha1.Shard{})
 			baseClient := clientBuilder.Build()
 
-			// For OnStatusUpdate failures, we need to make sure the object exists
+			// For OnStatusPatch failures, we need to make sure the object exists
 			// and that we are targeting the right call. The fake client intercepts calls.
 			finalClient := client.Client(baseClient)
 			if tc.failureConfig != nil {

--- a/pkg/resource-handler/controller/cell/cell_controller_test.go
+++ b/pkg/resource-handler/controller/cell/cell_controller_test.go
@@ -382,7 +382,7 @@ func TestCellReconciler_Reconcile(t *testing.T) {
 			},
 			existingObjects: []client.Object{},
 			failureConfig: &testutil.FailureConfig{
-				OnStatusUpdate: testutil.FailOnObjectName("test-cell", testutil.ErrInjected),
+				OnStatusPatch: testutil.FailOnObjectName("test-cell", testutil.ErrInjected),
 			},
 			wantErr: true,
 		},

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -546,7 +546,7 @@ func TestShardReconciler_Reconcile(t *testing.T) {
 			},
 			existingObjects: []client.Object{},
 			failureConfig: &testutil.FailureConfig{
-				OnStatusUpdate: testutil.FailOnObjectName("test-shard", testutil.ErrInjected),
+				OnStatusPatch: testutil.FailOnObjectName("test-shard", testutil.ErrInjected),
 			},
 			wantErr: true,
 		},

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller_test.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller_test.go
@@ -212,7 +212,7 @@ func TestTopoServerReconciler_Reconcile(t *testing.T) {
 			},
 			existingObjects: []client.Object{},
 			failureConfig: &testutil.FailureConfig{
-				OnStatusUpdate: testutil.FailOnObjectName("test-toposerver", testutil.ErrInjected),
+				OnStatusPatch: testutil.FailOnObjectName("test-toposerver", testutil.ErrInjected),
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Status updates were previously performed using client-side updates, which are vulnerable to 409 Conflict errors if the resource metadata changes during the reconciliation loop. This change switches all status updates to Server-Side Apply (SSA), ensuring robust merging of status fields regardless of concurrent metadata changes.

- Refactored updateStatus in MultigresCluster, TableGroup, Cell, Shard, and TopoServer controllers to use client.Patch with Apply
- Constructed explicit patch objects containing only TypeMeta, ObjectMeta, and Status to ensure correct SSA behavior
- Updated unit test failure configurations to target OnStatusPatch hooks instead of OnStatusUpdate

Eliminates potential reconciliation loops caused by optimistic locking conflicts on status updates.