### PR TITLE
feat(shard): add postgres password Secret

### DIFF
--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -47,6 +47,7 @@ func TestBuildPostgresContainer(t *testing.T) {
 						Name:  "PGDATA",
 						Value: PgDataPath,
 					},
+					pgPasswordEnvVar(),
 				},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser:    ptr.To(int64(999)),
@@ -110,6 +111,7 @@ func TestBuildPostgresContainer(t *testing.T) {
 						Name:  "PGDATA",
 						Value: PgDataPath,
 					},
+					pgPasswordEnvVar(),
 				},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser:    ptr.To(int64(999)),
@@ -191,6 +193,7 @@ func TestBuildPostgresContainer(t *testing.T) {
 						Name:  "PGDATA",
 						Value: PgDataPath,
 					},
+					pgPasswordEnvVar(),
 				},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser:    ptr.To(int64(999)),
@@ -279,6 +282,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					"--service-id=$(POD_NAME)",
 					"--pgctld-addr=localhost:15470",
 					"--pg-port=5432",
+					"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
 				},
 				Ports:         buildMultiPoolerContainerPorts(),
 				Resources:     corev1.ResourceRequirements{},
@@ -325,6 +329,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 							},
 						},
 					},
+					connpoolAdminPasswordEnvVar(),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -382,6 +387,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					"--service-id=$(POD_NAME)",
 					"--pgctld-addr=localhost:15470",
 					"--pg-port=5432",
+					"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
 				},
 				Ports:         buildMultiPoolerContainerPorts(),
 				Resources:     corev1.ResourceRequirements{},
@@ -428,6 +434,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 							},
 						},
 					},
+					connpoolAdminPasswordEnvVar(),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -494,6 +501,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					"--service-id=$(POD_NAME)",
 					"--pgctld-addr=localhost:15470",
 					"--pg-port=5432",
+					"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
 				},
 				Ports: buildMultiPoolerContainerPorts(),
 				Resources: corev1.ResourceRequirements{
@@ -549,6 +557,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 							},
 						},
 					},
+					connpoolAdminPasswordEnvVar(),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{

--- a/pkg/resource-handler/controller/shard/integration_test.go
+++ b/pkg/resource-handler/controller/shard/integration_test.go
@@ -337,6 +337,7 @@ func TestShardReconciliation(t *testing.T) {
 											"--service-id=$(POD_NAME)",
 											"--pgctld-addr=localhost:15470",
 											"--pg-port=5432",
+											"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
 										},
 										Ports:         multipoolerPorts(t),
 										RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
@@ -383,6 +384,17 @@ func TestShardReconciliation(t *testing.T) {
 													},
 												},
 											},
+											{
+												Name: "CONNPOOL_ADMIN_PASSWORD",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: shardcontroller.PostgresPasswordSecretName,
+														},
+														Key: shardcontroller.PostgresPasswordSecretKey,
+													},
+												},
+											},
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: "pgdata", MountPath: "/var/lib/pooler"},
@@ -411,6 +423,17 @@ func TestShardReconciliation(t *testing.T) {
 										},
 										Env: []corev1.EnvVar{
 											{Name: "PGDATA", Value: "/var/lib/pooler/pg_data"},
+											{
+												Name: "PGPASSWORD",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: shardcontroller.PostgresPasswordSecretName,
+														},
+														Key: shardcontroller.PostgresPasswordSecretKey,
+													},
+												},
+											},
 										},
 										SecurityContext: &corev1.SecurityContext{
 											RunAsUser:    ptr.To(int64(999)),
@@ -681,6 +704,7 @@ func TestShardReconciliation(t *testing.T) {
 											"--service-id=$(POD_NAME)",
 											"--pgctld-addr=localhost:15470",
 											"--pg-port=5432",
+											"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
 										},
 										Ports:         multipoolerPorts(t),
 										RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
@@ -727,6 +751,17 @@ func TestShardReconciliation(t *testing.T) {
 													},
 												},
 											},
