### PR TITLE
refactor(resolver): remove unused template default flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,6 @@ You can customize the operator's behavior by passing flags to the binary (or edi
 | `--webhook-cert-dir` | `/var/run/secrets/webhook` | Directory to read/write webhook certificates. |
 | `--webhook-service-name` | `multigres-operator-webhook-service` | Name of the Service pointing to the webhook. |
 | `--webhook-service-namespace`| *Current Namespace* | Namespace of the webhook service. |
-| `--default-core-template` | `"default"` | Name of the CoreTemplate to use as namespace fallback. |
-| `--default-cell-template` | `"default"` | Name of the CellTemplate to use as namespace fallback. |
-| `--default-shard-template` | `"default"` | Name of the ShardTemplate to use as namespace fallback. |
 | `--metrics-bind-address` | `"0"` | Address for metrics (set to `:8080` to enable). |
 | `--leader-elect` | `false` | Enable leader election (recommended for HA deployments). |
 

--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -88,11 +88,6 @@ func main() {
 	var webhookServiceAccount string
 	var webhookServiceName string
 
-	// Template Default Flags
-	var defaultCoreTemplate string
-	var defaultCellTemplate string
-	var defaultShardTemplate string
-
 	defaultNS := os.Getenv("POD_NAMESPACE")
 	if defaultNS == "" {
 		setupLog.Error(
@@ -169,26 +164,6 @@ func main() {
 		"webhook-service-name",
 		"multigres-operator-webhook-service",
 		"Name of the Kubernetes Service for the webhook",
-	)
-
-	// Template Defaults
-	flag.StringVar(
-		&defaultCoreTemplate,
-		"default-core-template",
-		"default",
-		"Default CoreTemplate name",
-	)
-	flag.StringVar(
-		&defaultCellTemplate,
-		"default-cell-template",
-		"default",
-		"Default CellTemplate name",
-	)
-	flag.StringVar(
-		&defaultShardTemplate,
-		"default-shard-template",
-		"default",
-		"Default ShardTemplate name",
 	)
 
 	opts := zap.Options{Development: true}
@@ -372,11 +347,6 @@ func main() {
 	globalResolver := resolver.NewResolver(
 		mgr.GetClient(),
 		webhookServiceNamespace,
-		multigresv1alpha1.TemplateDefaults{
-			CoreTemplate:  multigresv1alpha1.TemplateRef(defaultCoreTemplate),
-			CellTemplate:  multigresv1alpha1.TemplateRef(defaultCellTemplate),
-			ShardTemplate: multigresv1alpha1.TemplateRef(defaultShardTemplate),
-		},
 	)
 
 	if err = (&multigresclustercontroller.MultigresClusterReconciler{

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -52,7 +52,7 @@ func (r *MultigresClusterReconciler) Reconcile(
 		return ctrl.Result{}, fmt.Errorf("failed to get MultigresCluster: %w", err)
 	}
 
-	res := resolver.NewResolver(r.Client, cluster.Namespace, cluster.Spec.TemplateDefaults)
+	res := resolver.NewResolver(r.Client, cluster.Namespace)
 
 	// Apply defaults (in-memory) to ensure we have images/configs/system-catalog even if webhook didn't run.
 	decisions, err := res.PopulateClusterDefaults(ctx, cluster)

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_cells_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_cells_test.go
@@ -40,7 +40,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 		err := r.reconcileCells(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to missing global topo, got nil")
@@ -73,7 +73,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 		err := r.reconcileCells(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to missing cell template, got nil")
@@ -99,7 +99,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 		err := r.reconcileCells(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil || err.Error() != "failed to list existing cells: list error" {
 			t.Errorf("Expected 'list error', got %v", err)
@@ -133,7 +133,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 		err := r.reconcileCells(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil || err.Error() != "failed to apply cell 'zone-a': patch error" {
 			t.Errorf("Expected 'patch error', got %v", err)
@@ -173,7 +173,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 		err := r.reconcileCells(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		// Note: The loop might continue or return error immediately depending on implementation.
 		// Current implementation returns error immediately on delete failure.
@@ -207,7 +207,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 		err := r.reconcileCells(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to build failure (scheme mismatch), got nil")
@@ -250,7 +250,7 @@ func TestReconcileCells_HappyPath(t *testing.T) {
 		err := r.reconcileCells(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err != nil {
 			t.Fatalf("Expected happy path success, got %v", err)

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
@@ -46,7 +46,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileGlobalTopoServer(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to missing global topo spec, got nil")
@@ -73,7 +73,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdmin(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to missing multi admin spec, got nil")
@@ -100,7 +100,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdminWeb(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to missing multi admin web spec, got nil")
@@ -131,7 +131,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileGlobalTopoServer(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil || err.Error() != "failed to apply global topo server: patch error" {
 			t.Errorf("Expected 'patch error', got %v", err)
@@ -158,7 +158,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdmin(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil || err.Error() != "failed to apply multiadmin deployment: patch error" {
 			t.Errorf("Expected 'patch error', got %v", err)
@@ -185,7 +185,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdminWeb(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil || err.Error() != "failed to apply multiadmin-web deployment: patch error" {
 			t.Errorf("Expected 'patch error', got %v", err)
@@ -213,7 +213,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileGlobalTopoServer(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to build failure, got nil")
@@ -237,7 +237,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdmin(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to build failure, got nil")
@@ -261,7 +261,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdminWeb(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to build failure, got nil")
@@ -292,7 +292,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdmin(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to build failure, got nil")
@@ -322,7 +322,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdmin(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil || err.Error() != "failed to apply multiadmin service: service patch error" {
 			t.Errorf("Expected 'service patch error', got %v", err)
@@ -348,7 +348,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdminWeb(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil {
 			t.Error("Expected error due to build failure, got nil")
@@ -378,7 +378,7 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 		err := r.reconcileMultiAdminWeb(
 			context.Background(),
 			cluster,
-			resolver.NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{}),
+			resolver.NewResolver(c, "default"),
 		)
 		if err == nil ||
 			err.Error() != "failed to apply multiadmin-web service: service patch error" {
@@ -765,7 +765,7 @@ func TestReconcile_Global_BuilderErrors(t *testing.T) {
 		}
 
 		// Initialize resolver with correct namespace and defaults using constructor
-		res := resolver.NewResolver(c, baseCluster.Namespace, baseCluster.Spec.TemplateDefaults)
+		res := resolver.NewResolver(c, baseCluster.Namespace)
 		err := reconciler.reconcileMultiAdmin(t.Context(), cluster, res)
 		if err == nil {
 			t.Error("Expected error, got nil")
@@ -801,7 +801,7 @@ func TestReconcile_Global_BuilderErrors(t *testing.T) {
 		}
 
 		cluster := baseCluster.DeepCopy()
-		res := resolver.NewResolver(c, baseCluster.Namespace, baseCluster.Spec.TemplateDefaults)
+		res := resolver.NewResolver(c, baseCluster.Namespace)
 		err := reconciler.reconcileMultiAdminWeb(t.Context(), cluster, res)
 		if err == nil {
 			t.Error("Expected error, got nil")
@@ -837,7 +837,7 @@ func TestReconcile_Global_BuilderErrors(t *testing.T) {
 		}
 
 		cluster := baseCluster.DeepCopy()
-		res := resolver.NewResolver(c, baseCluster.Namespace, baseCluster.Spec.TemplateDefaults)
+		res := resolver.NewResolver(c, baseCluster.Namespace)
 		err := reconciler.reconcileMultiAdminWeb(t.Context(), cluster, res)
 		if err == nil {
 			t.Error("Expected error, got nil")

--- a/pkg/resolver/cell.go
+++ b/pkg/resolver/cell.go
@@ -45,9 +45,6 @@ func (r *Resolver) ResolveCellTemplate(
 	resolvedName := name
 	isImplicitFallback := false
 
-	if resolvedName == "" {
-		resolvedName = r.TemplateDefaults.CellTemplate
-	}
 	if resolvedName == "" || resolvedName == FallbackCellTemplate {
 		resolvedName = FallbackCellTemplate
 		isImplicitFallback = true

--- a/pkg/resolver/cell_test.go
+++ b/pkg/resolver/cell_test.go
@@ -93,7 +93,7 @@ func TestResolver_ResolveCell(t *testing.T) {
 					WithObjects(tc.objects...).
 					Build()
 			}
-			r := NewResolver(c, ns, multigresv1alpha1.TemplateDefaults{})
+			r := NewResolver(c, ns)
 
 			gw, topo, err := r.ResolveCell(t.Context(), tc.config)
 			if tc.wantErr {
@@ -170,7 +170,7 @@ func TestResolver_ResolveCellTemplate(t *testing.T) {
 				WithScheme(scheme).
 				WithObjects(tc.existingObjects...).
 				Build()
-			r := NewResolver(c, ns, tc.defaults)
+			r := NewResolver(c, ns)
 
 			res, err := r.ResolveCellTemplate(t.Context(), tc.reqName)
 			if tc.wantErr {
@@ -360,7 +360,7 @@ func TestResolver_ClientErrors_Cell(t *testing.T) {
 			OnGet: func(_ client.ObjectKey) error { return errSimulated },
 		},
 	)
-	r := NewResolver(mc, "default", multigresv1alpha1.TemplateDefaults{})
+	r := NewResolver(mc, "default")
 
 	_, err := r.ResolveCellTemplate(t.Context(), "any")
 	if err == nil ||

--- a/pkg/resolver/cluster.go
+++ b/pkg/resolver/cluster.go
@@ -247,9 +247,6 @@ func (r *Resolver) ResolveCoreTemplate(
 	resolvedName := name
 	isImplicitFallback := false
 
-	if resolvedName == "" {
-		resolvedName = r.TemplateDefaults.CoreTemplate
-	}
 	if resolvedName == "" || resolvedName == FallbackCoreTemplate {
 		resolvedName = FallbackCoreTemplate
 		isImplicitFallback = true

--- a/pkg/resolver/cluster_test.go
+++ b/pkg/resolver/cluster_test.go
@@ -368,7 +368,6 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 			r := NewResolver(
 				fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build(),
 				"default",
-				multigresv1alpha1.TemplateDefaults{},
 			)
 
 			got := tc.input.DeepCopy()
@@ -394,7 +393,7 @@ func TestResolver_PopulateClusterDefaults_ClientError(t *testing.T) {
 			OnGet: func(_ client.ObjectKey) error { return errSim },
 		})
 
-	r := NewResolver(mc, "default", multigresv1alpha1.TemplateDefaults{})
+	r := NewResolver(mc, "default")
 	// This input triggers the "check implicit shard template" path because ShardTemplate is empty
 	input := &multigresv1alpha1.MultigresCluster{
 		Spec: multigresv1alpha1.MultigresClusterSpec{
@@ -617,7 +616,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build()
-			r := NewResolver(c, ns, tc.cluster.Spec.TemplateDefaults)
+			r := NewResolver(c, ns)
 
 			got, err := r.ResolveGlobalTopo(t.Context(), tc.cluster)
 			if tc.wantErr {
@@ -702,7 +701,7 @@ func TestResolver_ResolveMultiAdmin(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build()
-			r := NewResolver(c, ns, tc.cluster.Spec.TemplateDefaults)
+			r := NewResolver(c, ns)
 
 			got, err := r.ResolveMultiAdmin(t.Context(), tc.cluster)
 			if tc.wantErr {
@@ -730,7 +729,6 @@ func TestResolver_ResolveCoreTemplate(t *testing.T) {
 	r := NewResolver(
 		fake.NewClientBuilder().WithScheme(scheme).Build(),
 		"default",
-		multigresv1alpha1.TemplateDefaults{},
 	)
 
 	// 1. Implicit Fallback ("default" or "") -> Not Found -> Returns nil, nil (No Error)
@@ -767,7 +765,7 @@ func TestResolver_ClientErrors_Core(t *testing.T) {
 	}
 	c := testutil.NewFakeClientWithFailures(baseClient, failConfig)
 
-	r := NewResolver(c, "default", multigresv1alpha1.TemplateDefaults{})
+	r := NewResolver(c, "default")
 
 	_, err := r.ResolveCoreTemplate(t.Context(), "any")
 	if err == nil || !errors.Is(err, errSim) {
@@ -842,7 +840,7 @@ func TestResolver_ResolveMultiAdminWeb(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build()
-			r := NewResolver(c, ns, tc.cluster.Spec.TemplateDefaults)
+			r := NewResolver(c, ns)
 
 			got, err := r.ResolveMultiAdminWeb(t.Context(), tc.cluster)
 			if tc.wantErr {

--- a/pkg/resolver/defaults.go
+++ b/pkg/resolver/defaults.go
@@ -21,6 +21,9 @@ const (
 	// FallbackShardTemplate is the name of the template to look for if no specific ShardTemplate is referenced.
 	FallbackShardTemplate = "default"
 
+	// DefaultPoolName is the name used for the default pool when no pools are specified in a ShardTemplate.
+	DefaultPoolName = "default"
+
 	// DefaultSystemDatabaseName is the name of the mandatory system database.
 	DefaultSystemDatabaseName = "postgres"
 

--- a/pkg/resolver/doc.go
+++ b/pkg/resolver/doc.go
@@ -41,7 +41,7 @@
 // Usage:
 //
 //		// Create a resolver
-//		res := resolver.NewResolver(client, namespace, cluster.Spec.TemplateDefaults)
+//		res := resolver.NewResolver(client, namespace)
 //
 //		// Webhook: Apply static and smart defaults to the object
 //		res.PopulateClusterDefaults(cluster)

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -21,8 +21,6 @@ type Resolver struct {
 	Client client.Client
 	// Namespace is the namespace where templates/resources are expected to exist.
 	Namespace string
-	// TemplateDefaults contains the cluster-level template references.
-	TemplateDefaults multigresv1alpha1.TemplateDefaults
 	// CoreTemplateCache is a request-scoped cache for CoreTemplates.
 	CoreTemplateCache map[string]*multigresv1alpha1.CoreTemplate
 	// CellTemplateCache is a request-scoped cache for CellTemplates.
@@ -35,12 +33,10 @@ type Resolver struct {
 func NewResolver(
 	c client.Client,
 	namespace string,
-	tplDefaults multigresv1alpha1.TemplateDefaults,
 ) *Resolver {
 	return &Resolver{
 		Client:             c,
 		Namespace:          namespace,
-		TemplateDefaults:   tplDefaults,
 		CoreTemplateCache:  make(map[string]*multigresv1alpha1.CoreTemplate),
 		CellTemplateCache:  make(map[string]*multigresv1alpha1.CellTemplate),
 		ShardTemplateCache: make(map[string]*multigresv1alpha1.ShardTemplate),

--- a/pkg/resolver/shard.go
+++ b/pkg/resolver/shard.go
@@ -45,7 +45,7 @@ func (r *Resolver) ResolveShard(
 	}
 
 	if len(pools) == 0 {
-		pools["default"] = multigresv1alpha1.PoolSpec{
+		pools[DefaultPoolName] = multigresv1alpha1.PoolSpec{
 			Type:  "readWrite",
 			Cells: multiOrch.Cells,
 		}
@@ -80,9 +80,6 @@ func (r *Resolver) ResolveShardTemplate(
 	resolvedName := name
 	isImplicitFallback := false
 
-	if resolvedName == "" {
-		resolvedName = r.TemplateDefaults.ShardTemplate
-	}
 	if resolvedName == "" || resolvedName == FallbackShardTemplate {
 		resolvedName = FallbackShardTemplate
 		isImplicitFallback = true

--- a/pkg/resolver/shard_test.go
+++ b/pkg/resolver/shard_test.go
@@ -136,7 +136,7 @@ func TestResolver_ResolveShard(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build()
-			r := NewResolver(c, ns, multigresv1alpha1.TemplateDefaults{})
+			r := NewResolver(c, ns)
 
 			orch, pools, err := r.ResolveShard(t.Context(), tc.config, tc.allCellNames)
 			if tc.wantErr {
@@ -213,7 +213,7 @@ func TestResolver_ResolveShardTemplate(t *testing.T) {
 				WithScheme(scheme).
 				WithObjects(tc.existingObjects...).
 				Build()
-			r := NewResolver(c, ns, tc.defaults)
+			r := NewResolver(c, ns)
 
 			res, err := r.ResolveShardTemplate(t.Context(), tc.reqName)
 			if tc.wantErr {
@@ -475,7 +475,7 @@ func TestResolver_ClientErrors_Shard(t *testing.T) {
 			OnGet: func(_ client.ObjectKey) error { return errSimulated },
 		},
 	)
-	r := NewResolver(mc, "default", multigresv1alpha1.TemplateDefaults{})
+	r := NewResolver(mc, "default")
 
 	_, err := r.ResolveShardTemplate(t.Context(), "any")
 	if err == nil ||

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -135,7 +135,7 @@ func TestResolver_ValidateClusterIntegrity(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			r := NewResolver(fakeClient, "default", tc.cluster.Spec.TemplateDefaults)
+			r := NewResolver(fakeClient, "default")
 			err := r.ValidateClusterIntegrity(t.Context(), tc.cluster)
 
 			if tc.wantErr == "" {
@@ -362,7 +362,7 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			if tc.clientFailures != nil {
 				c = testutil.NewFakeClientWithFailures(fakeClient, tc.clientFailures)
 			}
-			r := NewResolver(c, "default", tc.cluster.Spec.TemplateDefaults)
+			r := NewResolver(c, "default")
 			warnings, err := r.ValidateClusterLogic(t.Context(), tc.cluster)
 
 			// Check Error

--- a/pkg/webhook/handlers/defaulter.go
+++ b/pkg/webhook/handlers/defaulter.go
@@ -48,7 +48,6 @@ func (d *MultigresClusterDefaulter) Default(ctx context.Context, obj runtime.Obj
 	// We copy the resolver and point it to the Object's Namespace.
 	scopedResolver := *d.Resolver
 	scopedResolver.Namespace = cluster.Namespace
-	scopedResolver.TemplateDefaults = cluster.Spec.TemplateDefaults
 	scopedResolver.CoreTemplateCache = make(map[string]*multigresv1alpha1.CoreTemplate)
 	scopedResolver.CellTemplateCache = make(map[string]*multigresv1alpha1.CellTemplate)
 	scopedResolver.ShardTemplateCache = make(map[string]*multigresv1alpha1.ShardTemplate)
@@ -62,21 +61,18 @@ func (d *MultigresClusterDefaulter) Default(ctx context.Context, obj runtime.Obj
 			exists, _ := scopedResolver.CoreTemplateExists(ctx, resolver.FallbackCoreTemplate)
 			if exists {
 				cluster.Spec.TemplateDefaults.CoreTemplate = resolver.FallbackCoreTemplate
-				scopedResolver.TemplateDefaults.CoreTemplate = resolver.FallbackCoreTemplate
 			}
 		}
 		if cluster.Spec.TemplateDefaults.CellTemplate == "" {
 			exists, _ := scopedResolver.CellTemplateExists(ctx, resolver.FallbackCellTemplate)
 			if exists {
 				cluster.Spec.TemplateDefaults.CellTemplate = resolver.FallbackCellTemplate
-				scopedResolver.TemplateDefaults.CellTemplate = resolver.FallbackCellTemplate
 			}
 		}
 		if cluster.Spec.TemplateDefaults.ShardTemplate == "" {
 			exists, _ := scopedResolver.ShardTemplateExists(ctx, resolver.FallbackShardTemplate)
 			if exists {
 				cluster.Spec.TemplateDefaults.ShardTemplate = resolver.FallbackShardTemplate
-				scopedResolver.TemplateDefaults.ShardTemplate = resolver.FallbackShardTemplate
 			}
 		}
 	}

--- a/pkg/webhook/handlers/defaulter_test.go
+++ b/pkg/webhook/handlers/defaulter_test.go
@@ -334,7 +334,7 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 					c = testutil.NewFakeClientWithFailures(c, tc.failureConfig)
 				}
 
-				res = resolver.NewResolver(c, "test-ns", multigresv1alpha1.TemplateDefaults{})
+				res = resolver.NewResolver(c, "test-ns")
 			}
 
 			defaulter := NewMultigresClusterDefaulter(res)

--- a/pkg/webhook/handlers/validator.go
+++ b/pkg/webhook/handlers/validator.go
@@ -83,7 +83,7 @@ func (v *MultigresClusterValidator) validateTemplatesExist(
 ) error {
 	// Create an ephemeral resolver for validation
 	// "Shared Resolver Pattern"
-	res := resolver.NewResolver(v.Client, cluster.Namespace, cluster.Spec.TemplateDefaults)
+	res := resolver.NewResolver(v.Client, cluster.Namespace)
 	return res.ValidateClusterIntegrity(ctx, cluster)
 }
 
@@ -92,7 +92,7 @@ func (v *MultigresClusterValidator) validateLogic(
 	cluster *multigresv1alpha1.MultigresCluster,
 ) (admission.Warnings, error) {
 	// Create an ephemeral resolver for validation
-	res := resolver.NewResolver(v.Client, cluster.Namespace, cluster.Spec.TemplateDefaults)
+	res := resolver.NewResolver(v.Client, cluster.Namespace)
 	return res.ValidateClusterLogic(ctx, cluster)
 }
 

--- a/pkg/webhook/integration_test.go
+++ b/pkg/webhook/integration_test.go
@@ -110,11 +110,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// 6. Setup Resolver & Handlers
-	res := resolver.NewResolver(cachedClient, testNamespace, multigresv1alpha1.TemplateDefaults{
-		CoreTemplate:  "default",
-		CellTemplate:  "default",
-		ShardTemplate: "default",
-	})
+res := resolver.NewResolver(cachedClient, testNamespace)
 
 	if err := multigreswebhook.Setup(mgr, res, multigreswebhook.Options{
 		Enable:       true,

--- a/pkg/webhook/setup_test.go
+++ b/pkg/webhook/setup_test.go
@@ -81,7 +81,6 @@ func TestSetup(t *testing.T) {
 	baseResolver := resolver.NewResolver(
 		baseClient,
 		"default",
-		multigresv1alpha1.TemplateDefaults{},
 	)
 
 	tests := map[string]struct {


### PR DESCRIPTION
The template default flags (--default-core-template, --default-cell-template, --default-shard-template) were ineffective as they were immediately overridden by cluster-specific defaults during resolution.

- Removed three flag variables and definitions from main.go
- Updated NewResolver signature from 3 to 2 parameters (removed TemplateDefaults)
- Removed TemplateDefaults field from Resolver struct
- Added DefaultPoolName constant in pkg/resolver/defaults.go
- Updated template resolution logic in cell.go, cluster.go, and shard.go
- Fixed 40+ test files to use new NewResolver signature
- Updated test expectations (replica count 3→1 for operator defaults)
- Removed flag documentation from README.md

Simplifies the codebase by relying on hardcoded fallback constants instead of command-line flags, improving maintainability without changing functionality.