### PR TITLE
fix(webhook): isolate resolver cache per request to prevent races

### DIFF
--- a/pkg/resolver/cell.go
+++ b/pkg/resolver/cell.go
@@ -54,7 +54,7 @@ func (r *Resolver) ResolveCellTemplate(
 	}
 
 	// Check cache first
-	if cached, found := r.cellTemplateCache[string(resolvedName)]; found {
+	if cached, found := r.CellTemplateCache[string(resolvedName)]; found {
 		return cached.DeepCopy(), nil
 	}
 
@@ -76,7 +76,7 @@ func (r *Resolver) ResolveCellTemplate(
 	}
 
 	// Store in cache
-	r.cellTemplateCache[string(resolvedName)] = tpl
+	r.CellTemplateCache[string(resolvedName)] = tpl
 	return tpl.DeepCopy(), nil
 }
 

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -23,12 +23,12 @@ type Resolver struct {
 	Namespace string
 	// TemplateDefaults contains the cluster-level template references.
 	TemplateDefaults multigresv1alpha1.TemplateDefaults
-	// coreTemplateCache is a request-scoped cache for CoreTemplates.
-	coreTemplateCache map[string]*multigresv1alpha1.CoreTemplate
-	// cellTemplateCache is a request-scoped cache for CellTemplates.
-	cellTemplateCache map[string]*multigresv1alpha1.CellTemplate
-	// shardTemplateCache is a request-scoped cache for ShardTemplates.
-	shardTemplateCache map[string]*multigresv1alpha1.ShardTemplate
+	// CoreTemplateCache is a request-scoped cache for CoreTemplates.
+	CoreTemplateCache map[string]*multigresv1alpha1.CoreTemplate
+	// CellTemplateCache is a request-scoped cache for CellTemplates.
+	CellTemplateCache map[string]*multigresv1alpha1.CellTemplate
+	// ShardTemplateCache is a request-scoped cache for ShardTemplates.
+	ShardTemplateCache map[string]*multigresv1alpha1.ShardTemplate
 }
 
 // NewResolver creates a new defaults.Resolver.
@@ -41,9 +41,9 @@ func NewResolver(
 		Client:             c,
 		Namespace:          namespace,
 		TemplateDefaults:   tplDefaults,
-		coreTemplateCache:  make(map[string]*multigresv1alpha1.CoreTemplate),
-		cellTemplateCache:  make(map[string]*multigresv1alpha1.CellTemplate),
-		shardTemplateCache: make(map[string]*multigresv1alpha1.ShardTemplate),
+		CoreTemplateCache:  make(map[string]*multigresv1alpha1.CoreTemplate),
+		CellTemplateCache:  make(map[string]*multigresv1alpha1.CellTemplate),
+		ShardTemplateCache: make(map[string]*multigresv1alpha1.ShardTemplate),
 	}
 }
 

--- a/pkg/webhook/handlers/defaulter.go
+++ b/pkg/webhook/handlers/defaulter.go
@@ -49,6 +49,9 @@ func (d *MultigresClusterDefaulter) Default(ctx context.Context, obj runtime.Obj
 	scopedResolver := *d.Resolver
 	scopedResolver.Namespace = cluster.Namespace
 	scopedResolver.TemplateDefaults = cluster.Spec.TemplateDefaults
+	scopedResolver.CoreTemplateCache = make(map[string]*multigresv1alpha1.CoreTemplate)
+	scopedResolver.CellTemplateCache = make(map[string]*multigresv1alpha1.CellTemplate)
+	scopedResolver.ShardTemplateCache = make(map[string]*multigresv1alpha1.ShardTemplate)
 
 	// 2.5 Promote Implicit Defaults to Explicit
 	// If the user hasn't specified a template, but a "default" one exists,


### PR DESCRIPTION
The MultigresCluster defaulter was performing a shallow copy of the Resolver struct, causing all concurrent webhook requests to share the same underlying map pointers for template caching.

- Exported template cache fields in `Resolver` (e.g. `CoreTemplateCache`) to allow external modification
- Implemented explicit map re-initialization in the defaulter handler to ensure every request gets a fresh, isolated cache
- Updated all internal resolver references to use the new exported field names

Prevents memory corruption and potential panics by enforcing strict request isolation during template resolution.