### PR TITLE
feat(docker): inject version metadata via ldflags

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -75,6 +75,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
       - name: Build container image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -88,6 +91,10 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=oci,dest=container-image.tar
+          build-args: |
+            VERSION=${{ env.SHORT_SHA }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
 
       - name: Push to registry (sha)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine3.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+# Version metadata injected at build time via --build-arg.
+# Defaults ensure a plain `docker build .` still works.
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -26,7 +32,10 @@ RUN CGO_ENABLED=0 \
 	GOOS=${TARGETOS:-linux} \
 	GOARCH=${TARGETARCH} \
 	go build \
-	-ldflags '-s -w -buildid=' \
+	-ldflags "-s -w -buildid= \
+	-X main.version=${VERSION} \
+	-X main.gitCommit=${GIT_COMMIT} \
+	-X main.buildDate=${BUILD_DATE}" \
 	-trimpath -mod=readonly \
 	-a -o manager \
 	cmd/multigres-operator/main.go

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # Use docker-buildx target or pass --platform to docker build for multi-arch images.
 .PHONY: container
 container: ## Build container image
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build \
+		--build-arg VERSION=$$(git rev-parse --short HEAD) \
+		--build-arg GIT_COMMIT=$$(git rev-parse HEAD) \
+		--build-arg BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+		-t ${IMG} .
 
 .PHONY: minikube-load
 minikube-load:
@@ -286,7 +290,11 @@ PLATFORMS ?= linux/arm64,linux/amd64
 docker-buildx: ## Build and push docker image for cross-platform support
 	- $(CONTAINER_TOOL) buildx create --name multigres-operator-builder
 	$(CONTAINER_TOOL) buildx use multigres-operator-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) \
+		--build-arg VERSION=$$(git rev-parse --short HEAD) \
+		--build-arg GIT_COMMIT=$$(git rev-parse HEAD) \
+		--build-arg BUILD_DATE=$$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+		--tag ${IMG} .
 	- $(CONTAINER_TOOL) buildx rm multigres-operator-builder
 
 .PHONY: build-installer


### PR DESCRIPTION
The operator binary always reported version=dev, buildDate=unknown, and gitCommit=unknown because no ldflags were passed during the Docker build. This made it impossible to identify which commit a running operator was built from, both in logs and OTEL traces.

- Add VERSION, GIT_COMMIT, BUILD_DATE ARGs to Dockerfile with safe defaults (dev/unknown) for plain docker build
- Wire -X main.version, -X main.gitCommit, -X main.buildDate into go build ldflags
- Update Makefile container and docker-buildx targets to pass git rev-parse --short HEAD, git rev-parse HEAD, and date
- Add Compute short SHA step in build-and-release.yaml to pass the 7-char SHA as VERSION via GITHUB_ENV

The operator now logs its exact commit and build timestamp at startup, and OTEL traces carry the short SHA as service version.