### PR TITLE
docs: fix inaccurate sample references

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,13 @@ We provide a set of samples to get you started quickly:
 
 | Sample | Description |
 | :--- | :--- |
-| `config/samples/minimal.yaml` | A minimal startup cluster for testing. |
-| `config/samples/templated-cluster.yaml` | A full cluster example using templates. |
-| `config/samples/standard-templates.yaml` | Examples of Core, Cell, and Shard templates. |
+| `config/samples/minimal.yaml` | The simplest possible cluster, relying entirely on system defaults. |
+| `config/samples/templated-cluster.yaml` | A full cluster example using reusable templates. |
+| `config/samples/templates/` | Individual `CoreTemplate`, `CellTemplate`, and `ShardTemplate` examples. |
+| `config/samples/default-templates/` | Namespace-level default templates (named `default`). |
+| `config/samples/overrides.yaml` | Advanced usage showing how to override specific fields on top of templates. |
+| `config/samples/no-templates.yaml` | A verbose example where all configuration is defined inline. |
+| `config/samples/external-etcd.yaml` | Connecting to an existing external Etcd cluster. |
 
 To apply a sample:
 ```bash

--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -7,7 +7,7 @@ This directory contains various sample configurations to help you understand how
 | `minimal.yaml` | The simplest possible cluster. Relies entirely on system defaults. |
 | `templated-cluster.yaml` | Demonstrates how to use reusable `Templates` for configuration. |
 | `overrides.yaml` | Advanced usage showing how to patch/override specific fields on top of templates. |
-| `standard-templates.yaml` | A collection of recommended `CoreTemplate`, `CellTemplate`, and `ShardTemplate` specs (in one file). |
+| `templates/` | A directory containing recommended `CoreTemplate`, `CellTemplate`, and `ShardTemplate` specs as individual files. |
 | `default-templates/` | A directory containing individual default files (`cell.yaml`, `core.yaml`, `shard.yaml`). |
 | `external-etcd.yaml` | Demonstrates connecting to an existing external Etcd cluster instead of deploying one. |
 | `no-templates.yaml` | A verbose example where all configuration is defined inline (no templates used). |
@@ -43,7 +43,7 @@ The operator's Webhook and Controller inject standard defaults for all missing c
 ## 2. Templated Cluster (`templated-cluster.yaml`)
 This sample demonstrates the **Template System**. Instead of defining specs inline, you point to reusable templates.
 
-**Prerequisite:** Apply `standard-templates.yaml` first.
+**Prerequisite:** Apply the templates first: `kubectl apply -f config/samples/templates/`
 
 **Input:**
 ```yaml


### PR DESCRIPTION
The README and samples README referenced a nonexistent file standard-templates.yaml, and the main README was missing several available sample configurations.

- Replace standard-templates.yaml with templates/ directory in both README.md and config/samples/README.md
- Add missing samples to main README table: default-templates/, overrides.yaml, no-templates.yaml, external-etcd.yaml
- Update templated-cluster prerequisite command in samples README

Ensures documentation accurately reflects the actual sample files available in the repository.