### PR TITLE
perf(controller): tune concurrency and client limits for high throughput

### DIFF
--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -270,7 +270,12 @@ func main() {
 	// Local Config: Cache everything (for Cert-Manager / Leader Election)
 	unfilteredConfig := cache.Config{}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	// Adjust the client config to prevent throttling with high concurrency
+	config := ctrl.GetConfigOrDie()
+	config.QPS = 50
+	config.Burst = 100
+
+	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: probeAddr,

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -118,6 +118,8 @@ func (r *MultigresClusterReconciler) SetupWithManager(
 		controllerOpts = opts[0]
 	}
 
+	controllerOpts.MaxConcurrentReconciles = 20
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.MultigresCluster{}).
 		Owns(&multigresv1alpha1.Cell{}).

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -251,6 +251,8 @@ func (r *TableGroupReconciler) SetupWithManager(
 		controllerOpts = opts[0]
 	}
 
+	controllerOpts.MaxConcurrentReconciles = 20
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.TableGroup{}).
 		Owns(&multigresv1alpha1.Shard{}).

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -280,6 +280,8 @@ func (r *CellReconciler) SetupWithManager(mgr ctrl.Manager, opts ...controller.O
 		controllerOpts = opts[0]
 	}
 
+	controllerOpts.MaxConcurrentReconciles = 20
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.Cell{}).
 		Owns(&appsv1.Deployment{}).

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -625,6 +625,8 @@ func (r *ShardReconciler) SetupWithManager(mgr ctrl.Manager, opts ...controller.
 		controllerOpts = opts[0]
 	}
 
+	controllerOpts.MaxConcurrentReconciles = 20
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.Shard{}).
 		Owns(&appsv1.Deployment{}).

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller.go
@@ -312,6 +312,8 @@ func (r *TopoServerReconciler) SetupWithManager(
 		controllerOpts = opts[0]
 	}
 
+	controllerOpts.MaxConcurrentReconciles = 20
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.TopoServer{}).
 		Owns(&appsv1.StatefulSet{}).


### PR DESCRIPTION
Optimized the operator's runtime configuration to handle large-scale topologies without bottlenecking or throttling.

- Increased `MaxConcurrentReconciles` to 20 for all controllers (MultigresCluster, Shard, Cell, TableGroup, TopoServer) to prevent head-of-line blocking.
- Boosted global client-go rate limits (QPS: 50, Burst: 100) to support the increased worker concurrency without hitting client-side throttling.
- Documented performance tuning parameters in implementation notes.

This change significantly improves convergence time during mass updates or operator restarts.