### PR TITLE
fix(tracing): propagate child span context in updateStatus

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -170,7 +170,7 @@ func (r *MultigresClusterReconciler) Reconcile(
 	}
 
 	{
-		_, childSpan := monitoring.StartChildSpan(ctx, "MultigresCluster.UpdateStatus")
+		ctx, childSpan := monitoring.StartChildSpan(ctx, "MultigresCluster.UpdateStatus")
 		if err := r.updateStatus(ctx, cluster); err != nil {
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()


### PR DESCRIPTION
The UpdateStatus tracing block discarded the child context returned by StartChildSpan, passing the parent context to updateStatus instead. This caused the internal List and Patch calls to appear as orphaned siblings rather than children of the UpdateStatus span.

- Change _ to ctx in the UpdateStatus span block in multigrescluster_controller.go, matching the pattern used by all three preceding blocks

Fixes broken span parenting for status updates in traces.