### PR TITLE
perf(ci): replace tag rebuild with image retag

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -13,11 +13,6 @@ on:
         default: false
         required: false
         type: boolean
-      create-release:
-        description: Whether to create a Github release and attach the artifacts to it
-        default: false
-        required: false
-        type: boolean
 
 permissions:
   contents: write
@@ -120,15 +115,9 @@ jobs:
           jq '.runs[0].results | map(select(.level == "error"))' grype.sarif
           exit 1
 
-      - name: Push to registry (proper)
+      - name: Push to registry (latest)
         if: ${{ inputs.push-container-image }}
         run: |
           IMAGE="ghcr.io/${{ github.repository }}"
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            docker tag "$IMAGE:${{ github.sha }}" "$IMAGE:latest"
-            docker push "$IMAGE:latest"
-          fi
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            docker tag "$IMAGE:${{ github.sha }}" "$IMAGE:${{ github.ref_name }}"
-            docker push "$IMAGE:${{ github.ref_name }}"
-          fi
+          docker tag "$IMAGE:${{ github.sha }}" "$IMAGE:latest"
+          docker push "$IMAGE:latest"

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -11,11 +11,65 @@ on:
 permissions:
   contents: write
   packages: write
-  security-events: write
 
 jobs:
-  run:
-    uses: ./.github/workflows/build-and-release.yaml
-    with:
-      push-container-image: true
-      create-release: true
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main
+        run: |
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "::error::Tag must point to a commit on the main branch"
+            exit 1
+          fi
+
+      - name: Verify main workflow passed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Checking if 'Build main' workflow passed for commit ${{ github.sha }}..."
+          RESULT=$(gh run list \
+            --commit ${{ github.sha }} \
+            --workflow main.yaml \
+            --json conclusion \
+            --jq '.[0].conclusion')
+
+          if [ "$RESULT" != "success" ]; then
+            echo "::error::Main workflow has not passed for this commit (status: ${RESULT:-not found})"
+            exit 1
+          fi
+          echo "Main workflow passed ✅"
+
+      - name: Log into registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Retag existing image with version
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}"
+          SHA_TAG="${{ github.sha }}"
+          VERSION_TAG="${{ github.ref_name }}"
+
+          echo "Retagging $IMAGE:$SHA_TAG → $IMAGE:$VERSION_TAG"
+          docker buildx imagetools create \
+            --tag "$IMAGE:$VERSION_TAG" \
+            "$IMAGE:$SHA_TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --generate-notes \
+            --verify-tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN CGO_ENABLED=0 \
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 
-LABEL org.opencontainers.image.source = "https://github.com/numtide/multigres-operator"
+LABEL org.opencontainers.image.source="https://github.com/numtide/multigres-operator"
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
The tag workflow previously re-ran the entire build-and-release pipeline (test all modules, rebuild container, scan, push), taking ~15 minutes. This was redundant because the main workflow already builds, scans, and pushes the image with a SHA tag on every merge.

The new tag release flow:
1. Verify the tagged commit exists on main (reject non-main tags)
2. Verify the main workflow passed for that commit (reject broken commits)
3. Retag the existing SHA image with the version tag using docker buildx imagetools create (server-side, no pull/push)
4. Create a GitHub release with auto-generated notes

- Rewrite tags.yaml to retag instead of rebuild (~15s vs ~15min)
- Remove unused create-release input from build-and-release.yaml
- Simplify push step in build-and-release.yaml (only main calls it)
- Drop security-events permission from tags.yaml (no Grype scan)
- Fix legacy LABEL format warning in Dockerfile

This ensures tagged releases are always from main, always tested, and produced in seconds instead of minutes.