### PR TITLE
feat(observability): implement comprehensive events and strict recording

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/status.go
+++ b/pkg/cluster-handler/controller/multigrescluster/status.go
@@ -15,6 +15,7 @@ func (r *MultigresClusterReconciler) updateStatus(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
 ) error {
+	oldPhase := cluster.Status.Phase
 	cluster.Status.ObservedGeneration = cluster.Generation
 	cluster.Status.Cells = make(map[multigresv1alpha1.CellName]multigresv1alpha1.CellStatusSummary)
 	cluster.Status.Databases = make(
@@ -142,6 +143,10 @@ func (r *MultigresClusterReconciler) updateStatus(
 	}
 
 	// 2. Apply the Patch
+	if oldPhase != cluster.Status.Phase {
+		r.Recorder.Eventf(cluster, "Normal", "PhaseChange", "Transitioned from '%s' to '%s'", oldPhase, cluster.Status.Phase)
+	}
+
 	if err := r.Status().Patch(
 		ctx,
 		patchObj,

--- a/pkg/cluster-handler/controller/multigrescluster/status_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/status_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -117,8 +118,9 @@ func TestUpdateStatus_Coverage(t *testing.T) {
 		Build()
 
 	r := &MultigresClusterReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	if err := r.updateStatus(context.Background(), cluster); err != nil {
@@ -308,8 +310,9 @@ func TestUpdateStatus_ZeroResources(t *testing.T) {
 		Build()
 
 	r := &MultigresClusterReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	if err := r.updateStatus(context.Background(), cluster); err != nil {

--- a/pkg/cluster-handler/controller/tablegroup/integration_lifecycle_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/integration_lifecycle_test.go
@@ -48,8 +48,9 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 
 		// Start Controller
 		if err := (&tablegroup.TableGroupReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
+			Client:   mgr.GetClient(),
+			Scheme:   mgr.GetScheme(),
+			Recorder: mgr.GetEventRecorderFor("tablegroup-controller"),
 		}).SetupWithManager(mgr, controller.Options{SkipNameValidation: ptr.To(true)}); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cluster-handler/controller/tablegroup/integration_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/integration_test.go
@@ -38,8 +38,9 @@ func TestSetupWithManager(t *testing.T) {
 	)
 
 	if err := (&tablegroup.TableGroupReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("tablegroup-controller"),
 	}).SetupWithManager(mgr, controller.Options{
 		SkipNameValidation: ptr.To(true),
 	}); err != nil {
@@ -64,8 +65,9 @@ func TestSetupWithManager_Failure(t *testing.T) {
 
 	// Setup should fail because TableGroup is not in scheme
 	if err := (&tablegroup.TableGroupReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("tablegroup-controller"),
 	}).SetupWithManager(mgr, controller.Options{
 		SkipNameValidation: ptr.To(true),
 	}); err == nil {
@@ -243,8 +245,9 @@ func TestTableGroupReconciliation(t *testing.T) {
 
 			// 3. Setup and Start Controller
 			reconciler := &tablegroup.TableGroupReconciler{
-				Client: mgr.GetClient(),
-				Scheme: mgr.GetScheme(),
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("tablegroup-controller"),
 			}
 
 			if err := reconciler.SetupWithManager(mgr, controller.Options{

--- a/pkg/resolver/cluster_test.go
+++ b/pkg/resolver/cluster_test.go
@@ -372,7 +372,7 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 			)
 
 			got := tc.input.DeepCopy()
-			if err := r.PopulateClusterDefaults(t.Context(), got); err != nil {
+			if _, err := r.PopulateClusterDefaults(t.Context(), got); err != nil {
 				t.Fatalf("PopulateClusterDefaults failed: %v", err)
 			}
 
@@ -402,7 +402,7 @@ func TestResolver_PopulateClusterDefaults_ClientError(t *testing.T) {
 		},
 	}
 
-	err := r.PopulateClusterDefaults(t.Context(), input)
+	_, err := r.PopulateClusterDefaults(t.Context(), input)
 	if err == nil || !errors.Is(err, errSim) {
 		t.Errorf("Expected simulated error, got %v", err)
 	}

--- a/pkg/resource-handler/controller/cell/cell_controller_internal_test.go
+++ b/pkg/resource-handler/controller/cell/cell_controller_internal_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,8 +44,9 @@ func TestReconcileMultiGatewayDeployment_InvalidScheme(t *testing.T) {
 		Build()
 
 	reconciler := &CellReconciler{
-		Client: fakeClient,
-		Scheme: invalidScheme,
+		Client:   fakeClient,
+		Scheme:   invalidScheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.reconcileMultiGatewayDeployment(context.Background(), cell)
@@ -72,8 +74,9 @@ func TestReconcileMultiGatewayService_InvalidScheme(t *testing.T) {
 		Build()
 
 	reconciler := &CellReconciler{
-		Client: fakeClient,
-		Scheme: invalidScheme,
+		Client:   fakeClient,
+		Scheme:   invalidScheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.reconcileMultiGatewayService(context.Background(), cell)
@@ -105,8 +108,9 @@ func TestUpdateStatus_MultiGatewayDeploymentNotFound(t *testing.T) {
 		Build()
 
 	reconciler := &CellReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	// Call updateStatus when MultiGateway Deployment doesn't exist yet
@@ -152,8 +156,9 @@ func TestReconcileMultiGatewayDeployment_PatchError(t *testing.T) {
 	})
 
 	reconciler := &CellReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.reconcileMultiGatewayDeployment(context.Background(), cell)
@@ -195,8 +200,9 @@ func TestReconcileMultiGatewayService_PatchError(t *testing.T) {
 	})
 
 	reconciler := &CellReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.reconcileMultiGatewayService(context.Background(), cell)
@@ -237,8 +243,9 @@ func TestUpdateStatus_GetError(t *testing.T) {
 	})
 
 	reconciler := &CellReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.updateStatus(context.Background(), cell)
@@ -249,7 +256,9 @@ func TestUpdateStatus_GetError(t *testing.T) {
 
 // TestSetConditions_ZeroReplicas tests setConditions when deployments have zero replicas.
 func TestSetConditions_ZeroReplicas(t *testing.T) {
-	reconciler := &CellReconciler{}
+	reconciler := &CellReconciler{
+		Recorder: record.NewFakeRecorder(100),
+	}
 
 	cell := &multigresv1alpha1.Cell{
 		ObjectMeta: metav1.ObjectMeta{
@@ -322,7 +331,11 @@ func TestSetupWithManager(t *testing.T) {
 
 	t.Run("default options", func(t *testing.T) {
 		mgr := createMgr()
-		r := &CellReconciler{Client: mgr.GetClient(), Scheme: scheme}
+		r := &CellReconciler{
+			Client:   mgr.GetClient(),
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(100),
+		}
 		if err := r.SetupWithManager(mgr); err != nil {
 			t.Errorf("SetupWithManager() error = %v", err)
 		}
@@ -330,7 +343,11 @@ func TestSetupWithManager(t *testing.T) {
 
 	t.Run("with options", func(t *testing.T) {
 		mgr := createMgr()
-		r := &CellReconciler{Client: mgr.GetClient(), Scheme: scheme}
+		r := &CellReconciler{
+			Client:   mgr.GetClient(),
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(100),
+		}
 		if err := r.SetupWithManager(mgr, controller.Options{
 			MaxConcurrentReconciles: 1,
 			SkipNameValidation:      ptr.To(true),

--- a/pkg/resource-handler/controller/cell/integration_test.go
+++ b/pkg/resource-handler/controller/cell/integration_test.go
@@ -38,8 +38,9 @@ func TestSetupWithManager(t *testing.T) {
 	)
 
 	if err := (&cellcontroller.CellReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("cell-controller"),
 	}).SetupWithManager(mgr, controller.Options{
 		SkipNameValidation: ptr.To(true),
 	}); err != nil {
@@ -469,8 +470,9 @@ func TestCellReconciliation(t *testing.T) {
 			client := mgr.GetClient()
 
 			cellReconciler := &cellcontroller.CellReconciler{
-				Client: mgr.GetClient(),
-				Scheme: mgr.GetScheme(),
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("cell-controller"),
 			}
 			if err := cellReconciler.SetupWithManager(mgr, controller.Options{
 				// Needed for the parallel test runs

--- a/pkg/resource-handler/controller/shard/integration_test.go
+++ b/pkg/resource-handler/controller/shard/integration_test.go
@@ -42,8 +42,9 @@ func TestSetupWithManager(t *testing.T) {
 	)
 
 	if err := (&shardcontroller.ShardReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("shard-controller"),
 	}).SetupWithManager(mgr, controller.Options{
 		SkipNameValidation: ptr.To(true),
 	}); err != nil {
@@ -973,9 +974,11 @@ func TestShardReconciliation(t *testing.T) {
 			)
 			client := mgr.GetClient()
 
+			// 3. Setup and Start Controller
 			shardReconciler := &shardcontroller.ShardReconciler{
-				Client: mgr.GetClient(),
-				Scheme: mgr.GetScheme(),
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("shard-controller"),
 			}
 			if err := shardReconciler.SetupWithManager(mgr, controller.Options{
 				// Needed for the parallel test runs
@@ -1184,8 +1187,9 @@ func TestReconcileDeletions(t *testing.T) {
 
 	// Setup controller with manager
 	if err := (&shardcontroller.ShardReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("shard-controller"),
 	}).SetupWithManager(mgr, controller.Options{
 		SkipNameValidation: ptr.To(true),
 	}); err != nil {

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -151,6 +151,8 @@ func (r *ShardReconciler) reconcileMultiOrchDeployment(
 		return fmt.Errorf("failed to apply MultiOrch Deployment: %w", err)
 	}
 
+	r.Recorder.Eventf(shard, "Normal", "Applied", "Applied %s %s", desired.GroupVersionKind().Kind, desired.Name)
+
 	return nil
 }
 
@@ -177,6 +179,8 @@ func (r *ShardReconciler) reconcilePgHbaConfigMap(
 		return fmt.Errorf("failed to apply pg_hba ConfigMap: %w", err)
 	}
 
+	r.Recorder.Eventf(shard, "Normal", "Applied", "Applied %s %s", desired.GroupVersionKind().Kind, desired.Name)
+
 	return nil
 }
 
@@ -202,6 +206,8 @@ func (r *ShardReconciler) reconcileMultiOrchService(
 	); err != nil {
 		return fmt.Errorf("failed to apply MultiOrch Service: %w", err)
 	}
+
+	r.Recorder.Eventf(shard, "Normal", "Applied", "Applied %s %s", desired.GroupVersionKind().Kind, desired.Name)
 
 	return nil
 }
@@ -275,6 +281,8 @@ func (r *ShardReconciler) reconcilePoolStatefulSet(
 		return fmt.Errorf("failed to apply pool StatefulSet: %w", err)
 	}
 
+	r.Recorder.Eventf(shard, "Normal", "Applied", "Applied %s %s", desired.GroupVersionKind().Kind, desired.Name)
+
 	return nil
 }
 
@@ -302,6 +310,8 @@ func (r *ShardReconciler) reconcilePoolBackupPVC(
 	); err != nil {
 		return fmt.Errorf("failed to apply backup PVC: %w", err)
 	}
+
+	r.Recorder.Eventf(shard, "Normal", "Applied", "Applied %s %s", desired.GroupVersionKind().Kind, desired.Name)
 
 	return nil
 }
@@ -331,6 +341,8 @@ func (r *ShardReconciler) reconcilePoolHeadlessService(
 		return fmt.Errorf("failed to apply pool headless Service: %w", err)
 	}
 
+	r.Recorder.Eventf(shard, "Normal", "Applied", "Applied %s %s", desired.GroupVersionKind().Kind, desired.Name)
+
 	return nil
 }
 
@@ -339,6 +351,7 @@ func (r *ShardReconciler) updateStatus(
 	ctx context.Context,
 	shard *multigresv1alpha1.Shard,
 ) error {
+	oldPhase := shard.Status.Phase
 	cellsSet := make(map[multigresv1alpha1.CellName]bool)
 
 	// Update pools status
@@ -384,6 +397,10 @@ func (r *ShardReconciler) updateStatus(
 	}
 
 	// 2. Apply the Patch
+	if oldPhase != shard.Status.Phase {
+		r.Recorder.Eventf(shard, "Normal", "PhaseChange", "Transitioned from '%s' to '%s'", oldPhase, shard.Status.Phase)
+	}
+
 	if err := r.Status().Patch(
 		ctx,
 		patchObj,

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -1020,7 +1020,7 @@ func TestShardReconciler_Reconcile(t *testing.T) {
 			reconciler := &ShardReconciler{
 				Client:   fakeClient,
 				Scheme:   scheme,
-				Recorder: record.NewFakeRecorder(10),
+				Recorder: record.NewFakeRecorder(1000),
 			}
 			if tc.reconcilerScheme != nil {
 				reconciler.Scheme = tc.reconcilerScheme
@@ -1188,8 +1188,9 @@ func TestShardReconciler_UpdateStatus(t *testing.T) {
 			Build()
 
 		r := &ShardReconciler{
-			Client: fakeClient,
-			Scheme: scheme,
+			Client:   fakeClient,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(100),
 		}
 
 		if err := r.updateStatus(context.Background(), shard); err != nil {
@@ -1273,8 +1274,9 @@ func TestShardReconciler_UpdateStatus(t *testing.T) {
 			Build()
 
 		r := &ShardReconciler{
-			Client: fakeClient,
-			Scheme: scheme,
+			Client:   fakeClient,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(100),
 		}
 
 		if err := r.updateStatus(context.Background(), shard); err != nil {

--- a/pkg/resource-handler/controller/toposerver/integration_test.go
+++ b/pkg/resource-handler/controller/toposerver/integration_test.go
@@ -38,8 +38,9 @@ func TestSetupWithManager(t *testing.T) {
 	)
 
 	if err := (&toposervercontroller.TopoServerReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("toposerver-controller"),
 	}).SetupWithManager(mgr, controller.Options{
 		SkipNameValidation: ptr.To(true),
 	}); err != nil {
@@ -217,8 +218,9 @@ func TestTopoServerReconciliation(t *testing.T) {
 			client := mgr.GetClient()
 
 			toposerverReconciler := &toposervercontroller.TopoServerReconciler{
-				Client: mgr.GetClient(),
-				Scheme: mgr.GetScheme(),
+				Client:   mgr.GetClient(),
+				Scheme:   mgr.GetScheme(),
+				Recorder: mgr.GetEventRecorderFor("toposerver-controller"),
 			}
 			if err := toposerverReconciler.SetupWithManager(mgr, controller.Options{
 				// Needed for the parallel test runs

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller_internal_test.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller_internal_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,8 +41,9 @@ func TestReconcileStatefulSet_InvalidScheme(t *testing.T) {
 		Build()
 
 	reconciler := &TopoServerReconciler{
-		Client: fakeClient,
-		Scheme: invalidScheme,
+		Client:   fakeClient,
+		Scheme:   invalidScheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.reconcileStatefulSet(context.Background(), toposerver)
@@ -67,8 +69,9 @@ func TestReconcileHeadlessService_InvalidScheme(t *testing.T) {
 		Build()
 
 	reconciler := &TopoServerReconciler{
-		Client: fakeClient,
-		Scheme: invalidScheme,
+		Client:   fakeClient,
+		Scheme:   invalidScheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.reconcileHeadlessService(context.Background(), toposerver)
@@ -94,8 +97,9 @@ func TestReconcileClientService_InvalidScheme(t *testing.T) {
 		Build()
 
 	reconciler := &TopoServerReconciler{
-		Client: fakeClient,
-		Scheme: invalidScheme,
+		Client:   fakeClient,
+		Scheme:   invalidScheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.reconcileClientService(context.Background(), toposerver)
@@ -125,8 +129,9 @@ func TestUpdateStatus_StatefulSetNotFound(t *testing.T) {
 		Build()
 
 	reconciler := &TopoServerReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	// Call updateStatus when StatefulSet doesn't exist yet
@@ -167,8 +172,9 @@ func TestReconcileClientService_PatchError(t *testing.T) {
 	})
 
 	reconciler := &TopoServerReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.reconcileClientService(context.Background(), toposerver)
@@ -202,8 +208,9 @@ func TestUpdateStatus_GetError(t *testing.T) {
 	})
 
 	reconciler := &TopoServerReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
 	}
 
 	err := reconciler.updateStatus(context.Background(), toposerver)
@@ -235,7 +242,11 @@ func TestSetupWithManager(t *testing.T) {
 
 	t.Run("default options", func(t *testing.T) {
 		mgr := createMgr()
-		r := &TopoServerReconciler{Client: mgr.GetClient(), Scheme: scheme}
+		r := &TopoServerReconciler{
+			Client:   mgr.GetClient(),
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(100),
+		}
 		if err := r.SetupWithManager(mgr); err != nil {
 			t.Errorf("SetupWithManager() error = %v", err)
 		}
@@ -243,7 +254,11 @@ func TestSetupWithManager(t *testing.T) {
 
 	t.Run("with options", func(t *testing.T) {
 		mgr := createMgr()
-		r := &TopoServerReconciler{Client: mgr.GetClient(), Scheme: scheme}
+		r := &TopoServerReconciler{
+			Client:   mgr.GetClient(),
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(100),
+		}
 		if err := r.SetupWithManager(mgr, controller.Options{
 			MaxConcurrentReconciles: 1,
 			SkipNameValidation:      ptr.To(true),

--- a/pkg/webhook/handlers/defaulter.go
+++ b/pkg/webhook/handlers/defaulter.go
@@ -40,7 +40,7 @@ func (d *MultigresClusterDefaulter) Default(ctx context.Context, obj runtime.Obj
 	}
 
 	// 1. Static Defaulting (Images, System Catalog)
-	if err := d.Resolver.PopulateClusterDefaults(ctx, cluster); err != nil {
+	if _, err := d.Resolver.PopulateClusterDefaults(ctx, cluster); err != nil {
 		return fmt.Errorf("failed to populate cluster defaults: %w", err)
 	}
 


### PR DESCRIPTION
The operator previously lacked visibility into state transitions, child resource updates, and implicit defaulting, making debugging difficult. Additionally, defensive nil-checks for the EventRecorder masked uninitialized dependencies in the test suite.

* Refactored `PopulateClusterDefaults` to return decision strings for implicit configuration
* Added `ImplicitDefault` events to MultigresCluster controller
* Implemented `Applied` events in Shard, Cell, TableGroup, and TopoServer controllers for all child resources
* Added `PhaseChange` events to track lifecycle transitions across all controllers
* Updated all controller test suites to initialize `FakeRecorder` to prevent panics

Significantly enhances operator observability via standard Kubernetes events and improves code quality by enforcing strict dependency invariants.