### PR TITLE
fix(controller): prevent redundant status loops

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -9,10 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
@@ -121,7 +123,7 @@ func (r *MultigresClusterReconciler) SetupWithManager(
 	controllerOpts.MaxConcurrentReconciles = 20
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&multigresv1alpha1.MultigresCluster{}).
+		For(&multigresv1alpha1.MultigresCluster{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&multigresv1alpha1.Cell{}).
 		Owns(&multigresv1alpha1.TableGroup{}).
 		Owns(&multigresv1alpha1.TopoServer{}).

--- a/pkg/cluster-handler/controller/multigrescluster/status.go
+++ b/pkg/cluster-handler/controller/multigrescluster/status.go
@@ -165,6 +165,9 @@ func (r *MultigresClusterReconciler) updateStatus(
 		)
 	}
 
+	// Note: We rely on Server-Side Apply (SSA) to handle idempotency.
+	// If the status hasn't changed, the API server will treat this Patch as a no-op,
+	// so we don't need a manual DeepEqual check here.
 	if err := r.Status().Patch(
 		ctx,
 		patchObj,

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -10,9 +10,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 )
@@ -230,6 +232,9 @@ func (r *TableGroupReconciler) Reconcile(
 		)
 	}
 
+	// Note: We rely on Server-Side Apply (SSA) to handle idempotency.
+	// If the status hasn't changed, the API server will treat this Patch as a no-op,
+	// so we don't need a manual DeepEqual check here.
 	if err := r.Status().Patch(
 		ctx,
 		patchObj,
@@ -258,7 +263,7 @@ func (r *TableGroupReconciler) SetupWithManager(
 	controllerOpts.MaxConcurrentReconciles = 20
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&multigresv1alpha1.TableGroup{}).
+		For(&multigresv1alpha1.TableGroup{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&multigresv1alpha1.Shard{}).
 		WithOptions(controllerOpts).
 		Complete(r)

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -12,9 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/util/status"
@@ -216,6 +218,9 @@ func (r *CellReconciler) updateStatus(ctx context.Context, cell *multigresv1alph
 		)
 	}
 
+	// Note: We rely on Server-Side Apply (SSA) to handle idempotency.
+	// If the status hasn't changed, the API server will treat this Patch as a no-op,
+	// so we don't need a manual DeepEqual check here.
 	if err := r.Status().Patch(
 		ctx,
 		patchObj,
@@ -289,7 +294,7 @@ func (r *CellReconciler) SetupWithManager(mgr ctrl.Manager, opts ...controller.O
 	controllerOpts.MaxConcurrentReconciles = 20
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&multigresv1alpha1.Cell{}).
+		For(&multigresv1alpha1.Cell{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(controllerOpts).


### PR DESCRIPTION
Controllers were triggering a new reconciliation event immediately after patching their own status, leading to unnecessary CPU usage and execution cycles.

- Added `GenerationChangedPredicate` to the primary `For()` resource in all controllers to ignore status-only updates
- Documented reliance on Server-Side Apply (SSA) for idempotency in status update logic
- Updated implementation notes to explain the new event filtering and SSA strategy

Eliminates "echo" reconciliations by ensuring controllers only wake up for Spec changes or child resource updates.