### PR TITLE
fix(monitoring): use native histogram syntax in data plane dashboard

### DIFF
--- a/config/monitoring/grafana-dashboard-data-plane.json
+++ b/config/monitoring/grafana-dashboard-data-plane.json
@@ -65,7 +65,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (http_response_status_code, http_request_method) (rate(http_server_request_duration_seconds_count{job=~\"multigateway|multiadmin\"}[$__rate_interval]))",
+          "expr": "sum by (http_response_status_code, http_request_method) (histogram_count(rate(http_server_request_duration_seconds{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
           "legendFormat": "{{http_request_method}} [{{http_response_status_code}}]",
           "range": true,
           "refId": "A"
@@ -149,7 +149,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (rate(rpc_client_duration_milliseconds_count{job=~\"multigateway|multiadmin\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=~\"multigateway|multiadmin\"}[$__rate_interval])))",
           "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
@@ -246,7 +246,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (rpc_method, rpc_grpc_status_code) (rate(rpc_server_duration_milliseconds_count{job=\"multipooler\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_server_duration_milliseconds{job=\"multipooler\"}[$__rate_interval])))",
           "legendFormat": "{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
@@ -330,7 +330,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (rate(rpc_client_duration_milliseconds_count{job=\"multipooler\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=\"multipooler\"}[$__rate_interval])))",
           "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
@@ -598,7 +598,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (rate(rpc_client_duration_milliseconds_count{job=\"multiorch\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_service, rpc_method, rpc_grpc_status_code) (histogram_count(rate(rpc_client_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "{{rpc_service}}.{{rpc_method}} [{{rpc_grpc_status_code}}]",
           "range": true,
           "refId": "A"
@@ -682,7 +682,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (action, status) (rate(multiorch_recovery_action_duration_milliseconds_count{job=\"multiorch\"}[$__rate_interval]))",
+          "expr": "sum by (action, status) (histogram_count(rate(multiorch_recovery_action_duration_milliseconds{job=\"multiorch\"}[$__rate_interval])))",
           "legendFormat": "{{action}} [{{status}}]",
           "range": true,
           "refId": "A"
@@ -970,7 +970,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (operation, result, resource_type) (rate(topoclient_lock_duration_seconds_count[$__rate_interval]))",
+          "expr": "sum by (operation, result, resource_type) (histogram_count(rate(topoclient_lock_duration_seconds[$__rate_interval])))",
           "legendFormat": "{{operation}} on {{resource_type}} [{{result}}]",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
Rate-based request count panels in the data plane Grafana dashboard were not rendering because the queries referenced _count bucket metrics, which do not exist under native histograms.

- Update 8 PromQL expressions in grafana-dashboard-data-plane.json to use histogram_count(rate(...)) instead of rate(..._count)
- Affected panels: multigateway HTTP/gRPC, multipooler server/client gRPC, multiorch client gRPC, recovery actions, and topoclient locks

Restores visibility for all rate-of-requests panels in Grafana.