### PR TITLE
fix(controller): enforce strict observed generation checks

### DIFF
--- a/api/v1alpha1/cell_types.go
+++ b/api/v1alpha1/cell_types.go
@@ -107,6 +107,10 @@ type TopologyReconciliation struct {
 
 // CellStatus defines the observed state of Cell.
 type CellStatus struct {
+	// ObservedGeneration is the most recent generation observed.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions represent the latest available observations.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -160,6 +160,10 @@ type ShardImages struct {
 
 // ShardStatus defines the observed state of Shard.
 type ShardStatus struct {
+	// ObservedGeneration is the most recent generation observed.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions represent the latest available observations.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/api/v1alpha1/tablegroup_types.go
+++ b/api/v1alpha1/tablegroup_types.go
@@ -85,6 +85,10 @@ type ShardResolvedSpec struct {
 
 // TableGroupStatus defines the observed state of TableGroup.
 type TableGroupStatus struct {
+	// ObservedGeneration is the most recent generation observed.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions represent the latest available observations.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/api/v1alpha1/toposerver_types.go
+++ b/api/v1alpha1/toposerver_types.go
@@ -60,6 +60,10 @@ type TopoServerSpec struct {
 
 // TopoServerStatus defines the observed state of TopoServer.
 type TopoServerStatus struct {
+	// ObservedGeneration is the most recent generation observed.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions represent the latest available observations.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/config/crd/bases/multigres.com_cells.yaml
+++ b/config/crd/bases/multigres.com_cells.yaml
@@ -1388,6 +1388,10 @@ spec:
               message:
                 description: Message provides details about the current phase.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed.
+                format: int64
+                type: integer
               phase:
                 description: Phase represents the aggregated lifecycle state of the
                   cell.

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -2376,6 +2376,10 @@ spec:
               message:
                 description: Message provides details about the current phase.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed.
+                format: int64
+                type: integer
               orchReady:
                 description: OrchReady indicates if the MultiOrch component is ready.
                 type: boolean

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -2398,6 +2398,10 @@ spec:
               message:
                 description: Message provides details about the current phase.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed.
+                format: int64
+                type: integer
               phase:
                 description: Phase represents the aggregated lifecycle state of the
                   table group.

--- a/config/crd/bases/multigres.com_toposervers.yaml
+++ b/config/crd/bases/multigres.com_toposervers.yaml
@@ -218,6 +218,10 @@ spec:
               message:
                 description: Message provides details about the current phase.
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed.
+                format: int64
+                type: integer
               peerService:
                 description: PeerService is the name of the service for peers.
                 type: string


### PR DESCRIPTION
Controllers currently can report false positive "Ready" states momentarily due to cache lag immediately after patching child resources (read-after-write inconsistency).

* Added `ObservedGeneration` field to `CellStatus`, `ShardStatus`, and `TopoServerStatus` definitions.
* Updated `updateStatus` in resource controllers to explicitly sync `ObservedGeneration` with the metadata generation.
* Refactored condition building logic to strictly require matching generations before marking resources as "Ready".

Prevents status flapping during updates and guarantees accurate deployment state for automation pipelines.