### PR TITLE
fix(resolver): restore DeepCopy on cache-hit return

### DIFF
--- a/pkg/resolver/cluster.go
+++ b/pkg/resolver/cluster.go
@@ -260,7 +260,7 @@ func (r *Resolver) ResolveCoreTemplate(
 
 	// Check cache first
 	if cached, found := r.CoreTemplateCache[string(resolvedName)]; found {
-		return cached, nil
+		return cached.DeepCopy(), nil
 	}
 
 	// 2. Fetch

--- a/pkg/resolver/shard.go
+++ b/pkg/resolver/shard.go
@@ -87,7 +87,7 @@ func (r *Resolver) ResolveShardTemplate(
 
 	// Check cache first
 	if cached, found := r.ShardTemplateCache[string(resolvedName)]; found {
-		return cached, nil
+		return cached.DeepCopy(), nil
 	}
 
 	// 2. Fetch


### PR DESCRIPTION
Commit 5c509ba accidentally dropped .DeepCopy() from the cache-hit return path in ResolveShardTemplate and ResolveCoreTemplate while exporting cache fields for per-request isolation. ResolveCellTemplate was unaffected because its diff was a simple field rename.

Without DeepCopy, any caller mutating the returned template would silently corrupt the cache, causing all subsequent resolutions within the same request scope to use corrupted data.

- Add cached.DeepCopy() to cache-hit returns in shard.go and cluster.go, matching the existing pattern in cell.go
- Add reverse-direction cache corruption tests for all three template types: mutate a cached result, resolve again, and verify the cache is not polluted

Prevents latent cache corruption and ensures future refactors cannot regress template isolation.