### PR TITLE
fix(resolver): adjust to replicasPerCell to match

### DIFF
--- a/pkg/resolver/shard.go
+++ b/pkg/resolver/shard.go
@@ -211,7 +211,12 @@ func mergePoolSpec(
 
 func defaultPoolSpec(spec *multigresv1alpha1.PoolSpec) {
 	if spec.ReplicasPerCell == nil {
-		spec.ReplicasPerCell = ptr.To(int32(1))
+		// Default to 3 replicas to satisfy multiorch's ANY_2 durability policy
+		// requirement.
+		// TODO: multiorch currently only supports ANY_2 or MULTI_CELL_ANY_2,
+		// both of which require at least 2 replicas for quorum. Single-node
+		// policies are not yet supported.
+		spec.ReplicasPerCell = ptr.To(int32(3))
 	}
 	if spec.Storage.Size == "" {
 		spec.Storage.Size = DefaultEtcdStorageSize

--- a/pkg/resolver/shard_test.go
+++ b/pkg/resolver/shard_test.go
@@ -44,7 +44,7 @@ func TestResolver_ResolveShard(t *testing.T) {
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"default": {
 					Type:            "readWrite",
-					ReplicasPerCell: ptr.To(int32(1)),
+					ReplicasPerCell: ptr.To(int32(3)),
 					Storage: multigresv1alpha1.StorageSpec{
 						Size: DefaultEtcdStorageSize,
 					},
@@ -79,7 +79,7 @@ func TestResolver_ResolveShard(t *testing.T) {
 			// FIX: Updated to expect fully hydrated defaults for pool "p"
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"p": {
-					ReplicasPerCell: ptr.To(int32(1)),
+					ReplicasPerCell: ptr.To(int32(3)),
 					Storage: multigresv1alpha1.StorageSpec{
 						Size: DefaultEtcdStorageSize, // "1Gi"
 					},
@@ -116,7 +116,7 @@ func TestResolver_ResolveShard(t *testing.T) {
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"p1": {
 					Type:            "read",
-					ReplicasPerCell: ptr.To(int32(1)),
+					ReplicasPerCell: ptr.To(int32(3)),
 					// Expect injected cells
 					Cells: []multigresv1alpha1.CellName{"zone-a", "zone-b"},
 					Storage: multigresv1alpha1.StorageSpec{
@@ -151,7 +151,7 @@ func TestResolver_ResolveShard(t *testing.T) {
 			},
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"p": {
-					ReplicasPerCell: ptr.To(int32(1)),
+					ReplicasPerCell: ptr.To(int32(3)),
 					Storage:         multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 					Postgres: multigresv1alpha1.ContainerConfig{
 						Resources: DefaultResourcesPostgres(),
@@ -420,7 +420,7 @@ func TestMergeShardConfig(t *testing.T) {
 			tpl: &multigresv1alpha1.ShardTemplate{
 				Spec: multigresv1alpha1.ShardTemplateSpec{
 					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
-						"p1": {Type: "read", ReplicasPerCell: ptr.To(int32(1))},
+						"p1": {Type: "read", ReplicasPerCell: ptr.To(int32(3))},
 					},
 				},
 			},
@@ -431,7 +431,7 @@ func TestMergeShardConfig(t *testing.T) {
 			},
 			wantOrch: multigresv1alpha1.MultiOrchSpec{},
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
-				"p1": {Type: "read", ReplicasPerCell: ptr.To(int32(1))},
+				"p1": {Type: "read", ReplicasPerCell: ptr.To(int32(3))},
 			},
 		},
 		"Inline Priority": {


### PR DESCRIPTION
The current implementation upstream expects multiorch to work out with
ANY_2, meaning a single replica will never become ready to serve traffic.