### PR TITLE
feat(data-handler): add event emission to cell and shard controllers

### DIFF
--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -384,16 +384,18 @@ func main() {
 	}
 
 	if err = (&datahandlercellcontroller.CellReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("cell-datahandler"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cell-DataHandler")
 		os.Exit(1)
 	}
 
 	if err = (&datahandlershardcontroller.ShardReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("shard-datahandler"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Shard-DataHandler")
 		os.Exit(1)

--- a/pkg/data-handler/controller/cell/cell_controller_internal_test.go
+++ b/pkg/data-handler/controller/cell/cell_controller_internal_test.go
@@ -15,6 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"k8s.io/client-go/tools/record"
+
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/testutil"
 )
@@ -134,7 +136,9 @@ func TestRegisterCellInTopology(t *testing.T) {
 				tc.topoSetup(t, store)
 			}
 
-			reconciler := &CellReconciler{}
+			reconciler := &CellReconciler{
+				Recorder: record.NewFakeRecorder(10),
+			}
 
 			// Setup topology store creation based on test needs
 			if tc.mockCreateFunc != nil {
@@ -286,7 +290,9 @@ func TestUnregisterCellFromTopology(t *testing.T) {
 				tc.topoSetup(t, store)
 			}
 
-			reconciler := &CellReconciler{}
+			reconciler := &CellReconciler{
+				Recorder: record.NewFakeRecorder(10),
+			}
 
 			// Setup topology store creation based on test needs
 			if tc.mockCreateFunc != nil {
@@ -456,8 +462,9 @@ func TestHandleDeletion(t *testing.T) {
 			}
 
 			reconciler := &CellReconciler{
-				Client: c,
-				Scheme: scheme,
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
 			}
 
 			// Setup topology store creation based on test needs

--- a/pkg/data-handler/controller/cell/cell_controller_test.go
+++ b/pkg/data-handler/controller/cell/cell_controller_test.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"k8s.io/client-go/tools/record"
+
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/data-handler/controller/cell"
 	"github.com/numtide/multigres-operator/pkg/testutil"
@@ -405,8 +407,9 @@ func TestReconcile(t *testing.T) {
 			}
 
 			reconciler := &cell.CellReconciler{
-				Client: c,
-				Scheme: scheme,
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
 			}
 
 			// Override createTopoStore for valid implementations

--- a/pkg/data-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/data-handler/controller/shard/shard_controller_internal_test.go
@@ -13,7 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -184,8 +186,9 @@ func TestUnregisterDatabaseSuccessPath(t *testing.T) {
 		Build()
 
 	reconciler := &ShardReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
 	}
 
 	// Setup memory topo with database
@@ -330,8 +333,9 @@ func TestReconcile_ErrorRegisteringDatabase(t *testing.T) {
 		Build()
 
 	reconciler := &ShardReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
 	}
 
 	// Set custom factory that returns a store that fails CreateDatabase
@@ -389,8 +393,9 @@ func TestReconcile_ErrorDeletingDatabase(t *testing.T) {
 		Build()
 
 	reconciler := &ShardReconciler{
-		Client: fakeClient,
-		Scheme: scheme,
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
 	}
 
 	// Set custom factory that returns a store that fails DeleteDatabase

--- a/pkg/data-handler/controller/shard/shard_controller_test.go
+++ b/pkg/data-handler/controller/shard/shard_controller_test.go
@@ -17,6 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"k8s.io/client-go/tools/record"
+
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/data-handler/controller/shard"
 	"github.com/numtide/multigres-operator/pkg/testutil"
@@ -435,8 +437,9 @@ func TestReconcile(t *testing.T) {
 			}
 
 			reconciler := &shard.ShardReconciler{
-				Client: c,
-				Scheme: scheme,
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
 			}
 
 			// Use custom topo store function if provided, otherwise default to memory topo


### PR DESCRIPTION
The data-handler controllers lacked observability compared to resource-handler controllers. Users had no visibility into topology registration operations.

Changes:
- Add Recorder field to CellReconciler and ShardReconciler structs
- Emit CellRegistered/DatabaseRegistered events on successful topology registration
- Emit CellUnregistered/DatabaseUnregistered events on successful cleanup
- Emit Synced events on successful reconciliation
- Emit Warning events for topology failures (RegistrationFailed, UnregistrationFailed, CleanupFailed, FinalizerFailed, TopologyError)
- Initialize event recorders in main.go for both data-handler controllers

Improves observability by surfacing topology operations in kubectl describe output, matching the event coverage already present in resource-handler controllers.