+											{
+												Name: "CONNPOOL_ADMIN_PASSWORD",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: shardcontroller.PostgresPasswordSecretName,
+														},
+														Key: shardcontroller.PostgresPasswordSecretKey,
+													},
+												},
+											},
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: "pgdata", MountPath: "/var/lib/pooler"},
@@ -755,6 +790,17 @@ func TestShardReconciliation(t *testing.T) {
 										},
 										Env: []corev1.EnvVar{
 											{Name: "PGDATA", Value: "/var/lib/pooler/pg_data"},
+											{
+												Name: "PGPASSWORD",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: shardcontroller.PostgresPasswordSecretName,
+														},
+														Key: shardcontroller.PostgresPasswordSecretKey,
+													},
+												},
+											},
 										},
 										SecurityContext: &corev1.SecurityContext{
 											RunAsUser:    ptr.To(int64(999)),
@@ -1133,6 +1179,7 @@ func TestShardReconciliation(t *testing.T) {
 											"--service-id=$(POD_NAME)",
 											"--pgctld-addr=localhost:15470",
 											"--pg-port=5432",
+											"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
 										},
 										Ports: []corev1.ContainerPort{
 											tcpPort(t, "http", 15200),
@@ -1183,6 +1230,17 @@ func TestShardReconciliation(t *testing.T) {
 													},
 												},
 											},
+											{
+												Name: "CONNPOOL_ADMIN_PASSWORD",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: shardcontroller.PostgresPasswordSecretName,
+														},
+														Key: shardcontroller.PostgresPasswordSecretKey,
+													},
+												},
+											},
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: "pgdata", MountPath: "/var/lib/pooler"},
@@ -1211,6 +1269,17 @@ func TestShardReconciliation(t *testing.T) {
 										},
 										Env: []corev1.EnvVar{
 											{Name: "PGDATA", Value: "/var/lib/pooler/pg_data"},
+											{
+												Name: "PGPASSWORD",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: shardcontroller.PostgresPasswordSecretName,
+														},
+														Key: shardcontroller.PostgresPasswordSecretKey,
+													},
+												},
+											},
 										},
 										SecurityContext: &corev1.SecurityContext{
 											RunAsUser:    ptr.To(int64(999)),
@@ -1350,6 +1419,7 @@ func TestShardReconciliation(t *testing.T) {
 											"--service-id=$(POD_NAME)",
 											"--pgctld-addr=localhost:15470",
 											"--pg-port=5432",
+											"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
 										},
 										Ports: []corev1.ContainerPort{
 											tcpPort(t, "http", 15200),
@@ -1400,6 +1470,17 @@ func TestShardReconciliation(t *testing.T) {
 													},
 												},
 											},
+											{
+												Name: "CONNPOOL_ADMIN_PASSWORD",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: shardcontroller.PostgresPasswordSecretName,
+														},
+														Key: shardcontroller.PostgresPasswordSecretKey,
+													},
+												},
+											},
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: "pgdata", MountPath: "/var/lib/pooler"},
@@ -1428,6 +1509,17 @@ func TestShardReconciliation(t *testing.T) {
 										},
 										Env: []corev1.EnvVar{
 											{Name: "PGDATA", Value: "/var/lib/pooler/pg_data"},
+											{
+												Name: "PGPASSWORD",
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: shardcontroller.PostgresPasswordSecretName,
+														},
+														Key: shardcontroller.PostgresPasswordSecretKey,
+													},
+												},
+											},
 										},
 										SecurityContext: &corev1.SecurityContext{
 											RunAsUser:    ptr.To(int64(999)),

--- a/pkg/resource-handler/controller/shard/pool_statefulset_test.go
+++ b/pkg/resource-handler/controller/shard/pool_statefulset_test.go
@@ -157,6 +157,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 											Name:  "PGDATA",
 											Value: "/var/lib/pooler/pg_data",
 										},
+										pgPasswordEnvVar(),
 									},
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser:    ptr.To(int64(999)),
@@ -369,6 +370,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 											Name:  "PGDATA",
 											Value: "/var/lib/pooler/pg_data",
 										},
+										pgPasswordEnvVar(),
 									},
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser:    ptr.To(int64(999)),
@@ -574,6 +576,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 											Name:  "PGDATA",
 											Value: "/var/lib/pooler/pg_data",
 										},
+										pgPasswordEnvVar(),
 									},
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser:    ptr.To(int64(999)),
@@ -814,6 +817,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 											Name:  "PGDATA",
 											Value: "/var/lib/pooler/pg_data",
 										},
