### PR TITLE
feat(probes): add health probes to all data plane components

### DIFF
--- a/pkg/resource-handler/controller/cell/integration_test.go
+++ b/pkg/resource-handler/controller/cell/integration_test.go
@@ -125,6 +125,26 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 15432),
 										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15100),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15100),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
 									},
 								},
 							},
@@ -212,6 +232,26 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 15432),
 										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15100),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15100),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
 									},
 								},
 							},
@@ -298,6 +338,26 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 15432),
+										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15100),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15100),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
 										},
 									},
 								},
@@ -403,6 +463,26 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 15432),
 										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15100),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15100),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
 									},
 								},
 								Affinity: &corev1.Affinity{
@@ -463,6 +543,7 @@ func TestCellReconciliation(t *testing.T) {
 					testutil.IgnoreServiceRuntimeFields(),
 					testutil.IgnoreDeploymentRuntimeFields(),
 					testutil.IgnorePodSpecDefaults(),
+					testutil.IgnoreProbeDefaults(),
 					testutil.IgnoreDeploymentSpecDefaults(),
 				),
 				testutil.WithExtraResource(&multigresv1alpha1.Cell{}),

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -133,6 +133,26 @@ func BuildMultiGatewayDeployment(
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/live",
+										Port: intstr.FromInt32(MultiGatewayHTTPPort),
+									},
+								},
+								InitialDelaySeconds: 60,
+								PeriodSeconds:       10,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/ready",
+										Port: intstr.FromInt32(MultiGatewayHTTPPort),
+									},
+								},
+								InitialDelaySeconds: 60,
+								PeriodSeconds:       10,
+							},
 						},
 					},
 					Affinity: cell.Spec.MultiGateway.Affinity,

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -116,6 +116,26 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/live",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/ready",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
 								},
 							},
 						},
@@ -216,6 +236,26 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/live",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/ready",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
 								},
 							},
 						},
@@ -315,6 +355,26 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											ContainerPort: MultiGatewayPostgresPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/live",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/ready",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
 									},
 								},
 							},
@@ -431,6 +491,26 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											ContainerPort: MultiGatewayPostgresPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/live",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/ready",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
 									},
 								},
 							},
@@ -567,6 +647,26 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/live",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/ready",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
 								},
 							},
 						},
@@ -669,6 +769,26 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											ContainerPort: MultiGatewayPostgresPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/live",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/ready",
+												Port: intstr.FromInt32(MultiGatewayHTTPPort),
+											},
+										},
+										InitialDelaySeconds: 60,
+										PeriodSeconds:       10,
 									},
 								},
 							},

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -2,6 +2,7 @@ package shard
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
@@ -301,6 +302,26 @@ func buildMultiPoolerSidecar(
 			RunAsGroup:   ptr.To(int64(999)),
 			RunAsNonRoot: ptr.To(true),
 		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/live",
+					Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
+				},
+			},
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       10,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/ready",
+					Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
+				},
+			},
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       10,
+		},
 		Env: []corev1.EnvVar{
 			{
 				Name: "POD_NAME",
@@ -386,6 +407,26 @@ func buildMultiOrchContainer(shard *multigresv1alpha1.Shard, cellName string) co
 		Args:      args,
 		Ports:     buildMultiOrchContainerPorts(),
 		Resources: shard.Spec.MultiOrch.Resources,
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/live",
+					Port: intstr.FromInt32(DefaultMultiOrchHTTPPort),
+				},
+			},
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       10,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/ready",
+					Port: intstr.FromInt32(DefaultMultiOrchHTTPPort),
+				},
+			},
+			InitialDelaySeconds: 60,
+			PeriodSeconds:       10,
+		},
 	}
 	if envVars := multigresv1alpha1.BuildOTELEnvVars(shard.Spec.Observability); len(envVars) > 0 {
 		c.Env = append(c.Env, envVars...)

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
@@ -287,6 +288,26 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					RunAsGroup:   ptr.To(int64(999)),
 					RunAsNonRoot: ptr.To(true),
 				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/live",
+							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       10,
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/ready",
+							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       10,
+				},
 				Env: []corev1.EnvVar{
 					{
 						Name: "POD_NAME",
@@ -361,6 +382,26 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					RunAsUser:    ptr.To(int64(999)),
 					RunAsGroup:   ptr.To(int64(999)),
 					RunAsNonRoot: ptr.To(true),
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/live",
+							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       10,
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/ready",
+							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       10,
 				},
 				Env: []corev1.EnvVar{
 					{
@@ -454,6 +495,26 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					RunAsUser:    ptr.To(int64(999)),
 					RunAsGroup:   ptr.To(int64(999)),
 					RunAsNonRoot: ptr.To(true),
+				},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/live",
+							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       10,
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/ready",
+							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       10,
 				},
 				Env: []corev1.EnvVar{
 					{
@@ -565,6 +626,26 @@ func TestBuildMultiOrchContainer(t *testing.T) {
 				},
 				Ports:     buildMultiOrchContainerPorts(),
 				Resources: corev1.ResourceRequirements{},
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/live",
+							Port: intstr.FromInt32(DefaultMultiOrchHTTPPort),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       10,
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/ready",
+							Port: intstr.FromInt32(DefaultMultiOrchHTTPPort),
+						},
+					},
+					InitialDelaySeconds: 60,
+					PeriodSeconds:       10,
+				},
 			},
 		},
 	}

