### PR TITLE
feat(backup): add S3 backup support

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -163,6 +163,10 @@ type S3BackupConfig struct {
 	Endpoint          string `json:"endpoint,omitempty"`
 	KeyPrefix         string `json:"keyPrefix,omitempty"`
 	UseEnvCredentials bool   `json:"useEnvCredentials,omitempty"`
+
+	// CredentialsSecret is the name of the Secret containing AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+	// +optional
+	CredentialsSecret string `json:"credentialsSecret,omitempty"`
 }
 
 // ============================================================================

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -96,6 +96,10 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      credentialsSecret:
+                        description: CredentialsSecret is the name of the Secret containing
+                          AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+                        type: string
                       endpoint:
                         type: string
                       keyPrefix:
@@ -2462,6 +2466,10 @@ spec:
                           properties:
                             bucket:
                               type: string
+                            credentialsSecret:
+                              description: CredentialsSecret is the name of the Secret
+                                containing AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+                              type: string
                             endpoint:
                               type: string
                             keyPrefix:
@@ -2548,6 +2556,11 @@ spec:
                                   Required when type is "s3".
                                 properties:
                                   bucket:
+                                    type: string
+                                  credentialsSecret:
+                                    description: CredentialsSecret is the name of
+                                      the Secret containing AWS_ACCESS_KEY_ID and
+                                      AWS_SECRET_ACCESS_KEY.
                                     type: string
                                   endpoint:
                                     type: string
@@ -2663,6 +2676,11 @@ spec:
                                         Required when type is "s3".
                                       properties:
                                         bucket:
+                                          type: string
+                                        credentialsSecret:
+                                          description: CredentialsSecret is the name
+                                            of the Secret containing AWS_ACCESS_KEY_ID
+                                            and AWS_SECRET_ACCESS_KEY.
                                           type: string
                                         endpoint:
                                           type: string

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -94,6 +94,10 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      credentialsSecret:
+                        description: CredentialsSecret is the name of the Secret containing
+                          AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+                        type: string
                       endpoint:
                         type: string
                       keyPrefix:

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -93,6 +93,10 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      credentialsSecret:
+                        description: CredentialsSecret is the name of the Secret containing
+                          AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+                        type: string
                       endpoint:
                         type: string
                       keyPrefix:
@@ -383,6 +387,10 @@ spec:
                             Required when type is "s3".
                           properties:
                             bucket:
+                              type: string
+                            credentialsSecret:
+                              description: CredentialsSecret is the name of the Secret
+                                containing AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
                               type: string
                             endpoint:
                               type: string

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -451,6 +451,12 @@ func (r *ShardReconciler) reconcileSharedBackupPVC(
 	shard *multigresv1alpha1.Shard,
 	cellName string,
 ) error {
+	// S3 backups use object storage; no shared PVC is needed.
+	// TODO: Consider cleaning up orphaned backup PVCs when migrating from filesystem to S3.
+	if shard.Spec.Backup != nil && shard.Spec.Backup.Type == multigresv1alpha1.BackupTypeS3 {
+		return nil
+	}
+
 	desired, err := BuildSharedBackupPVC(shard, cellName, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to build shared backup PVC: %w", err)


### PR DESCRIPTION
The operator only supported filesystem backups, writing a hardcoded BackupLocation_Filesystem to the topology. This meant pgbackrest could not be configured for S3 object storage.

- Add CredentialsSecret field to S3BackupConfig in common_types.go
- Refactor getBackupLocation in data-handler shard_controller.go to return BackupLocation_S3 with bucket, region, endpoint, key prefix, and UseEnvCredentials from the Shard spec
- Extract s3EnvVars helper in resource-handler containers.go to inject AWS_REGION, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY into both postgres and multipooler containers from a referenced Secret
- Use EmptyDir for backup-data volume when backup type is S3 instead of provisioning a shared PVC
- Skip reconcileSharedBackupPVC when backup type is S3
- Update CRD manifests for the new credentialsSecret field
- Add unit tests for s3EnvVars, S3 env injection, and S3 volume

Enables S3-backed pgbackrest backups with proper credential injection and correct topology metadata propagation to the data plane.