### PR TITLE
fix(controllers): add missing events and logs

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -103,6 +103,13 @@ func (r *MultigresClusterReconciler) Reconcile(
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
 			l.Error(err, "Failed to populate cluster defaults")
+			r.Recorder.Eventf(
+				cluster,
+				"Warning",
+				"FailedApply",
+				"Failed to populate cluster defaults: %v",
+				err,
+			)
 			return ctrl.Result{}, err
 		}
 		childSpan.End()
@@ -119,6 +126,13 @@ func (r *MultigresClusterReconciler) Reconcile(
 		cluster.Finalizers = append(cluster.Finalizers, finalizerName)
 		if err := r.Update(ctx, cluster); err != nil {
 			l.Error(err, "Failed to add finalizer")
+			r.Recorder.Eventf(
+				cluster,
+				"Warning",
+				"FinalizerFailed",
+				"Failed to add finalizer: %v",
+				err,
+			)
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -121,6 +121,7 @@ func (r *TableGroupReconciler) Reconcile(
 		"multigres.com/database":   string(tg.Spec.DatabaseName),
 		"multigres.com/tablegroup": string(tg.Spec.TableGroupName),
 	}); err != nil {
+		l.Error(err, "Failed to list shards for pruning")
 		r.Recorder.Eventf(
 			tg,
 			"Warning",
@@ -134,6 +135,7 @@ func (r *TableGroupReconciler) Reconcile(
 	for _, s := range existingShards.Items {
 		if !activeShardNames[s.Name] {
 			if err := r.Delete(ctx, &s); err != nil {
+				l.Error(err, "Failed to delete orphan shard", "shard", s.Name)
 				r.Recorder.Eventf(
 					tg,
 					"Warning",
@@ -162,6 +164,7 @@ func (r *TableGroupReconciler) Reconcile(
 		"multigres.com/database":   string(tg.Spec.DatabaseName),
 		"multigres.com/tablegroup": string(tg.Spec.TableGroupName),
 	}); err != nil {
+		l.Error(err, "Failed to list shards for status")
 		r.Recorder.Eventf(
 			tg,
 			"Warning",
@@ -257,6 +260,7 @@ func (r *TableGroupReconciler) Reconcile(
 		client.FieldOwner("multigres-operator"),
 		client.ForceOwnership,
 	); err != nil {
+		l.Error(err, "Failed to patch status")
 		r.Recorder.Eventf(tg, "Warning", "StatusError", "Failed to patch status: %v", err)
 		return ctrl.Result{}, fmt.Errorf("failed to patch status: %w", err)
 	}

--- a/pkg/data-handler/controller/cell/cell_controller.go
+++ b/pkg/data-handler/controller/cell/cell_controller.go
@@ -158,6 +158,13 @@ func (r *CellReconciler) handleDeletion(
 		})
 		if err := r.Update(ctx, cell); err != nil {
 			logger.Error(err, "Failed to remove finalizer")
+			r.Recorder.Eventf(
+				cell,
+				"Warning",
+				"FinalizerFailed",
+				"Failed to remove finalizer: %v",
+				err,
+			)
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/data-handler/controller/shard/shard_controller.go
+++ b/pkg/data-handler/controller/shard/shard_controller.go
@@ -150,6 +150,13 @@ func (r *ShardReconciler) handleDeletion(
 		})
 		if err := r.Update(ctx, shard); err != nil {
 			logger.Error(err, "Failed to remove finalizer")
+			r.Recorder.Eventf(
+				shard,
+				"Warning",
+				"FinalizerFailed",
+				"Failed to remove finalizer: %v",
+				err,
+			)
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -109,6 +109,7 @@ func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
 			logger.Error(err, "Failed to update status")
+			r.Recorder.Eventf(cell, "Warning", "StatusError", "Failed to update status: %v", err)
 			return ctrl.Result{}, err
 		}
 		childSpan.End()

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -84,6 +84,7 @@ func (r *ShardReconciler) Reconcile(
 		if err != nil {
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
+			logger.Error(err, "Failed to determine MultiOrch cells")
 			r.Recorder.Eventf(
 				shard,
 				"Warning",
@@ -161,6 +162,7 @@ func (r *ShardReconciler) Reconcile(
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
 			logger.Error(err, "Failed to update status")
+			r.Recorder.Eventf(shard, "Warning", "StatusError", "Failed to update status: %v", err)
 			return ctrl.Result{}, err
 		}
 		childSpan.End()

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller.go
@@ -131,6 +131,13 @@ func (r *TopoServerReconciler) Reconcile(
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
 			logger.Error(err, "Failed to update status")
+			r.Recorder.Eventf(
+				toposerver,
+				"Warning",
+				"StatusError",
+				"Failed to update status: %v",
+				err,
+			)
 			return ctrl.Result{}, err
 		}
 		childSpan.End()


### PR DESCRIPTION
Several controller error paths had inconsistent observability: some logged errors but didn't emit Kubernetes events (invisible to kubectl describe), others emitted events but skipped l.Error.

- Add r.Recorder.Eventf to PopulateDefaults and finalizer error paths in multigrescluster_controller.go
- Add l.Error to 4 error paths in tablegroup_controller.go that only had events (list/delete shards, patch status)
- Add r.Recorder.Eventf to updateStatus error paths in cell, shard, and toposerver resource-handler controllers
- Add r.Recorder.Eventf to remove-finalizer error paths in cell and shard data-handler controllers
- Add l.Error to getMultiOrchCells error path in shard resource-handler controller

Every reconcile error path now consistently emits both operator logs and user-facing Kubernetes events.