### PR TITLE
fix(data-handler): add grace period for topology unavailable errors during startup

### DIFF
--- a/config/monitoring/grafana-dashboard-data-plane.json
+++ b/config/monitoring/grafana-dashboard-data-plane.json
@@ -65,7 +65,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (http_response_status_code, http_request_method) (histogram_count(rate(http_server_request_duration_seconds{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
+          "expr": "sum by (http_response_status_code, http_request_method) (rate(http_server_request_duration_seconds_count{job=~\"multigateway|multiadmin\"}[$__rate_interval]))",
           "legendFormat": "{{http_request_method}} [{{http_response_status_code}}]",
           "range": true,
           "refId": "A"
@@ -101,7 +101,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (http_request_method) (rate(http_server_request_duration_seconds{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (http_request_method, le) (rate(http_server_request_duration_seconds_bucket{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
           "legendFormat": "p95 - {{http_request_method}}",
           "range": true,
           "refId": "A"
@@ -113,7 +113,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (http_request_method) (rate(http_server_request_duration_seconds{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (http_request_method, le) (rate(http_server_request_duration_seconds_bucket{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
           "legendFormat": "p50 - {{http_request_method}}",
           "range": true,
           "refId": "B"
@@ -149,7 +149,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (rate(rpc_client_duration_milliseconds_count{job=~\"multigateway|multiadmin\"}[$__rate_interval]))",
           "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
@@ -185,7 +185,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=~\"multigateway|multiadmin\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=~\"multigateway|multiadmin\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "A"
@@ -197,7 +197,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=~\"multigateway|multiadmin\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=~\"multigateway|multiadmin\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "B"
@@ -246,7 +246,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval])))",
+          "expr": "sum by (rpc_method, rpc_grpc_status_code) (rate(rpc_server_duration_milliseconds_count{job=\"multipooler\"}[$__rate_interval]))",
           "legendFormat": "{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
@@ -282,7 +282,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (rpc_method) (rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.95, sum by (rpc_method, le) (rate(rpc_server_duration_milliseconds_bucket{job=\"multipooler\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p95 - {{rpc_method}}",
           "range": true,
           "refId": "A"
@@ -294,7 +294,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (rpc_method) (rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.50, sum by (rpc_method, le) (rate(rpc_server_duration_milliseconds_bucket{job=\"multipooler\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p50 - {{rpc_method}}",
           "range": true,
           "refId": "B"
@@ -330,7 +330,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval])))",
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (rate(rpc_client_duration_milliseconds_count{job=\"multipooler\"}[$__rate_interval]))",
           "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
@@ -366,7 +366,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=\"multipooler\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "A"
@@ -378,7 +378,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=\"multipooler\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "B"
@@ -537,7 +537,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (path) (rate(rpcclient_connection_dial_duration_seconds[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (path, le) (rate(rpcclient_connection_dial_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "p95 - {{path}}",
           "range": true,
           "refId": "A"
@@ -549,7 +549,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (path) (rate(rpcclient_connection_dial_duration_seconds[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (path, le) (rate(rpcclient_connection_dial_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "p50 - {{path}}",
           "range": true,
           "refId": "B"
@@ -598,7 +598,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (rate(rpc_client_duration_milliseconds_count{job=\"multiorch\"}[$__rate_interval]))",
           "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
@@ -634,7 +634,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=\"multiorch\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "A"
@@ -646,7 +646,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=\"multiorch\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "B"
@@ -682,7 +682,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (action, status) (histogram_count(rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "sum by (action, status) (rate(multiorch_recovery_action_duration_milliseconds_count{job=\"multiorch\"}[$__rate_interval]))",
           "legendFormat": "{{action}} [{{status}}]",
           "range": true,
           "refId": "A"
@@ -718,7 +718,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (action) (rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (action, le) (rate(multiorch_recovery_action_duration_milliseconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p95 - {{action}}",
           "range": true,
           "refId": "A"
@@ -730,7 +730,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (action) (rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (action, le) (rate(multiorch_recovery_action_duration_milliseconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p50 - {{action}}",
           "range": true,
           "refId": "B"
@@ -801,7 +801,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (db_namespace, status) (rate(multiorch_recovery_pooler_poll_duration_seconds{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (db_namespace, status, le) (rate(multiorch_recovery_pooler_poll_duration_seconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p95 - {{db_namespace}} [{{status}}]",
           "range": true,
           "refId": "A"
@@ -813,7 +813,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (db_namespace, status) (rate(multiorch_recovery_pooler_poll_duration_seconds{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (db_namespace, status, le) (rate(multiorch_recovery_pooler_poll_duration_seconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p50 - {{db_namespace}} [{{status}}]",
           "range": true,
           "refId": "B"
@@ -909,7 +909,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds{job=\"multiorch\"}[$__rate_interval]))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p95",
           "range": true,
           "refId": "A"
@@ -921,7 +921,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds{job=\"multiorch\"}[$__rate_interval]))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p50",
           "range": true,
           "refId": "B"
@@ -970,7 +970,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (operation, result, resource_type) (histogram_count(rate(topoclient_lock_duration_seconds[$__rate_interval])))",
+          "expr": "sum by (operation, result, resource_type) (rate(topoclient_lock_duration_seconds_count[$__rate_interval]))",
           "legendFormat": "{{operation}} on {{resource_type}} [{{result}}]",
           "range": true,
           "refId": "A"
@@ -1023,7 +1023,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (operation, resource_type) (rate(topoclient_lock_duration_seconds[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (operation, resource_type, le) (rate(topoclient_lock_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "p95 - {{operation}} on {{resource_type}}",
           "range": true,
           "refId": "A"
@@ -1035,7 +1035,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (operation, resource_type) (rate(topoclient_lock_duration_seconds[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (operation, resource_type, le) (rate(topoclient_lock_duration_seconds_bucket[$__rate_interval])))",
           "legendFormat": "p50 - {{operation}} on {{resource_type}}",
           "range": true,
           "refId": "B"

--- a/pkg/data-handler/controller/cell/cell_controller.go
+++ b/pkg/data-handler/controller/cell/cell_controller.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/pb/clustermetadata"
+	"go.opentelemetry.io/otel/attribute"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -24,6 +26,16 @@ import (
 
 const (
 	finalizerName = "cell.data-handler.multigres.com/finalizer"
+
+	// topoUnavailableGracePeriod is the duration after resource creation during
+	// which topology UNAVAILABLE errors are silently requeued instead of being
+	// reported as reconcile errors. This prevents noisy error metrics during
+	// normal cluster startup while the toposerver is still initializing.
+	topoUnavailableGracePeriod = 2 * time.Minute
+
+	// topoUnavailableRequeueDelay is the delay before retrying when the topology
+	// server is unavailable during the grace period.
+	topoUnavailableRequeueDelay = 5 * time.Second
 )
 
 // CellReconciler reconciles Cell data plane operations.
@@ -110,6 +122,26 @@ func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	{
 		_, childSpan := monitoring.StartChildSpan(ctx, "CellData.RegisterCellInTopology")
 		if err := r.registerCellInTopology(ctx, cell); err != nil {
+			// During cluster startup the toposerver may not be ready yet.
+			// Silently requeue during the grace period to avoid noisy error metrics.
+			resourceAge := time.Since(cell.CreationTimestamp.Time)
+			if isTopoUnavailable(err) && resourceAge < topoUnavailableGracePeriod {
+				childSpan.SetAttributes(attribute.Bool("topo.unavailable_grace", true))
+				childSpan.End()
+				logger.V(1).Info("Topology server not available yet, requeueing",
+					"resourceAge", resourceAge.Round(time.Second).String(),
+					"gracePeriod", topoUnavailableGracePeriod.String(),
+				)
+				r.Recorder.Eventf(
+					cell,
+					"Normal",
+					"TopologyWaiting",
+					"Topology server not available yet (age %s), will retry",
+					resourceAge.Round(time.Second),
+				)
+				return ctrl.Result{RequeueAfter: topoUnavailableRequeueDelay}, nil
+			}
+
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
 			r.Recorder.Eventf(
@@ -307,6 +339,17 @@ func (r *CellReconciler) SetCreateTopoStore(
 	f func(*multigresv1alpha1.Cell) (topoclient.Store, error),
 ) {
 	r.createTopoStore = f
+}
+
+// isTopoUnavailable returns true if the error indicates the topology server
+// is not reachable (e.g., gRPC UNAVAILABLE during startup).
+func isTopoUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNAVAILABLE") ||
+		strings.Contains(msg, "no connection available")
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/data-handler/controller/cell/cell_controller_internal_test.go
+++ b/pkg/data-handler/controller/cell/cell_controller_internal_test.go
@@ -2,6 +2,7 @@ package cell
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -596,4 +597,27 @@ func (m *mockTopoStoreWrapper) DeleteCell(ctx context.Context, cellName string, 
 		return m.deleteCellFunc(ctx, cellName, force)
 	}
 	return m.Store.DeleteCell(ctx, cellName, force)
+}
+
+func TestIsTopoUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"nil error":           {err: nil, want: false},
+		"UNAVAILABLE error":   {err: errors.New("Code: UNAVAILABLE"), want: true},
+		"no connection error": {err: errors.New("no connection available"), want: true},
+		"unrelated error":     {err: errors.New("permission denied"), want: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTopoUnavailable(tc.err); got != tc.want {
+				t.Errorf("isTopoUnavailable(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
During normal cluster startup, the cell and shard data handler controllers attempt to register in the topology server before it is fully ready, producing ~50 UNAVAILABLE errors that increment reconcile_errors_total. These errors are harmless (controller-runtime's backoff retries until success) but they pollute the Grafana Operator Overview dashboard and logs, making it difficult to distinguish real outages from startup noise.

This adds a 2-minute grace period based on the resource's CreationTimestamp. During the grace period, UNAVAILABLE topology errors are silently requeued with a 5-second delay instead of being returned as reconcile errors. After the grace period, they escalate normally.

Observability during the grace period:
- Normal/TopologyWaiting event on the resource (visible via kubectl describe)
- V(1) log entry with resourceAge and gracePeriod
- Span attribute topo.unavailable_grace=true (visible in Tempo)
- No reconcile_errors_total increment (clean dashboard)

Changes:
- cell_controller.go: grace period logic, isTopoUnavailable helper
- shard_controller.go: same grace period logic and helper
- cell_controller_test.go: two new test cases (within/past grace period), wantRequeue field, updated existing error test with old CreationTimestamp
- shard_controller_test.go: same test updates as cell
- cell_controller_internal_test.go: TestIsTopoUnavailable table test
- shard_controller_internal_test.go: same + old CreationTimestamp on TestReconcile_ErrorRegisteringDatabase

Also converts 27 PromQL queries in grafana-dashboard-data-plane.json from native histogram syntax to classic histogram syntax. The OTLP pipeline currently stores metrics as classic explicit-bucket histograms, so queries using histogram_count/histogram_quantile on native histograms return no data. These dashboard changes may be reverted if native histogram support is implemented upstream (multigres/multigres#620).