### PR TITLE
docs: enhance implementation notes with naming and quirks

### DIFF
--- a/plans/phase-1/implementation-notes.md
+++ b/plans/phase-1/implementation-notes.md
@@ -187,6 +187,143 @@ if !reflect.DeepEqual(cluster.Status, newStatus) {
 **Decision:** We prefer the cleaner code of SSA rely on the API Server's optimized diffing engine until proven otherwise.
 
 
+## Resource Naming Strategy
+
+### Hierarchical Naming with Safety Hashes
+
+We use a **hierarchical naming scheme** where child resource names are built by concatenating the logical path from the cluster root to the resource, separated by hyphens.
+
+**Naming Pattern:**
+```
+{cluster-name}-{database-name}-{tablegroup-name}-{shard-name}-{pool-name}-{cell-name}-{hash}
+```
+
+**Examples:**
+- **Cell:** `inline-z1-8a4f2b1c` (cluster: `inline`, cell: `z1`, hash for uniqueness)
+- **Shard:** `inline-postgres-default-0-inf-a7c3d9e2` (cluster: `inline`, database: `postgres`, tablegroup: `default`, shard: `0-inf`, hash)
+- **Pool StatefulSet:** `inline-postgres-default-0-inf---d8f1a` (truncated with `---` separator, then hash)
+- **Pod (from StatefulSet):** `inline-postgres-default-0-inf---d8f1a-0` (StatefulSet name + ordinal suffix)
+
+### The `name` Package
+
+All resource naming goes through the `pkg/util/name` package, which provides:
+
+**1. Hash-Based Collision Prevention**
+
+The `Hash()` function generates an 8-character hex suffix (4 bytes, FNV-1a 32-bit) from the input parts:
+```go
+Hash([]string{"cluster", "db", "tg", "shard"}) → "a7c3d9e2"
+```
+
+This hash ensures uniqueness even when names are truncated to fit Kubernetes limits.
+
+**2. Smart Truncation with Constraints**
+
+`JoinWithConstraints()` concatenates name parts with hyphens, applies transformations (lowercase, alphanumeric only), and truncates if necessary while preserving the hash:
+```go
+// Full name fits
+JoinWithConstraints(ServiceConstraints, "cluster", "cell")
+→ "cluster-cell-8a4f2b1c"
+
+// Name too long, truncated with special marker
+JoinWithConstraints(ServiceConstraints, "very-long-cluster-name", "postgres", "default", "0-inf", "pool", "main", "z1")
+→ "very-long-cluster-name-postgres-default-0-inf---d8f1a"
+```
+
+The `---` (triple-hyphen) marker indicates truncation occurred.
+
+**3. Predefined Constraints**
+
+Different Kubernetes resources have different name length limits:
+
+| Constraint | MaxLength | ValidFirstChar | Used For |
+|:---|:---:|:---|:---|
+| `DefaultConstraints` | 253 | alphanumeric | CRDs, most resources |
+| `ServiceConstraints` | 63 | lowercase letter | Services, PVCs |
+| `StatefulSetConstraints` | 52 | lowercase letter | StatefulSets (reserves 11 chars for pod suffix + controller hash) |
+
+### Character Limits on User-Provided Names
+
+To ensure generated resource names stay within Kubernetes limits even after adding hashes and parent prefixes, we enforce strict character limits on user-provided names:
+
+| Field | MaxLength | Rationale |
+|:---|:---:|:---|
+| **Cluster Name** | 30 | Root of all names; must leave room for 5-6 more levels |
+| **Database Name** | 30 | Typically short; allows deep nesting |
+| **TableGroup Name** | 25 | Reduces risk of truncation in shard/pool names |
+| **Shard Name** | 25 | Often simple (e.g., `0-inf`, `shard1`) |
+| **Pool Name** | 25 | Conservative to prevent StatefulSet truncation |
+| **Cell Name** | 30 | Typically az names (e.g., `us-east-1a`, `z1`) |
+
+These limits are enforced via **CRD validation** (`+kubebuilder:validation:MaxLength=X`) in `api/v1alpha1/common_types.go`.
+
+### Resources Without Hashes (No Collision Risk)
+
+Some resources use **simple string concatenation** without hashes:
+
+**Singleton Global Resources:**
+- `{cluster-name}-global-topo` (e.g., `inline-global-topo`)
+- `{cluster-name}-multiadmin` (e.g., `inline-multiadmin`)
+- `{cluster-name}-multiadmin-web` (e.g., `inline-multiadmin-web`)
+
+**Why no hash?**
+1. **1:1 Relationship:** Each cluster has exactly one GlobalTopoServer and one MultiAdmin.
+2. **Predictable and Short:** The cluster name is already validated to be ≤30 chars, and we only append a fixed suffix.
+3. **No User-Defined Nesting:** Unlike cells/shards/pools where users can define arbitrary names, these components are static.
+4. **No Collision Possible:** Since there's only ever one instance per cluster, there's no scenario where two different logical paths could produce the same name after truncation.
+
+**Collision Example (why others need hashes):**
+- `very-long-cluster-name-postgres-tablegroup1-shard1-pool1-z1` (63 chars, truncated to 63)
+- `very-long-cluster-name-postgres-tablegroup1-shard1-pool2-z1` (different pool, but if truncated at the same point, would collide)
+- **Solution:** The hash distinguishes them: `...tablegroup1-shard1---a7c3d9e2` vs `...tablegroup1-shard1---b8e4f1a3`
+
+### Naming Scheme Drawbacks
+
+**1. Deeply Nested Names Become Abbreviated**
+
+For resources like pools with long hierarchical paths, the generated names can exceed 63 (Service) or 52 (StatefulSet) characters, triggering truncation:
+```
+Original intent:  inline-postgres-default-0-inf-pool-main-z1
+After truncation: inline-postgres-default-0-inf---d8f1a
+```
+
+**Impact:**
+- **Pod Names:** become even longer with ordinal suffixes (e.g., `inline-postgres-default-0-inf---d8f1a-0`, `...-1`)
+- **Readability:** Users see truncated names in `kubectl get pods`, making it harder to identify which pool/shard a pod belongs to without checking labels
+- **Debugging:** Must rely on labels (`multigres.com/pool`, `multigres.com/cell`, etc.) to understand the logical hierarchy
+
+**2. User Names Constrained**
+
+Users cannot use very descriptive names for databases, tablegroups, shards, or pools without triggering truncation early.
+
+**Mitigation:**
+- Enforce strict character limits (25-30 chars) on user-provided names
+- Encourage short, meaningful names (e.g., `main`, `z1`, `0-inf` instead of `primary-read-write-pool`, `us-east-1a-availability-zone`)
+- Provide rich labeling to compensate for abbreviated resource names
+
+### Why Different Maximum Lengths?
+
+**Services and PVCs: 63 Characters**
+- Kubernetes DNS label limit (RFC 1123)
+- Service names become DNS records: `{service-name}.{namespace}.svc.cluster.local`
+
+**StatefulSets: 52 Characters**
+- Reserve 11 characters for Pod ordinal suffix and controller hash
+  - Pod name format: `{statefulset-name}-{ordinal}` (e.g., `-0`, `-1`, ..., `-999`)
+  - Controller-revision-hash label: appended by Kubernetes, adds ~10 chars
+- Without this reservation, long StatefulSet names would produce invalid Pod names (>63 chars)
+
+**Pods: 63 Characters (Derived)**
+- Pods don't have a separate constraint in our naming package
+- Their names are auto-generated by the owning controller (StatefulSet, Deployment)
+- StatefulSet pods: `{sts-name}-{ordinal}`
+- Deployment pods: `{deployment-name}-{replicaset-hash}-{pod-hash}`
+
+**CRDs and most other resources: 253 Characters**
+- Kubernetes metadata.name limit for most resources
+- We use `DefaultConstraints` for custom resources (Cell, Shard, TableGroup, etc.)
+- These names are rarely used in DNS, so the 63-char limit doesn't apply
+
 ## Known Behaviors & Quirks
 
 ### Infinite "Configured" Loop (Client-Side Apply)
@@ -203,11 +340,31 @@ This is a conflict between **Client-Side Apply (CSA)** and **Mutating Webhooks**
 5.  **The Report:** Despite the server-side no-op, `kubectl` reports `configured` because it successfully sent a non-empty patch.
 
 **The Verdict:**
-This is **standard Kubernetes behavior** for Operators with defaulting webhooks (common in Istio, Cert-Manager, etc.). It is a limitation of the legacy `kubectl apply` logic, not a bug in the operator.
+This is **standard Kubernetes behavior** for Operators with defaulting webhooks (common in Istio, Cert-Manager, etc.). It is a limitation of the legacy `kubectl apply` logic, not a bug in the operator. **Critically, this is purely cosmetic** - no actual changes occur on the server (confirmed by no `Generation` increment), and controllers do not unnecessarily reconcile.
 
-**The Solution:**
+**The Solutions:**
 
-It's worth noting here that this is NOT an issue, but if seeing repeatedly `configured` is disturbing the following can be done:
+If seeing repeated `configured` messages is disturbing, users can:
 
 * **Recommended:** Use Server-Side Apply (`kubectl apply --server-side`). This moves the merge logic to the API server, which correctly handles ownership and defaults without fighting.
-* **Alternative:** Explicitly set all default values in your local YAML to match the server state (e.g., manually add `replicas: 1`).
+* **Alternative:** Explicitly set all default values in your local YAML to match the server state (e.g., manually add all defaulted fields).
+
+**Rejected Alternative Solutions:**
+
+We considered several approaches to eliminate this behavior entirely, but each has significant drawbacks:
+
+**Option 1: Remove the Defaulting Webhook** ❌
+* **Why it would work:** Without the webhook adding defaults, there would be no discrepancy for `kubectl` to detect.
+* **Why we rejected it:** Our defaulting logic includes complex computed defaults (e.g., deriving resource requirements, setting up template references) that are essential for operator functionality and good UX. Removing the webhook would break the API design and force users to specify every field manually.
+
+**Option 2: Make All Fields Required** ❌
+* **Why it would work:** If every field must be specified in the YAML, the webhook wouldn't add anything new.
+* **Why we rejected it:** This defeats the entire purpose of defaults and creates terrible user experience. Users would need to write massive YAML files with hundreds of fields just to create a simple cluster.
+
+**Option 3: Use CRD-Level Defaults Instead of Webhooks** ⚠️
+* **Why it would work:** CRD OpenAPIv3 schemas support `default:` values that are applied by the API server before storage. `kubectl apply` sees these in the OpenAPI schema and includes them in comparison.
+* **Why we rejected it:** CRD defaults are extremely limited - they only support simple scalar values (e.g., `replicas: 1`), not complex computed logic like "derive this field from these other fields" or "populate template references." Our defaulting logic is too sophisticated for CRD-level defaults.
+
+**Option 4: Document and Accept** ✅
+* **What we did:** Documented this as a known cosmetic quirk with zero operational impact.
+* **Why this is correct:** The behavior is harmless, standard across the ecosystem, and users have easy workarounds. The alternatives would compromise our API design or user experience for purely cosmetic gain.


### PR DESCRIPTION
Client-side apply behavior with defaulting webhooks can confuse users who see repeated "configured" messages despite no actual changes. Our hierarchical naming scheme also has nuances worth documenting.

- Add comprehensive Resource Naming Strategy section explaining hierarchical naming, the name package utilities (Hash, JoinWithConstraints), and predefined constraints for different resource types
- Document character limits on user-provided names (cluster: 30, database: 30, tablegroup/shard/pool: 25, cell: 30) enforced via CRD validation
- Explain why singleton resources (global-topo, multiadmin) don't use hashes due to 1:1 relationship with cluster and no collision risk
- Detail naming scheme drawbacks including truncation of deeply nested names and readability impact on kubectl output
- Clarify different maximum name lengths for Services (63), StatefulSets (52), and CRDs (253) based on Kubernetes DNS and pod naming constraints
- Strengthen "Infinite Configured Loop" section emphasizing behavior is purely cosmetic with no Generation increment or unnecessary reconciliation
- Add rejected alternative solutions (remove webhook, required fields, CRD-level defaults) explaining why each compromises API design or UX

Provides comprehensive reference for developers on naming architecture constraints and helps users understand kubectl apply cosmetic quirks.