### PR TITLE
fix(ci): restore security-events permission and bump builder image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: write
   packages: write
+  security-events: write
 
 jobs:
   build:

--- a/.github/workflows/scan-intermediate-image.yaml
+++ b/.github/workflows/scan-intermediate-image.yaml
@@ -21,7 +21,7 @@ jobs:
         continue-on-error: true
         with:
           cache-db: true
-          image: "golang:1.25.6-alpine3.22" # sync this with Dockerfile
+          image: "golang:1.25.7-alpine3.23" # sync this with Dockerfile
           output-file: grype.sarif
           severity-cutoff: high
       - name: Upload SARIF file

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Github workflow step anchore/scan-action scans only the final image
 # sync this intermediate FROM reference with:
 #   scan-intermediate-image.yaml
-FROM golang:1.25.6-alpine3.22 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
The previous commit removed security-events: write from main.yaml, but build-and-release.yaml still needs it for uploading Grype SARIF results via codeql-action/upload-sarif.

- Restore security-events: write in main.yaml
- Bump builder image to golang:1.25.7-alpine3.23 in Dockerfile and scan-intermediate-image.yaml