### PR TITLE
refactor(resource-handler): standardize controller deletion

### DIFF
--- a/pkg/resource-handler/controller/cell/cell_controller_internal_test.go
+++ b/pkg/resource-handler/controller/cell/cell_controller_internal_test.go
@@ -9,8 +9,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/testutil"
@@ -111,41 +116,6 @@ func TestUpdateStatus_MultiGatewayDeploymentNotFound(t *testing.T) {
 			"updateStatus() should not error when MultiGateway Deployment not found, got: %v",
 			err,
 		)
-	}
-}
-
-// TestHandleDeletion_NoFinalizer tests early return when no finalizer is present.
-func TestHandleDeletion_NoFinalizer(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
-
-	cell := &multigresv1alpha1.Cell{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-cell",
-			Namespace:  "default",
-			Finalizers: []string{}, // No finalizer
-		},
-		Spec: multigresv1alpha1.CellSpec{
-			Name: "zone1",
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(cell).
-		Build()
-
-	reconciler := &CellReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
-	}
-
-	result, err := reconciler.handleDeletion(context.Background(), cell)
-	if err != nil {
-		t.Errorf("handleDeletion() should not error when no finalizer, got: %v", err)
-	}
-	if result.RequeueAfter > 0 {
-		t.Error("handleDeletion() should not requeue when no finalizer")
 	}
 }
 
@@ -327,4 +297,45 @@ func TestSetConditions_ZeroReplicas(t *testing.T) {
 	if readyCond.Reason != "MultiGatewayNotReady" {
 		t.Errorf("Condition reason = %s, want MultiGatewayNotReady", readyCond.Reason)
 	}
+}
+
+// TestSetupWithManager tests the manager setup function.
+func TestSetupWithManager(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	// dummy config
+	cfg := &rest.Config{Host: "http://localhost:8080"}
+
+	createMgr := func() ctrl.Manager {
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:  scheme,
+			Metrics: metricsserver.Options{BindAddress: "0"},
+		})
+		if err != nil {
+			t.Fatalf("Failed to create manager: %v", err)
+		}
+		return mgr
+	}
+
+	t.Run("default options", func(t *testing.T) {
+		mgr := createMgr()
+		r := &CellReconciler{Client: mgr.GetClient(), Scheme: scheme}
+		if err := r.SetupWithManager(mgr); err != nil {
+			t.Errorf("SetupWithManager() error = %v", err)
+		}
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		mgr := createMgr()
+		r := &CellReconciler{Client: mgr.GetClient(), Scheme: scheme}
+		if err := r.SetupWithManager(mgr, controller.Options{
+			MaxConcurrentReconciles: 1,
+			SkipNameValidation:      ptr.To(true),
+		}); err != nil {
+			t.Errorf("SetupWithManager() with opts error = %v", err)
+		}
+	})
 }

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -337,38 +337,6 @@ func TestUpdateStatus_PoolStatefulSetNotFound(t *testing.T) {
 	}
 }
 
-// TestHandleDeletion_NoFinalizer tests early return when no finalizer is present.
-func TestHandleDeletion_NoFinalizer(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = multigresv1alpha1.AddToScheme(scheme)
-
-	shard := &multigresv1alpha1.Shard{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "test-shard",
-			Namespace:  "default",
-			Finalizers: []string{}, // No finalizer
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(shard).
-		Build()
-
-	reconciler := &ShardReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
-	}
-
-	result, err := reconciler.handleDeletion(context.Background(), shard)
-	if err != nil {
-		t.Errorf("handleDeletion() should not error when no finalizer, got: %v", err)
-	}
-	if result.RequeueAfter > 0 {
-		t.Error("handleDeletion() should not requeue when no finalizer")
-	}
-}
-
 // TestReconcile_PatchError tests error path on Patch operations.
 func TestReconcile_PatchError(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
Refactors the deletion logic across the `cell`, `shard`, and `toposerver` controllers to remove manual finalizer handling in favor of Kubernetes garbage collection. This simplifies the reconciliation loop and prevents potential deadlocks.

Changes:

* Removed `finalizerName` constants and `handleDeletion` methods from `cell`, `shard`, and `toposerver` controllers.
* Implemented an "early exit" pattern (`if !resource.DeletionTimestamp.IsZero()`) for deletion handling.
* Updated internal and external tests to remove finalizer validations and add specific test cases for the early exit behavior.
* Added missing `TestSetupWithManager` to `cell` and `toposerver` internal tests.

Restores 100% test coverage for all three controllers while simplifying the codebase.