### PR TITLE
fix(cluster-handler): derive topo implementation from spec

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global.go
@@ -165,10 +165,15 @@ func (r *MultigresClusterReconciler) getGlobalTopoRef(
 		rootPath = spec.Etcd.RootPath
 	}
 
+	implementation := "etcd"
+	if spec.External != nil && spec.External.Implementation != "" {
+		implementation = spec.External.Implementation
+	}
+
 	return multigresv1alpha1.GlobalTopoServerRef{
 		Address:        address,
 		RootPath:       rootPath,
-		Implementation: "etcd",
+		Implementation: implementation,
 	}, nil
 }
 


### PR DESCRIPTION
getGlobalTopoRef hardcoded Implementation to "etcd" regardless of whether the user configured an external topology backend.

- Read External.Implementation from the resolved spec when an external topo server is configured in reconcile_global.go
- Default to "etcd" when using a managed etcd backend or when no explicit implementation is specified

Enables external (non-etcd) topology backends to work correctly with the data-handler controllers.