### PR TITLE
fix(resolver): reject explicit "default" template references

### DIFF
--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -56,9 +56,6 @@ func (r *Resolver) ValidateCoreTemplateReference(
 	if name == "" {
 		return nil
 	}
-	if name == FallbackCoreTemplate {
-		return nil
-	}
 
 	exists, err := r.CoreTemplateExists(ctx, name)
 	if err != nil {
@@ -102,9 +99,6 @@ func (r *Resolver) ValidateCellTemplateReference(
 	if name == "" {
 		return nil
 	}
-	if name == FallbackCellTemplate {
-		return nil
-	}
 
 	exists, err := r.CellTemplateExists(ctx, name)
 	if err != nil {
@@ -146,9 +140,6 @@ func (r *Resolver) ValidateShardTemplateReference(
 	name multigresv1alpha1.TemplateRef,
 ) error {
 	if name == "" {
-		return nil
-	}
-	if name == FallbackShardTemplate {
 		return nil
 	}
 

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -192,13 +192,13 @@ func TestResolver_ValidateReference(t *testing.T) {
 	t.Run("Core", func(t *testing.T) {
 		r := NewResolver(cEmpty, ns)
 
-		// Empty name -> Valid
+		// Empty name -> Valid (no explicit reference)
 		if err := r.ValidateCoreTemplateReference(t.Context(), ""); err != nil {
 			t.Errorf("Empty name should be valid, got %v", err)
 		}
-		// Fallback name ("default") -> Valid even if missing in client
-		if err := r.ValidateCoreTemplateReference(t.Context(), FallbackCoreTemplate); err != nil {
-			t.Errorf("Fallback name should be valid even if missing, got %v", err)
+		// Explicit "default" reference with missing template -> Invalid
+		if err := r.ValidateCoreTemplateReference(t.Context(), FallbackCoreTemplate); err == nil {
+			t.Error("Explicit 'default' reference should error when template is missing")
 		}
 		// Random missing -> Invalid
 		if err := r.ValidateCoreTemplateReference(t.Context(), "missing"); err == nil {
@@ -223,8 +223,9 @@ func TestResolver_ValidateReference(t *testing.T) {
 		if err := r.ValidateCellTemplateReference(t.Context(), ""); err != nil {
 			t.Errorf("Empty name should be valid, got %v", err)
 		}
-		if err := r.ValidateCellTemplateReference(t.Context(), FallbackCellTemplate); err != nil {
-			t.Errorf("Fallback name should be valid even if missing, got %v", err)
+		// Explicit "default" reference with missing template -> Invalid
+		if err := r.ValidateCellTemplateReference(t.Context(), FallbackCellTemplate); err == nil {
+			t.Error("Explicit 'default' reference should error when template is missing")
 		}
 		if err := r.ValidateCellTemplateReference(t.Context(), "missing"); err == nil {
 			t.Error("Missing template should error")
@@ -245,8 +246,9 @@ func TestResolver_ValidateReference(t *testing.T) {
 		if err := r.ValidateShardTemplateReference(t.Context(), ""); err != nil {
 			t.Errorf("Empty name should be valid, got %v", err)
 		}
-		if err := r.ValidateShardTemplateReference(t.Context(), FallbackShardTemplate); err != nil {
-			t.Errorf("Fallback name should be valid even if missing, got %v", err)
+		// Explicit "default" reference with missing template -> Invalid
+		if err := r.ValidateShardTemplateReference(t.Context(), FallbackShardTemplate); err == nil {
+			t.Error("Explicit 'default' reference should error when template is missing")
 		}
 		if err := r.ValidateShardTemplateReference(t.Context(), "missing"); err == nil {
 			t.Error("Missing template should error")

--- a/pkg/webhook/handlers/validator_test.go
+++ b/pkg/webhook/handlers/validator_test.go
@@ -222,7 +222,7 @@ func TestMultigresClusterValidator(t *testing.T) {
 			wantAllowed: false,
 			wantMessage: "injected test error",
 		},
-		"Allowed: Missing Fallback Templates": {
+		"Denied: Missing Explicit Default Templates": {
 			object: func() *multigresv1alpha1.MultigresCluster {
 				c := baseCluster.DeepCopy()
 				c.Spec.TemplateDefaults = multigresv1alpha1.TemplateDefaults{
@@ -233,7 +233,8 @@ func TestMultigresClusterValidator(t *testing.T) {
 				return c
 			}(),
 			operation:   "Create",
-			wantAllowed: true,
+			wantAllowed: false,
+			wantMessage: "referenced CoreTemplate 'default' not found",
 		},
 		"Error: Missing CellTemplate (Core Valid)": {
 			object: func() *multigresv1alpha1.MultigresCluster {


### PR DESCRIPTION
The validation functions incorrectly bypassed existence checks when a template was named "default", allowing invisible fallback to hardcoded operator defaults. This violated the design goal of solving the "invisible defaults" problem.

- Remove FallbackCoreTemplate bypass in ValidateCoreTemplateReference
- Remove FallbackCellTemplate bypass in ValidateCellTemplateReference
- Remove FallbackShardTemplate bypass in ValidateShardTemplateReference
- Update unit tests to expect errors for missing explicit "default"

Explicit "default" references now error when the template doesn't exist, while empty references still correctly use the implicit fallback chain.