--- a/pkg/resource-handler/controller/shard/integration_test.go
+++ b/pkg/resource-handler/controller/shard/integration_test.go
@@ -139,6 +139,26 @@ func TestShardReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15300),
 											tcpPort(t, "grpc", 15370),
 										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
 									},
 								},
 							},
@@ -199,6 +219,26 @@ func TestShardReconciliation(t *testing.T) {
 										Ports: []corev1.ContainerPort{
 											tcpPort(t, "http", 15300),
 											tcpPort(t, "grpc", 15370),
+										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
 										},
 									},
 								},
@@ -288,6 +328,26 @@ func TestShardReconciliation(t *testing.T) {
 											RunAsUser:    ptr.To(int64(999)),
 											RunAsGroup:   ptr.To(int64(999)),
 											RunAsNonRoot: ptr.To(true),
+										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15200),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15200),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
 										},
 										Env: []corev1.EnvVar{
 											{
@@ -500,6 +560,26 @@ func TestShardReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15300),
 											tcpPort(t, "grpc", 15370),
 										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
 									},
 								},
 							},
@@ -576,6 +656,26 @@ func TestShardReconciliation(t *testing.T) {
 											RunAsUser:    ptr.To(int64(999)),
 											RunAsGroup:   ptr.To(int64(999)),
 											RunAsNonRoot: ptr.To(true),
+										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15200),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15200),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
 										},
 										Env: []corev1.EnvVar{
 											{
@@ -773,6 +873,26 @@ func TestShardReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15300),
 											tcpPort(t, "grpc", 15370),
 										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
 									},
 								},
 							},
@@ -833,6 +953,26 @@ func TestShardReconciliation(t *testing.T) {
 										Ports: []corev1.ContainerPort{
 											tcpPort(t, "http", 15300),
 											tcpPort(t, "grpc", 15370),
+										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15300),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
 										},
 									},
 								},
@@ -948,6 +1088,26 @@ func TestShardReconciliation(t *testing.T) {
 											RunAsUser:    ptr.To(int64(999)),
 											RunAsGroup:   ptr.To(int64(999)),
 											RunAsNonRoot: ptr.To(true),
+										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15200),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15200),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
 										},
 										Env: []corev1.EnvVar{
 											{
@@ -1138,6 +1298,26 @@ func TestShardReconciliation(t *testing.T) {
 											RunAsGroup:   ptr.To(int64(999)),
 											RunAsNonRoot: ptr.To(true),
 										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/live",
+													Port: intstr.FromInt32(15200),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path: "/ready",
+													Port: intstr.FromInt32(15200),
+												},
+											},
+											InitialDelaySeconds: 60,
+											PeriodSeconds:       10,
+										},
 										Env: []corev1.EnvVar{
 											{
 												Name: "POD_NAME",
@@ -1256,6 +1436,7 @@ func TestShardReconciliation(t *testing.T) {
 					testutil.IgnoreDeploymentRuntimeFields(),
 					testutil.IgnoreStatefulSetRuntimeFields(),
 					testutil.IgnorePodSpecDefaults(),
+					testutil.IgnoreProbeDefaults(),
 					testutil.IgnoreDeploymentSpecDefaults(),
 					testutil.IgnoreStatefulSetSpecDefaults(),
 				),

--- a/pkg/testutil/compare.go
+++ b/pkg/testutil/compare.go
@@ -178,6 +178,22 @@ func IgnoreDeploymentSpecDefaults() cmp.Option {
 	)
 }
 
+// IgnoreProbeDefaults ignores Probe and HTTPGetAction fields that are populated
+// with Kubernetes defaults by the API server, such as Scheme ("HTTP"),
+// TimeoutSeconds (1), SuccessThreshold (1), and FailureThreshold (3).
+func IgnoreProbeDefaults() cmp.Option {
+	return cmp.Options{
+		cmpopts.IgnoreFields(corev1.Probe{},
+			"TimeoutSeconds",   // Defaults to 1
+			"SuccessThreshold", // Defaults to 1
+			"FailureThreshold", // Defaults to 3
+		),
+		cmpopts.IgnoreFields(corev1.HTTPGetAction{},
+			"Scheme", // Defaults to "HTTP"
+		),
+	}
+}
+
 // filterByFieldName returns a filter function that checks if the last path element
 // is a struct field with the given name. Extracted for testability.
 func filterByFieldName(fieldName string) func(cmp.Path) bool {


### PR DESCRIPTION
Components (multigateway, multipooler, multiorch) had no liveness or readiness probes, causing Kubernetes to treat them as always healthy even when dependencies like the topo initialization wasn't done.

- Add HTTP liveness (/live) and readiness (/ready) probes to multigateway in multigateway.go on port 15100
- Add HTTP probes to multipooler in containers.go on port 15200
- Add HTTP probes to multiorch in containers.go on port 15300
- Set InitialDelaySeconds to 60 for both probe types to allow time for topo server and other dependencies to become available
- Add IgnoreProbeDefaults() helper to compare.go for ignoring API server-applied probe defaults (Scheme, TimeoutSeconds, etc.)
- Update all unit and integration test expectations to include the new probe configurations

Prevents premature container restarts and provides accurate readiness signaling during cluster bootstrap.