### PR TITLE
fix(api): add listType markers to CRDs

### DIFF
--- a/api/v1alpha1/cell_types.go
+++ b/api/v1alpha1/cell_types.go
@@ -113,6 +113,8 @@ type CellStatus struct {
 
 	// Conditions represent the latest available observations.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Phase represents the aggregated lifecycle state of the cell.

--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -313,6 +313,8 @@ type MultigresClusterStatus struct {
 
 	// Conditions represent the latest available observations.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Phase represents the aggregated lifecycle state of the cluster.

--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -166,6 +166,8 @@ type ShardStatus struct {
 
 	// Conditions represent the latest available observations.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Phase represents the aggregated lifecycle state of the shard.
@@ -178,6 +180,7 @@ type ShardStatus struct {
 
 	// Cells is a list of cells this shard is currently deployed to.
 	// +optional
+	// +listType=set
 	// +kubebuilder:validation:MaxItems=50
 	Cells []CellName `json:"cells,omitempty"`
 

--- a/api/v1alpha1/tablegroup_types.go
+++ b/api/v1alpha1/tablegroup_types.go
@@ -59,6 +59,8 @@ type TableGroupSpec struct {
 	GlobalTopoServer GlobalTopoServerRef `json:"globalTopoServer"`
 
 	// Shards is the list of FULLY RESOLVED shard specifications.
+	// +listType=map
+	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=32
 	Shards []ShardResolvedSpec `json:"shards"`
 }
@@ -91,6 +93,8 @@ type TableGroupStatus struct {
 
 	// Conditions represent the latest available observations.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Phase represents the aggregated lifecycle state of the table group.

--- a/api/v1alpha1/toposerver_types.go
+++ b/api/v1alpha1/toposerver_types.go
@@ -66,6 +66,8 @@ type TopoServerStatus struct {
 
 	// Conditions represent the latest available observations.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Phase represents the aggregated lifecycle state of the toposerver.
@@ -141,6 +143,7 @@ type ExternalTopoServerSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:XValidation:rule="self.all(x, x.matches('^https?://'))",message="endpoints must be valid URLs"
+	// +listType=set
 	Endpoints []EndpointUrl `json:"endpoints"`
 
 	// CASecret is the name of the secret containing the CA certificate.

--- a/config/crd/bases/multigres.com_cells.yaml
+++ b/config/crd/bases/multigres.com_cells.yaml
@@ -1266,6 +1266,7 @@ spec:
                         maxItems: 20
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: set
                         x-kubernetes-validations:
                         - message: endpoints must be valid URLs
                           rule: self.all(x, x.matches('^https?://'))
@@ -1372,6 +1373,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               gatewayReadyReplicas:
                 description: GatewayReadyReplicas is the number of gateway pods that
                   are ready.

--- a/config/crd/bases/multigres.com_celltemplates.yaml
+++ b/config/crd/bases/multigres.com_celltemplates.yaml
@@ -169,6 +169,7 @@ spec:
                         maxItems: 20
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: set
                         x-kubernetes-validations:
                         - message: endpoints must be valid URLs
                           rule: self.all(x, x.matches('^https?://'))

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -1240,6 +1240,7 @@ spec:
                                   maxItems: 20
                                   minItems: 1
                                   type: array
+                                  x-kubernetes-list-type: set
                                   x-kubernetes-validations:
                                   - message: endpoints must be valid URLs
                                     rule: self.all(x, x.matches('^https?://'))
@@ -7128,6 +7129,7 @@ spec:
                         maxItems: 20
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: set
                         x-kubernetes-validations:
                         - message: endpoints must be valid URLs
                           rule: self.all(x, x.matches('^https?://'))
@@ -9367,6 +9369,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               databases:
                 additionalProperties:
                   description: DatabaseStatusSummary provides a high-level status

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -2316,6 +2316,7 @@ spec:
                   type: string
                 maxItems: 50
                 type: array
+                x-kubernetes-list-type: set
               conditions:
                 description: Conditions represent the latest available observations.
                 items:
@@ -2373,6 +2374,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               message:
                 description: Message provides details about the current phase.
                 type: string

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -2323,6 +2323,9 @@ spec:
                   type: object
                 maxItems: 32
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               tableGroupName:
                 description: TableGroupName is the name of this table group.
                 maxLength: 25
@@ -2395,6 +2398,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               message:
                 description: Message provides details about the current phase.
                 type: string

--- a/config/crd/bases/multigres.com_toposervers.yaml
+++ b/config/crd/bases/multigres.com_toposervers.yaml
@@ -215,6 +215,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               message:
                 description: Message provides details about the current phase.
                 type: string


### PR DESCRIPTION
* Added `+listType=map` and `listMapKey` markers to `Conditions`, `Shards`, `Databases`, and `TableGroups` in API definitions.
* Added `+listType=set` markers to `Cells` and `Endpoints`.
* Updated `plans/phase-1/implementation-notes.md` with consistent headers and a new section on "Known Behaviors & Quirks".

Kubernetes defaults to treating lists in CRDs as atomic (replace-all), which causes updates to overwrite existing entries instead of merging them. Additionally, the interaction between Client-Side Apply and mutating webhooks causes confusing "configured" reports.

Enables correct merging of list items during updates (critical for Server-Side Apply) and documents the expected CLI behavior to prevent user confusion.