+										pgPasswordEnvVar(),
 									},
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser:    ptr.To(int64(999)),

--- a/pkg/resource-handler/controller/shard/secret.go
+++ b/pkg/resource-handler/controller/shard/secret.go
@@ -1,0 +1,47 @@
+package shard
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
+)
+
+// DefaultPostgresPassword is the default password for the PostgreSQL
+// superuser during v1alpha1. Future versions will support user-supplied
+// or auto-generated credentials.
+const DefaultPostgresPassword = "postgres"
+
+// BuildPostgresPasswordSecret creates a Secret containing the PostgreSQL
+// superuser password. Both pgctld (via PGPASSWORD env var) and multipooler
+// (via --connpool-admin-password) source credentials from this Secret.
+func BuildPostgresPasswordSecret(
+	shard *multigresv1alpha1.Shard,
+	scheme *runtime.Scheme,
+) (*corev1.Secret, error) {
+	clusterName := shard.Labels["multigres.com/cluster"]
+	labels := metadata.BuildStandardLabels(clusterName, "postgres-password")
+	labels = metadata.MergeLabels(labels, shard.GetObjectMeta().GetLabels())
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PostgresPasswordSecretName,
+			Namespace: shard.Namespace,
+			Labels:    labels,
+		},
+		Data: map[string][]byte{
+			PostgresPasswordSecretKey: []byte(DefaultPostgresPassword),
+		},
+	}
+
+	if err := ctrl.SetControllerReference(shard, secret, scheme); err != nil {
+		return nil, fmt.Errorf("failed to set controller reference: %w", err)
+	}
+
+	return secret, nil
+}

--- a/pkg/resource-handler/controller/shard/secret_test.go
+++ b/pkg/resource-handler/controller/shard/secret_test.go
@@ -1,0 +1,94 @@
+package shard
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
+)
+
+func TestBuildPostgresPasswordSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	tests := map[string]struct {
+		shard   *multigresv1alpha1.Shard
+		scheme  *runtime.Scheme
+		want    *corev1.Secret
+		wantErr bool
+	}{
+		"builds secret with correct metadata and data": {
+			shard: &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shard",
+					Namespace: "default",
+					UID:       "test-uid",
+					Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+				},
+			},
+			scheme: scheme,
+			want: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      PostgresPasswordSecretName,
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "multigres",
+						"app.kubernetes.io/instance":   "test-cluster",
+						"app.kubernetes.io/component":  "postgres-password",
+						"app.kubernetes.io/part-of":    "multigres",
+						"app.kubernetes.io/managed-by": "multigres-operator",
+						"multigres.com/cluster":        "test-cluster",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "multigres.com/v1alpha1",
+							Kind:               "Shard",
+							Name:               "test-shard",
+							UID:                "test-uid",
+							Controller:         ptr.To(true),
+							BlockOwnerDeletion: ptr.To(true),
+						},
+					},
+				},
+				Data: map[string][]byte{
+					PostgresPasswordSecretKey: []byte(DefaultPostgresPassword),
+				},
+			},
+		},
+		"error with empty scheme": {
+			shard: &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-shard",
+					Namespace: "default",
+					UID:       "test-uid",
+					Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+				},
+			},
+			scheme:  runtime.NewScheme(),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := BuildPostgresPasswordSecret(tc.shard, tc.scheme)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("BuildPostgresPasswordSecret() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
pgctld initialized PostgreSQL without a superuser password because the operator never provided one. This caused multipooler to return an empty SCRAM hash, making multigateway reject all connections with "password authentication failed".

- Add secret.go with BuildPostgresPasswordSecret using a hardcoded default password for v1alpha1
- Inject PGPASSWORD env var into pgctld containers via secretKeyRef
- Add --connpool-admin-password flag and CONNPOOL_ADMIN_PASSWORD env var to multipooler sidecar
- Add reconcilePostgresPasswordSecret to shard controller with Server Side Apply
- Register Secret ownership in SetupWithManager
- Add secret_test.go and update containers_test.go, pool_statefulset_test.go, and integration_test.go

Hardcoding "postgres" as the password matches the upstream local provisioner. In a future phase, this will be sourced from the MultigresCluster spec or generated randomly.

Enables end-to-end PostgreSQL authentication through multigateway on fresh cluster initialization.