### PR TITLE
refactor(controllers): fix SetupWithManager options override

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -115,12 +115,12 @@ func (r *MultigresClusterReconciler) SetupWithManager(
 	mgr ctrl.Manager,
 	opts ...controller.Options,
 ) error {
-	controllerOpts := controller.Options{}
+	controllerOpts := controller.Options{
+		MaxConcurrentReconciles: 20,
+	}
 	if len(opts) > 0 {
 		controllerOpts = opts[0]
 	}
-
-	controllerOpts.MaxConcurrentReconciles = 20
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.MultigresCluster{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -255,12 +255,12 @@ func (r *TableGroupReconciler) SetupWithManager(
 	mgr ctrl.Manager,
 	opts ...controller.Options,
 ) error {
-	controllerOpts := controller.Options{}
+	controllerOpts := controller.Options{
+		MaxConcurrentReconciles: 20,
+	}
 	if len(opts) > 0 {
 		controllerOpts = opts[0]
 	}
-
-	controllerOpts.MaxConcurrentReconciles = 20
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.TableGroup{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -286,12 +286,12 @@ func (r *CellReconciler) setConditions(
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CellReconciler) SetupWithManager(mgr ctrl.Manager, opts ...controller.Options) error {
-	controllerOpts := controller.Options{}
+	controllerOpts := controller.Options{
+		MaxConcurrentReconciles: 20,
+	}
 	if len(opts) > 0 {
 		controllerOpts = opts[0]
 	}
-
-	controllerOpts.MaxConcurrentReconciles = 20
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.Cell{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -627,12 +627,12 @@ func getMultiOrchCells(shard *multigresv1alpha1.Shard) ([]multigresv1alpha1.Cell
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ShardReconciler) SetupWithManager(mgr ctrl.Manager, opts ...controller.Options) error {
-	controllerOpts := controller.Options{}
+	controllerOpts := controller.Options{
+		MaxConcurrentReconciles: 20,
+	}
 	if len(opts) > 0 {
 		controllerOpts = opts[0]
 	}
-
-	controllerOpts.MaxConcurrentReconciles = 20
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.Shard{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller.go
@@ -321,12 +321,12 @@ func (r *TopoServerReconciler) SetupWithManager(
 	mgr ctrl.Manager,
 	opts ...controller.Options,
 ) error {
-	controllerOpts := controller.Options{}
+	controllerOpts := controller.Options{
+		MaxConcurrentReconciles: 20,
+	}
 	if len(opts) > 0 {
 		controllerOpts = opts[0]
 	}
-
-	controllerOpts.MaxConcurrentReconciles = 20
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&multigresv1alpha1.TopoServer{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).


### PR DESCRIPTION
Previously, SetupWithManager unconditionally overwrote passed controller.Options with hardcoded MaxConcurrentReconciles = 20, making the variadic parameter effectively useless.

- Moved MaxConcurrentReconciles = 20 to struct initialization
- Allow passed options to completely override defaults when provided
- Fixed in multigrescluster, tablegroup, cell, shard, and toposerver

Enables integration tests to properly use SkipNameValidation option while maintaining production defaults.