### PR TITLE
chore(deps): bump api module to latest main

### DIFF
--- a/api/v1alpha1/observability_helpers.go
+++ b/api/v1alpha1/observability_helpers.go
@@ -33,7 +33,11 @@ import (
 // Setting cfg.OTLPEndpoint to "disabled" suppresses all OTEL variables,
 // returning nil regardless of other field values.
 func BuildOTELEnvVars(cfg *ObservabilityConfig) []corev1.EnvVar {
-	endpoint := envOrCRD(cfg, func(c *ObservabilityConfig) string { return c.OTLPEndpoint }, "OTEL_EXPORTER_OTLP_ENDPOINT")
+	endpoint := envOrCRD(
+		cfg,
+		func(c *ObservabilityConfig) string { return c.OTLPEndpoint },
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+	)
 	if endpoint == "" || endpoint == "disabled" {
 		return nil
 	}
@@ -68,7 +72,11 @@ func BuildOTELEnvVars(cfg *ObservabilityConfig) []corev1.EnvVar {
 	appendIfSet("OTEL_METRICS_EXPORTER", metrics, "OTEL_METRICS_EXPORTER")
 	appendIfSet("OTEL_LOGS_EXPORTER", logs, "OTEL_LOGS_EXPORTER")
 	appendIfSet("OTEL_METRIC_EXPORT_INTERVAL", interval, "OTEL_METRIC_EXPORT_INTERVAL")
-	appendIfSet("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", temporality, "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE")
+	appendIfSet(
+		"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
+		temporality,
+		"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
+	)
 	appendIfSet("OTEL_TRACES_SAMPLER", sampler, "OTEL_TRACES_SAMPLER")
 
 	return vars
@@ -76,7 +84,11 @@ func BuildOTELEnvVars(cfg *ObservabilityConfig) []corev1.EnvVar {
 
 // envOrCRD returns the CRD field value if non-empty, otherwise falls back
 // to the named environment variable.
-func envOrCRD(cfg *ObservabilityConfig, getter func(*ObservabilityConfig) string, envName string) string {
+func envOrCRD(
+	cfg *ObservabilityConfig,
+	getter func(*ObservabilityConfig) string,
+	envName string,
+) string {
 	if cfg != nil {
 		if v := getter(cfg); v != "" {
 			return v

--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -182,7 +182,11 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// Initialize distributed tracing (noop if OTEL_EXPORTER_OTLP_ENDPOINT is unset).
-	shutdownTracing, err := monitoring.InitTracing(context.Background(), "multigres-operator", version)
+	shutdownTracing, err := monitoring.InitTracing(
+		context.Background(),
+		"multigres-operator",
+		version,
+	)
 	if err != nil {
 		setupLog.Error(err, "failed to initialise tracing")
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.2
 
 require (
 	github.com/multigres/multigres v0.0.0-20260206234310-62e1d947565c
-	github.com/numtide/multigres-operator/api v0.0.0-20260210092054-f7ad64000b6d
+	github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4
 	github.com/numtide/multigres-operator/pkg/cluster-handler v0.0.0-20260210092054-f7ad64000b6d
 	github.com/numtide/multigres-operator/pkg/data-handler v0.0.0-20260210092054-f7ad64000b6d
 	github.com/numtide/multigres-operator/pkg/monitoring v0.0.0-20260210092054-f7ad64000b6d

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/multigres/multigres v0.0.0-20260206234310-62e1d947565c h1:KUene2FBKD/
 github.com/multigres/multigres v0.0.0-20260206234310-62e1d947565c/go.mod h1:x+HiTIl2+sC378/i1MSh0SPknIIHf/VH7PGKNN5TI9s=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4 h1:+MmCOMJ62lFpKooBhk/EAm7r94OJ3bBKDFepFZnhgCA=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4/go.mod h1:7nlnBwoyLSbEloUaHHC6X3ncWZeuOvkOBnnF9cSW+Wg=
 github.com/numtide/multigres-operator/pkg/cluster-handler v0.0.0-20260210092054-f7ad64000b6d h1:VCSghVrjnUnzzXu9OgMb23qwDWhiL0Wnb89XoGHvgUE=
 github.com/numtide/multigres-operator/pkg/cluster-handler v0.0.0-20260210092054-f7ad64000b6d/go.mod h1:63AFZ+kMSgJNsiqo0dJA09sND+3gc3cHR5J85I1OPW8=
 github.com/numtide/multigres-operator/pkg/data-handler v0.0.0-20260210092054-f7ad64000b6d h1:gZ9r3GQ/D/AWoi1wR0x9q9TRYTd8Kzwt3HxlZkXhlao=

--- a/pkg/cluster-handler/controller/multigrescluster/builders_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global.go
@@ -141,7 +141,9 @@ func BuildMultiAdminDeployment(
 								},
 							},
 							Resources: spec.Resources,
-							Env:       multigresv1alpha1.BuildOTELEnvVars(cluster.Spec.Observability),
+							Env: multigresv1alpha1.BuildOTELEnvVars(
+								cluster.Spec.Observability,
+							),
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -39,7 +39,13 @@ func (r *TableGroupReconciler) Reconcile(
 	req ctrl.Request,
 ) (ctrl.Result, error) {
 	start := time.Now()
-	ctx, span := monitoring.StartReconcileSpan(ctx, "TableGroup.Reconcile", req.Name, req.Namespace, "TableGroup")
+	ctx, span := monitoring.StartReconcileSpan(
+		ctx,
+		"TableGroup.Reconcile",
+		req.Name,
+		req.Namespace,
+		"TableGroup",
+	)
 	defer span.End()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 

--- a/pkg/cluster-handler/go.mod
+++ b/pkg/cluster-handler/go.mod
@@ -3,7 +3,7 @@ module github.com/numtide/multigres-operator/pkg/cluster-handler
 go 1.25.2
 
 require (
-	github.com/numtide/multigres-operator/api v0.0.0-20260210092054-f7ad64000b6d
+	github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4
 	github.com/numtide/multigres-operator/pkg/monitoring v0.0.0-00010101000000-000000000000
 	github.com/numtide/multigres-operator/pkg/resolver v0.0.0-20260210092054-f7ad64000b6d
 	github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d

--- a/pkg/cluster-handler/go.sum
+++ b/pkg/cluster-handler/go.sum
@@ -98,6 +98,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4 h1:+MmCOMJ62lFpKooBhk/EAm7r94OJ3bBKDFepFZnhgCA=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4/go.mod h1:7nlnBwoyLSbEloUaHHC6X3ncWZeuOvkOBnnF9cSW+Wg=
 github.com/numtide/multigres-operator/pkg/resolver v0.0.0-20260210092054-f7ad64000b6d h1:1x/nn1VbjmAdo4pQf29L8RZEKrqRsTGRpgypdugrVBY=
 github.com/numtide/multigres-operator/pkg/resolver v0.0.0-20260210092054-f7ad64000b6d/go.mod h1:tEAj5qK19UlWqPln+RLojeGgL7bS9vzuLO98zionDZk=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d h1:asXsAwZLU82zMOU/4TVk/EPIIyKtxpxHIejkCS5Iv8s=

--- a/pkg/data-handler/controller/cell/cell_controller.go
+++ b/pkg/data-handler/controller/cell/cell_controller.go
@@ -45,7 +45,13 @@ type CellReconciler struct {
 // Reconcile handles Cell resource reconciliation for data plane operations.
 func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	start := time.Now()
-	ctx, span := monitoring.StartReconcileSpan(ctx, "CellData.Reconcile", req.Name, req.Namespace, "Cell")
+	ctx, span := monitoring.StartReconcileSpan(
+		ctx,
+		"CellData.Reconcile",
+		req.Name,
+		req.Namespace,
+		"Cell",
+	)
 	defer span.End()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 

--- a/pkg/data-handler/controller/shard/shard_controller.go
+++ b/pkg/data-handler/controller/shard/shard_controller.go
@@ -44,7 +44,13 @@ type ShardReconciler struct {
 // Reconcile handles Shard resource reconciliation for data plane operations.
 func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	start := time.Now()
-	ctx, span := monitoring.StartReconcileSpan(ctx, "ShardData.Reconcile", req.Name, req.Namespace, "Shard")
+	ctx, span := monitoring.StartReconcileSpan(
+		ctx,
+		"ShardData.Reconcile",
+		req.Name,
+		req.Namespace,
+		"Shard",
+	)
 	defer span.End()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 

--- a/pkg/data-handler/go.mod
+++ b/pkg/data-handler/go.mod
@@ -5,7 +5,7 @@ go 1.25.2
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/multigres/multigres v0.0.0-20260206234310-62e1d947565c
-	github.com/numtide/multigres-operator/api v0.0.0-20260210092054-f7ad64000b6d
+	github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4
 	github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0

--- a/pkg/data-handler/go.sum
+++ b/pkg/data-handler/go.sum
@@ -143,6 +143,8 @@ github.com/multigres/multigres v0.0.0-20260206234310-62e1d947565c h1:KUene2FBKD/
 github.com/multigres/multigres v0.0.0-20260206234310-62e1d947565c/go.mod h1:x+HiTIl2+sC378/i1MSh0SPknIIHf/VH7PGKNN5TI9s=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4 h1:+MmCOMJ62lFpKooBhk/EAm7r94OJ3bBKDFepFZnhgCA=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4/go.mod h1:7nlnBwoyLSbEloUaHHC6X3ncWZeuOvkOBnnF9cSW+Wg=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d h1:asXsAwZLU82zMOU/4TVk/EPIIyKtxpxHIejkCS5Iv8s=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d/go.mod h1:Mu9d9ss422+enNZ1/w3z4J1AYifJhwPGGAVZDjA7g44=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=

--- a/pkg/monitoring/metrics_test.go
+++ b/pkg/monitoring/metrics_test.go
@@ -89,7 +89,12 @@ func TestGaugeLabels(t *testing.T) {
 			descStr := desc.String()
 			for _, label := range tt.wantLabels {
 				if !strings.Contains(descStr, label) {
-					t.Errorf("metric %s missing label %q in descriptor: %s", tt.name, label, descStr)
+					t.Errorf(
+						"metric %s missing label %q in descriptor: %s",
+						tt.name,
+						label,
+						descStr,
+					)
 				}
 			}
 		})

--- a/pkg/monitoring/recorder_test.go
+++ b/pkg/monitoring/recorder_test.go
@@ -104,7 +104,12 @@ func TestRecordWebhookRequest(t *testing.T) {
 	})
 
 	RecordWebhookRequest("CREATE", "MultigresCluster", nil, 50*time.Millisecond)
-	RecordWebhookRequest("UPDATE", "MultigresCluster", errors.New("validation failed"), 100*time.Millisecond)
+	RecordWebhookRequest(
+		"UPDATE",
+		"MultigresCluster",
+		errors.New("validation failed"),
+		100*time.Millisecond,
+	)
 
 	successVal := counterValue(t, webhookRequestTotal, "CREATE", "MultigresCluster", "success")
 	if successVal != 1 {

--- a/pkg/monitoring/tracing.go
+++ b/pkg/monitoring/tracing.go
@@ -44,7 +44,10 @@ var Tracer = otel.Tracer(tracerName)
 // (default: "http/protobuf"). Supported values: "grpc", "http/protobuf".
 // If OTEL_EXPORTER_OTLP_ENDPOINT is unset, tracing is left disabled and a
 // noop shutdown function is returned.
-func InitTracing(ctx context.Context, serviceName, version string) (func(context.Context) error, error) {
+func InitTracing(
+	ctx context.Context,
+	serviceName, version string,
+) (func(context.Context) error, error) {
 	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") == "" {
 		return func(context.Context) error { return nil }, nil
 	}
@@ -83,7 +86,10 @@ func InitTracing(ctx context.Context, serviceName, version string) (func(context
 // StartReconcileSpan starts a new span for a controller reconciliation.
 // The span is annotated with the Kubernetes resource name, namespace, and kind.
 // Callers must call span.End() when the operation completes.
-func StartReconcileSpan(ctx context.Context, spanName, name, namespace, kind string) (context.Context, trace.Span) {
+func StartReconcileSpan(
+	ctx context.Context,
+	spanName, name, namespace, kind string,
+) (context.Context, trace.Span) {
 	ctx, span := Tracer.Start(ctx, spanName,
 		trace.WithAttributes(
 			attribute.String("k8s.resource.name", name),

--- a/pkg/monitoring/tracing_test.go
+++ b/pkg/monitoring/tracing_test.go
@@ -27,7 +27,13 @@ func TestStartReconcileSpan(t *testing.T) {
 	Tracer = tp.Tracer(tracerName)
 
 	ctx := context.Background()
-	ctx, span := StartReconcileSpan(ctx, "MultigresCluster.Reconcile", "my-cluster", "default", "MultigresCluster")
+	ctx, span := StartReconcileSpan(
+		ctx,
+		"MultigresCluster.Reconcile",
+		"my-cluster",
+		"default",
+		"MultigresCluster",
+	)
 	span.End()
 
 	spans := exporter.GetSpans()
@@ -88,7 +94,11 @@ func TestStartChildSpan(t *testing.T) {
 	childSpan := spans[0]
 	parentSpan := spans[1]
 	if childSpan.Parent.SpanID() != parentSpan.SpanContext.SpanID() {
-		t.Errorf("child parent span ID = %s, want %s", childSpan.Parent.SpanID(), parentSpan.SpanContext.SpanID())
+		t.Errorf(
+			"child parent span ID = %s, want %s",
+			childSpan.Parent.SpanID(),
+			parentSpan.SpanContext.SpanID(),
+		)
 	}
 	if childSpan.Name != "ChildOperation" {
 		t.Errorf("child span name = %q, want %q", childSpan.Name, "ChildOperation")
@@ -119,7 +129,11 @@ func TestRecordSpanError(t *testing.T) {
 			t.Errorf("span status = %v, want Error", s.Status.Code)
 		}
 		if s.Status.Description != "something failed" {
-			t.Errorf("span status description = %q, want %q", s.Status.Description, "something failed")
+			t.Errorf(
+				"span status description = %q, want %q",
+				s.Status.Description,
+				"something failed",
+			)
 		}
 
 		// Check that an error event was recorded.
@@ -128,7 +142,8 @@ func TestRecordSpanError(t *testing.T) {
 			if event.Name == "exception" {
 				foundErrorEvent = true
 				for _, attr := range event.Attributes {
-					if attr.Key == attribute.Key("exception.message") && attr.Value.AsString() == "something failed" {
+					if attr.Key == attribute.Key("exception.message") &&
+						attr.Value.AsString() == "something failed" {
 						break
 					}
 				}

--- a/pkg/resolver/go.mod
+++ b/pkg/resolver/go.mod
@@ -4,7 +4,7 @@ go 1.25.2
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/numtide/multigres-operator/api v0.0.0-20260210092054-f7ad64000b6d
+	github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4
 	github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0

--- a/pkg/resolver/go.sum
+++ b/pkg/resolver/go.sum
@@ -89,6 +89,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4 h1:+MmCOMJ62lFpKooBhk/EAm7r94OJ3bBKDFepFZnhgCA=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4/go.mod h1:7nlnBwoyLSbEloUaHHC6X3ncWZeuOvkOBnnF9cSW+Wg=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d h1:asXsAwZLU82zMOU/4TVk/EPIIyKtxpxHIejkCS5Iv8s=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d/go.mod h1:Mu9d9ss422+enNZ1/w3z4J1AYifJhwPGGAVZDjA7g44=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -34,7 +34,13 @@ type CellReconciler struct {
 // Reconcile handles Cell resource reconciliation.
 func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	start := time.Now()
-	ctx, span := monitoring.StartReconcileSpan(ctx, "Cell.Reconcile", req.Name, req.Namespace, "Cell")
+	ctx, span := monitoring.StartReconcileSpan(
+		ctx,
+		"Cell.Reconcile",
+		req.Name,
+		req.Namespace,
+		"Cell",
+	)
 	defer span.End()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 
@@ -203,7 +209,12 @@ func (r *CellReconciler) updateStatus(ctx context.Context, cell *multigresv1alph
 	r.setConditions(cell, mgDeploy)
 	cell.Status.GatewayReplicas = mgDeploy.Status.Replicas
 	cell.Status.GatewayReadyReplicas = mgDeploy.Status.ReadyReplicas
-	monitoring.SetCellGatewayReplicas(cell.Name, cell.Namespace, mgDeploy.Status.Replicas, mgDeploy.Status.ReadyReplicas)
+	monitoring.SetCellGatewayReplicas(
+		cell.Name,
+		cell.Namespace,
+		mgDeploy.Status.Replicas,
+		mgDeploy.Status.ReadyReplicas,
+	)
 
 	// Update Phase
 	cell.Status.Phase = status.ComputePhase(mgDeploy.Status.ReadyReplicas, mgDeploy.Status.Replicas)

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -38,7 +38,13 @@ func (r *ShardReconciler) Reconcile(
 	req ctrl.Request,
 ) (ctrl.Result, error) {
 	start := time.Now()
-	ctx, span := monitoring.StartReconcileSpan(ctx, "Shard.Reconcile", req.Name, req.Namespace, "Shard")
+	ctx, span := monitoring.StartReconcileSpan(
+		ctx,
+		"Shard.Reconcile",
+		req.Name,
+		req.Namespace,
+		"Shard",
+	)
 	defer span.End()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 
@@ -538,7 +544,13 @@ func (r *ShardReconciler) updatePoolsStatus(
 				readyPods += sts.Status.ReadyReplicas
 			} // else treat as 0 ready pods because it is stale/progressing
 
-			monitoring.SetShardPoolReplicas(shard.Name, string(poolName), shard.Namespace, sts.Status.Replicas, sts.Status.ReadyReplicas)
+			monitoring.SetShardPoolReplicas(
+				shard.Name,
+				string(poolName),
+				shard.Namespace,
+				sts.Status.Replicas,
+				sts.Status.ReadyReplicas,
+			)
 		}
 	}
 

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller.go
@@ -37,7 +37,13 @@ func (r *TopoServerReconciler) Reconcile(
 	req ctrl.Request,
 ) (ctrl.Result, error) {
 	start := time.Now()
-	ctx, span := monitoring.StartReconcileSpan(ctx, "TopoServer.Reconcile", req.Name, req.Namespace, "TopoServer")
+	ctx, span := monitoring.StartReconcileSpan(
+		ctx,
+		"TopoServer.Reconcile",
+		req.Name,
+		req.Namespace,
+		"TopoServer",
+	)
 	defer span.End()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 
@@ -263,7 +269,12 @@ func (r *TopoServerReconciler) updateStatus(
 
 	// Update Phase
 	toposerver.Status.Phase = status.ComputePhase(sts.Status.ReadyReplicas, sts.Status.Replicas)
-	monitoring.SetTopoServerReplicas(toposerver.Name, toposerver.Namespace, sts.Status.Replicas, sts.Status.ReadyReplicas)
+	monitoring.SetTopoServerReplicas(
+		toposerver.Name,
+		toposerver.Namespace,
+		sts.Status.Replicas,
+		sts.Status.ReadyReplicas,
+	)
 	if sts.Status.ObservedGeneration != sts.Generation {
 		toposerver.Status.Phase = multigresv1alpha1.PhaseProgressing
 		toposerver.Status.Message = "StatefulSet is progressing"

--- a/pkg/resource-handler/go.mod
+++ b/pkg/resource-handler/go.mod
@@ -4,7 +4,7 @@ go 1.25.2
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/numtide/multigres-operator/api v0.0.0-20260210092054-f7ad64000b6d
+	github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4
 	github.com/numtide/multigres-operator/pkg/monitoring v0.0.0-00010101000000-000000000000
 	github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d
 	github.com/numtide/multigres-operator/pkg/util v0.0.0-20260210092054-f7ad64000b6d

--- a/pkg/resource-handler/go.sum
+++ b/pkg/resource-handler/go.sum
@@ -98,6 +98,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4 h1:+MmCOMJ62lFpKooBhk/EAm7r94OJ3bBKDFepFZnhgCA=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4/go.mod h1:7nlnBwoyLSbEloUaHHC6X3ncWZeuOvkOBnnF9cSW+Wg=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d h1:asXsAwZLU82zMOU/4TVk/EPIIyKtxpxHIejkCS5Iv8s=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d/go.mod h1:Mu9d9ss422+enNZ1/w3z4J1AYifJhwPGGAVZDjA7g44=
 github.com/numtide/multigres-operator/pkg/util v0.0.0-20260210092054-f7ad64000b6d h1:o+QZivgtONCiO78TwzhpDk3jPxl1zjkWdZzhWUGS5Xc=

--- a/pkg/util/go.mod
+++ b/pkg/util/go.mod
@@ -4,7 +4,7 @@ go 1.25.2
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/numtide/multigres-operator/api v0.0.0-20260210092054-f7ad64000b6d
+	github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4
 	k8s.io/api v0.35.0
 )
 

--- a/pkg/util/go.sum
+++ b/pkg/util/go.sum
@@ -27,6 +27,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4 h1:+MmCOMJ62lFpKooBhk/EAm7r94OJ3bBKDFepFZnhgCA=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4/go.mod h1:7nlnBwoyLSbEloUaHHC6X3ncWZeuOvkOBnnF9cSW+Wg=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.3 h1:eTX+W6dobAYfFeGC2PV6RwXRu/MyT+cQguijutvkpSM=

--- a/pkg/webhook/go.mod
+++ b/pkg/webhook/go.mod
@@ -5,7 +5,7 @@ go 1.25.2
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
-	github.com/numtide/multigres-operator/api v0.0.0-20260210092054-f7ad64000b6d
+	github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4
 	github.com/numtide/multigres-operator/pkg/monitoring v0.0.0-00010101000000-000000000000
 	github.com/numtide/multigres-operator/pkg/resolver v0.0.0-20260210092054-f7ad64000b6d
 	github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d

--- a/pkg/webhook/go.sum
+++ b/pkg/webhook/go.sum
@@ -98,6 +98,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4 h1:+MmCOMJ62lFpKooBhk/EAm7r94OJ3bBKDFepFZnhgCA=
+github.com/numtide/multigres-operator/api v0.0.0-20260211100434-5c54868fb4e4/go.mod h1:7nlnBwoyLSbEloUaHHC6X3ncWZeuOvkOBnnF9cSW+Wg=
 github.com/numtide/multigres-operator/pkg/resolver v0.0.0-20260210092054-f7ad64000b6d h1:1x/nn1VbjmAdo4pQf29L8RZEKrqRsTGRpgypdugrVBY=
 github.com/numtide/multigres-operator/pkg/resolver v0.0.0-20260210092054-f7ad64000b6d/go.mod h1:tEAj5qK19UlWqPln+RLojeGgL7bS9vzuLO98zionDZk=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260210092054-f7ad64000b6d h1:asXsAwZLU82zMOU/4TVk/EPIIyKtxpxHIejkCS5Iv8s=


### PR DESCRIPTION
Update all internal go.mod files to reference the API module at v0.0.0-20260211100434-5c54868fb4e4, which includes the new ObservabilityConfig types.

- Upgrade api dependency in all 7 consuming modules via GOPROXY=direct
- Remove temporary replace directives that were needed pre-merge
- Run go mod tidy on all modules
- Fixing linting in all files.

All modules now build and vet correctly with GOWORK=off.