### PR TITLE
doc(design): add pod management design document

### DIFF
--- a/plans/phase-1/pod-management-design.md
+++ b/plans/phase-1/pod-management-design.md
@@ -1,6 +1,6 @@
 # Pod Management Design: StatefulSet → Direct Pod Management
 
-> **Status**: Draft — For Review by Multigres Team
+> **Status**: Approved — Ready for Implementation
 >
 > **Goal**: Document the design for replacing StatefulSets with direct pod management in the operator, covering pod identity, decommissioning, failure scenarios, and scope limitations.
 


### PR DESCRIPTION
This comprehensive design document details the transition from StatefulSets to direct pod management for the multigres operator. It covers the motivation, architecture, and specific implementation strategies for managing PostgreSQL pods directly.

Key components include:
- Resource topology changes (StatefulSet -> Pod + PVC + Service)
- Pod identity management (primary/replica distinction via etcd)
- Graceful scale-down using a drain state machine (annotations)
- Rolling update strategy (replicas first, primary last, drift detection)
- Failure scenarios and recovery procedures
- Backup infrastructure integration

Establishes the architectural foundation for Phase 1 implementation.