### PR TITLE
feat(observability): add native histogram support

### DIFF
--- a/api/v1alpha1/observability_helpers.go
+++ b/api/v1alpha1/observability_helpers.go
@@ -56,7 +56,7 @@ func BuildOTELEnvVars(cfg *ObservabilityConfig) []corev1.EnvVar {
 		}
 	}
 
-	var proto, traces, metrics, logs, interval, temporality, sampler string
+	var proto, traces, metrics, logs, interval, temporality, histogramAgg, sampler string
 	if cfg != nil {
 		proto = cfg.OTLPProtocol
 		traces = cfg.TracesExporter
@@ -64,6 +64,7 @@ func BuildOTELEnvVars(cfg *ObservabilityConfig) []corev1.EnvVar {
 		logs = cfg.LogsExporter
 		interval = cfg.MetricExportInterval
 		temporality = cfg.MetricsTemporality
+		histogramAgg = cfg.HistogramAggregation
 		sampler = cfg.TracesSampler
 	}
 
@@ -76,6 +77,11 @@ func BuildOTELEnvVars(cfg *ObservabilityConfig) []corev1.EnvVar {
 		"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
 		temporality,
 		"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
+	)
+	appendIfSet(
+		"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION",
+		histogramAgg,
+		"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION",
 	)
 	appendIfSet("OTEL_TRACES_SAMPLER", sampler, "OTEL_TRACES_SAMPLER")
 

--- a/api/v1alpha1/observability_helpers_test.go
+++ b/api/v1alpha1/observability_helpers_test.go
@@ -32,6 +32,7 @@ func TestBuildOTELEnvVars(t *testing.T) {
 		"OTEL_LOGS_EXPORTER",
 		"OTEL_METRIC_EXPORT_INTERVAL",
 		"OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE",
+		"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION",
 		"OTEL_TRACES_SAMPLER",
 	}
 	for _, env := range otelEnvVars {
@@ -71,6 +72,7 @@ func TestBuildOTELEnvVars(t *testing.T) {
 				LogsExporter:         "otlp",
 				MetricExportInterval: "30s",
 				MetricsTemporality:   "cumulative",
+				HistogramAggregation: "base2_exponential_bucket_histogram",
 				TracesSampler:        "always_on",
 			},
 			want: []corev1.EnvVar{
@@ -81,6 +83,10 @@ func TestBuildOTELEnvVars(t *testing.T) {
 				{Name: "OTEL_LOGS_EXPORTER", Value: "otlp"},
 				{Name: "OTEL_METRIC_EXPORT_INTERVAL", Value: "30s"},
 				{Name: "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", Value: "cumulative"},
+				{
+					Name:  "OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION",
+					Value: "base2_exponential_bucket_histogram",
+				},
 				{Name: "OTEL_TRACES_SAMPLER", Value: "always_on"},
 			},
 		},

--- a/api/v1alpha1/observability_types.go
+++ b/api/v1alpha1/observability_types.go
@@ -67,6 +67,14 @@ type ObservabilityConfig struct {
 	// +kubebuilder:validation:Enum=cumulative;delta
 	MetricsTemporality string `json:"metricsTemporality,omitempty"`
 
+	// HistogramAggregation selects the default histogram aggregation.
+	// Maps to OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION.
+	// Use "base2_exponential_bucket_histogram" for native/exponential histograms
+	// which are more compact and accurate than explicit bucket histograms.
+	// +optional
+	// +kubebuilder:validation:Enum=base2_exponential_bucket_histogram;explicit_bucket_histogram
+	HistogramAggregation string `json:"histogramAggregation,omitempty"`
+
 	// TracesSampler selects the sampler.
 	// Maps to OTEL_TRACES_SAMPLER.
 	// Standard values: always_on, always_off, parentbased_traceidratio.

--- a/config/crd/bases/multigres.com_cells.yaml
+++ b/config/crd/bases/multigres.com_cells.yaml
@@ -1139,6 +1139,16 @@ spec:
                   Observability configures OpenTelemetry for cell-level data-plane components.
                   Inherited from MultigresCluster.Spec.Observability by the resolver.
                 properties:
+                  histogramAggregation:
+                    description: |-
+                      HistogramAggregation selects the default histogram aggregation.
+                      Maps to OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION.
+                      Use "base2_exponential_bucket_histogram" for native/exponential histograms
+                      which are more compact and accurate than explicit bucket histograms.
+                    enum:
+                    - base2_exponential_bucket_histogram
+                    - explicit_bucket_histogram
+                    type: string
                   logsExporter:
                     description: |-
                       LogsExporter selects the logs exporter.

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -9470,6 +9470,16 @@ spec:
                   When nil, data-plane pods inherit the operator's own OTEL environment
                   variables at reconcile time. Set fields to override or disable.
                 properties:
+                  histogramAggregation:
+                    description: |-
+                      HistogramAggregation selects the default histogram aggregation.
+                      Maps to OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION.
+                      Use "base2_exponential_bucket_histogram" for native/exponential histograms
+                      which are more compact and accurate than explicit bucket histograms.
+                    enum:
+                    - base2_exponential_bucket_histogram
+                    - explicit_bucket_histogram
+                    type: string
                   logsExporter:
                     description: |-
                       LogsExporter selects the logs exporter.

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -1155,6 +1155,16 @@ spec:
                   Observability configures OpenTelemetry for shard-level data-plane components.
                   Inherited from MultigresCluster.Spec.Observability by the resolver.
                 properties:
+                  histogramAggregation:
+                    description: |-
+                      HistogramAggregation selects the default histogram aggregation.
+                      Maps to OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION.
+                      Use "base2_exponential_bucket_histogram" for native/exponential histograms
+                      which are more compact and accurate than explicit bucket histograms.
+                    enum:
+                    - base2_exponential_bucket_histogram
+                    - explicit_bucket_histogram
+                    type: string
                   logsExporter:
                     description: |-
                       LogsExporter selects the logs exporter.

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -140,6 +140,16 @@ spec:
                   Observability configures OpenTelemetry for shard-level data-plane components.
                   Inherited from MultigresCluster.Spec.Observability.
                 properties:
+                  histogramAggregation:
+                    description: |-
+                      HistogramAggregation selects the default histogram aggregation.
+                      Maps to OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION.
+                      Use "base2_exponential_bucket_histogram" for native/exponential histograms
+                      which are more compact and accurate than explicit bucket histograms.
+                    enum:
+                    - base2_exponential_bucket_histogram
+                    - explicit_bucket_histogram
+                    type: string
                   logsExporter:
                     description: |-
                       LogsExporter selects the logs exporter.

--- a/config/deploy-observability/manager-otel-patch.yaml
+++ b/config/deploy-observability/manager-otel-patch.yaml
@@ -22,3 +22,5 @@ spec:
               value: "otlp"
             - name: OTEL_TRACES_SAMPLER
               value: "always_on"
+            - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+              value: "base2_exponential_bucket_histogram"

--- a/config/monitoring/grafana-dashboard-data-plane.json
+++ b/config/monitoring/grafana-dashboard-data-plane.json
@@ -101,7 +101,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (http_request_method, le) (rate(http_server_request_duration_seconds_bucket{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (http_request_method) (rate(http_server_request_duration_seconds{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
           "legendFormat": "p95 - {{http_request_method}}",
           "range": true,
           "refId": "A"
@@ -113,7 +113,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (http_request_method, le) (rate(http_server_request_duration_seconds_bucket{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (http_request_method) (rate(http_server_request_duration_seconds{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
           "legendFormat": "p50 - {{http_request_method}}",
           "range": true,
           "refId": "B"
@@ -185,7 +185,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=~\"multigateway|multiadmin\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=~\"multigateway|multiadmin\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "A"
@@ -197,7 +197,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=~\"multigateway|multiadmin\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=~\"multigateway|multiadmin\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "B"
@@ -282,7 +282,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (rpc_method, le) (rate(rpc_server_duration_milliseconds_bucket{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.95, sum by (rpc_method) (rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p95 - {{rpc_method}}",
           "range": true,
           "refId": "A"
@@ -294,7 +294,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (rpc_method, le) (rate(rpc_server_duration_milliseconds_bucket{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.50, sum by (rpc_method) (rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p50 - {{rpc_method}}",
           "range": true,
           "refId": "B"
@@ -366,7 +366,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "A"
@@ -378,7 +378,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=\"multipooler\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "B"
@@ -537,7 +537,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (path, le) (rate(rpcclient_connection_dial_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (path) (rate(rpcclient_connection_dial_duration_seconds[$__rate_interval])))",
           "legendFormat": "p95 - {{path}}",
           "range": true,
           "refId": "A"
@@ -549,7 +549,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (path, le) (rate(rpcclient_connection_dial_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (path) (rate(rpcclient_connection_dial_duration_seconds[$__rate_interval])))",
           "legendFormat": "p50 - {{path}}",
           "range": true,
           "refId": "B"
@@ -634,7 +634,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=\"multiorch\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.95, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p95 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "A"
@@ -646,7 +646,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method, le) (rate(rpc_client_duration_milliseconds_bucket{job=\"multiorch\"}[$__rate_interval]))) / 1000",
+          "expr": "histogram_quantile(0.50, sum by (rpc_service, rpc_method) (rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval]))) / 1000",
           "legendFormat": "p50 - {{rpc_service}}.{{rpc_method}}",
           "range": true,
           "refId": "B"
@@ -718,7 +718,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (action, le) (rate(multiorch_recovery_action_duration_milliseconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (action) (rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p95 - {{action}}",
           "range": true,
           "refId": "A"
@@ -730,7 +730,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (action, le) (rate(multiorch_recovery_action_duration_milliseconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (action) (rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p50 - {{action}}",
           "range": true,
           "refId": "B"
@@ -801,7 +801,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (db_namespace, status, le) (rate(multiorch_recovery_pooler_poll_duration_seconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (db_namespace, status) (rate(multiorch_recovery_pooler_poll_duration_seconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p95 - {{db_namespace}} [{{status}}]",
           "range": true,
           "refId": "A"
@@ -813,7 +813,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (db_namespace, status, le) (rate(multiorch_recovery_pooler_poll_duration_seconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (db_namespace, status) (rate(multiorch_recovery_pooler_poll_duration_seconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p50 - {{db_namespace}} [{{status}}]",
           "range": true,
           "refId": "B"
@@ -909,7 +909,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum(rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p95",
           "range": true,
           "refId": "A"
@@ -921,7 +921,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds_bucket{job=\"multiorch\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum(rate(multiorch_recovery_cluster_metadata_refresh_duration_seconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "p50",
           "range": true,
           "refId": "B"
@@ -1023,7 +1023,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (operation, resource_type, le) (rate(topoclient_lock_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (operation, resource_type) (rate(topoclient_lock_duration_seconds[$__rate_interval])))",
           "legendFormat": "p95 - {{operation}} on {{resource_type}}",
           "range": true,
           "refId": "A"
@@ -1035,7 +1035,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.50, sum by (operation, resource_type, le) (rate(topoclient_lock_duration_seconds_bucket[$__rate_interval])))",
+          "expr": "histogram_quantile(0.50, sum by (operation, resource_type) (rate(topoclient_lock_duration_seconds[$__rate_interval])))",
           "legendFormat": "p50 - {{operation}} on {{resource_type}}",
           "range": true,
           "refId": "B"


### PR DESCRIPTION
Data plane containers (multigateway, multipooler, multiorch) export metrics via the OTel SDK, which supports exponential bucket histograms for more compact and accurate quantile computation.

- Add HistogramAggregation field to ObservabilityConfig in observability_types.go
- Wire it through BuildOTELEnvVars() to propagate OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
- Set the env var to base2_exponential_bucket_histogram in manager-otel-patch.yaml so containers inherit it
- Update 22 histogram_quantile queries in grafana-dashboard-data-plane.json: remove _bucket suffix and le from sum by clauses
- Add test coverage for the new env var

Enables native histograms for data plane metrics, improving quantile accuracy without requiring explicit bucket boundaries.