### PR TITLE
feat(ci): generate install manifests for releases

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -128,3 +128,18 @@ jobs:
           IMAGE="ghcr.io/${{ github.repository }}"
           docker tag "$IMAGE:${{ github.sha }}" "$IMAGE:latest"
           docker push "$IMAGE:latest"
+
+  validate-installer:
+    needs: [ test-go ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Install Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Validate install manifests
+        run: make build-installer

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -66,10 +66,23 @@ jobs:
             --tag "$IMAGE:$VERSION_TAG" \
             "$IMAGE:$SHA_TAG"
 
+      - name: Install Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Generate install manifests
+        run: |
+          make build-installer \
+            IMG="ghcr.io/${{ github.repository }}:${{ github.ref_name }}"
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ github.ref_name }}" \
             --generate-notes \
-            --verify-tag
+            --verify-tag \
+            dist/install.yaml \
+            dist/install-certmanager.yaml \
+            dist/install-observability.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 result
 result-*
 
-# generic
+# distribution files are added to github releases
 dist/
 
 # Go

--- a/Makefile
+++ b/Makefile
@@ -298,11 +298,13 @@ docker-buildx: ## Build and push docker image for cross-platform support
 	- $(CONTAINER_TOOL) buildx rm multigres-operator-builder
 
 .PHONY: build-installer
-build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
+build-installer: manifests generate kustomize ## Generate consolidated install YAMLs under dist/.
 	mkdir -p dist
 	# kustomize has no build-time image override, so we mutate then restore.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
+	$(KUSTOMIZE) build config/deploy-certmanager > dist/install-certmanager.yaml
+	$(KUSTOMIZE) build config/deploy-observability > dist/install-observability.yaml
 	@git checkout -- config/manager/kustomization.yaml 2>/dev/null || true
 
 ##@ Test


### PR DESCRIPTION
The operator had no user-facing installation path beyond make targets intended for local development. End-users had no way to install via kubectl apply without cloning the repository.

- Expand build-installer target in Makefile to generate three variants: default, cert-manager, and observability
- Add validate-installer job to build-and-release.yaml to catch Kustomize breakage on every push to main
- Update tags.yaml to generate install YAMLs with the release image tag and attach them as GitHub Release assets
- Rewrite README Installation section with kubectl apply commands for all three variants, prerequisites, and an observability stack evaluation warning
- Update .gitignore comment to clarify dist/ is for releases

Users can now install with a single command:
kubectl apply --server-side -f
  https://github.com/.../releases/latest/download/install.yaml