### PR TITLE
fix(resource-handler): set ObservedGeneration before patch

### DIFF
--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -467,6 +467,8 @@ func (r *ShardReconciler) updateStatus(
 	// Update conditions
 	r.setConditions(shard, totalPods, readyPods)
 
+	shard.Status.ObservedGeneration = shard.Generation
+
 	// 1. Construct the Patch Object
 	patchObj := &multigresv1alpha1.Shard{
 		TypeMeta: metav1.TypeMeta{
@@ -479,8 +481,6 @@ func (r *ShardReconciler) updateStatus(
 		},
 		Status: shard.Status,
 	}
-
-	shard.Status.ObservedGeneration = shard.Generation
 
 	// 2. Apply the Patch
 	if oldPhase != shard.Status.Phase {


### PR DESCRIPTION
ObservedGeneration was assigned after the SSA patchObj was constructed, so the value was never included in the status patch sent to the API server.

- Move ObservedGeneration assignment in updateStatus to before patchObj construction in shard_controller.go
- Aligns with the correct pattern used by the TopoServer and Cell controllers

Ensures parent controllers and external tooling can correctly determine Shard status freshness.