### PR TITLE
feat(shard): add pgBackRest TLS cert handling

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -141,6 +141,13 @@ type BackupConfig struct {
 	// Required when type is "s3".
 	// +optional
 	S3 *S3BackupConfig `json:"s3,omitempty"`
+
+	// PgBackRestTLS configures TLS certificates for pgBackRest inter-node communication.
+	// Required for multi-replica shards where standbys connect to the primary's
+	// pgBackRest server. When SecretName is set, the operator mounts that Secret directly.
+	// When SecretName is empty, the operator auto-generates and rotates certificates.
+	// +optional
+	PgBackRestTLS *PgBackRestTLSConfig `json:"pgbackrestTLS,omitempty"`
 }
 
 // FilesystemBackupConfig defines settings for filesystem-based backups.
@@ -167,6 +174,16 @@ type S3BackupConfig struct {
 	// CredentialsSecret is the name of the Secret containing AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
 	// +optional
 	CredentialsSecret string `json:"credentialsSecret,omitempty"`
+}
+
+// PgBackRestTLSConfig configures TLS for pgBackRest inter-node communication.
+type PgBackRestTLSConfig struct {
+	// SecretName is the name of an existing Secret containing pgBackRest TLS certificates.
+	// The Secret must contain three keys: ca.crt, tls.crt, tls.key.
+	// This is directly compatible with cert-manager Certificate resources.
+	// When empty, the operator generates and rotates certificates automatically.
+	// +optional
+	SecretName string `json:"secretName,omitempty"`
 }
 
 // ============================================================================

--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -447,9 +447,10 @@ func main() {
 	}
 
 	if err = (&shardcontroller.ShardReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("shard-controller"),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("shard-controller"),
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Shard")
 		os.Exit(1)

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -89,6 +89,21 @@ spec:
                             type: string
                         type: object
                     type: object
+                  pgbackrestTLS:
+                    description: |-
+                      PgBackRestTLS configures TLS certificates for pgBackRest inter-node communication.
+                      Required for multi-replica shards where standbys connect to the primary's
+                      pgBackRest server. When SecretName is set, the operator mounts that Secret directly.
+                      When SecretName is empty, the operator auto-generates and rotates certificates.
+                    properties:
+                      secretName:
+                        description: |-
+                          SecretName is the name of an existing Secret containing pgBackRest TLS certificates.
+                          The Secret must contain three keys: ca.crt, tls.crt, tls.key.
+                          This is directly compatible with cert-manager Certificate resources.
+                          When empty, the operator generates and rotates certificates automatically.
+                        type: string
+                    type: object
                   s3:
                     description: |-
                       S3 defines the S3-compatible storage configuration.
@@ -2459,6 +2474,21 @@ spec:
                                   type: string
                               type: object
                           type: object
+                        pgbackrestTLS:
+                          description: |-
+                            PgBackRestTLS configures TLS certificates for pgBackRest inter-node communication.
+                            Required for multi-replica shards where standbys connect to the primary's
+                            pgBackRest server. When SecretName is set, the operator mounts that Secret directly.
+                            When SecretName is empty, the operator auto-generates and rotates certificates.
+                          properties:
+                            secretName:
+                              description: |-
+                                SecretName is the name of an existing Secret containing pgBackRest TLS certificates.
+                                The Secret must contain three keys: ca.crt, tls.crt, tls.key.
+                                This is directly compatible with cert-manager Certificate resources.
+                                When empty, the operator generates and rotates certificates automatically.
+                              type: string
+                          type: object
                         s3:
                           description: |-
                             S3 defines the S3-compatible storage configuration.
@@ -2549,6 +2579,21 @@ spec:
                                         pattern: ^([0-9]+)(.+)$
                                         type: string
                                     type: object
+                                type: object
+                              pgbackrestTLS:
+                                description: |-
+                                  PgBackRestTLS configures TLS certificates for pgBackRest inter-node communication.
+                                  Required for multi-replica shards where standbys connect to the primary's
+                                  pgBackRest server. When SecretName is set, the operator mounts that Secret directly.
+                                  When SecretName is empty, the operator auto-generates and rotates certificates.
+                                properties:
+                                  secretName:
+                                    description: |-
+                                      SecretName is the name of an existing Secret containing pgBackRest TLS certificates.
+                                      The Secret must contain three keys: ca.crt, tls.crt, tls.key.
+                                      This is directly compatible with cert-manager Certificate resources.
+                                      When empty, the operator generates and rotates certificates automatically.
+                                    type: string
                                 type: object
                               s3:
                                 description: |-
@@ -2669,6 +2714,21 @@ spec:
                                               pattern: ^([0-9]+)(.+)$
                                               type: string
                                           type: object
+                                      type: object
+                                    pgbackrestTLS:
+                                      description: |-
+                                        PgBackRestTLS configures TLS certificates for pgBackRest inter-node communication.
+                                        Required for multi-replica shards where standbys connect to the primary's
+                                        pgBackRest server. When SecretName is set, the operator mounts that Secret directly.
+                                        When SecretName is empty, the operator auto-generates and rotates certificates.
+                                      properties:
+                                        secretName:
+                                          description: |-
+                                            SecretName is the name of an existing Secret containing pgBackRest TLS certificates.
+                                            The Secret must contain three keys: ca.crt, tls.crt, tls.key.
+                                            This is directly compatible with cert-manager Certificate resources.
+                                            When empty, the operator generates and rotates certificates automatically.
+                                          type: string
                                       type: object
                                     s3:
                                       description: |-

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -87,6 +87,21 @@ spec:
                             type: string
                         type: object
                     type: object
+                  pgbackrestTLS:
+                    description: |-
+                      PgBackRestTLS configures TLS certificates for pgBackRest inter-node communication.
+                      Required for multi-replica shards where standbys connect to the primary's
+                      pgBackRest server. When SecretName is set, the operator mounts that Secret directly.
+                      When SecretName is empty, the operator auto-generates and rotates certificates.
+                    properties:
+                      secretName:
+                        description: |-
+                          SecretName is the name of an existing Secret containing pgBackRest TLS certificates.
+                          The Secret must contain three keys: ca.crt, tls.crt, tls.key.
+                          This is directly compatible with cert-manager Certificate resources.
+                          When empty, the operator generates and rotates certificates automatically.
+                        type: string
+                    type: object
                   s3:
                     description: |-
                       S3 defines the S3-compatible storage configuration.

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -86,6 +86,21 @@ spec:
                             type: string
                         type: object
                     type: object
+                  pgbackrestTLS:
+                    description: |-
+                      PgBackRestTLS configures TLS certificates for pgBackRest inter-node communication.
+                      Required for multi-replica shards where standbys connect to the primary's
+                      pgBackRest server. When SecretName is set, the operator mounts that Secret directly.
+                      When SecretName is empty, the operator auto-generates and rotates certificates.
+                    properties:
+                      secretName:
+                        description: |-
+                          SecretName is the name of an existing Secret containing pgBackRest TLS certificates.
+                          The Secret must contain three keys: ca.crt, tls.crt, tls.key.
+                          This is directly compatible with cert-manager Certificate resources.
+                          When empty, the operator generates and rotates certificates automatically.
+                        type: string
+                    type: object
                   s3:
                     description: |-
                       S3 defines the S3-compatible storage configuration.
@@ -380,6 +395,21 @@ spec:
                                   pattern: ^([0-9]+)(.+)$
                                   type: string
                               type: object
+                          type: object
+                        pgbackrestTLS:
+                          description: |-
+                            PgBackRestTLS configures TLS certificates for pgBackRest inter-node communication.
+                            Required for multi-replica shards where standbys connect to the primary's
+                            pgBackRest server. When SecretName is set, the operator mounts that Secret directly.
+                            When SecretName is empty, the operator auto-generates and rotates certificates.
+                          properties:
+                            secretName:
+                              description: |-
+                                SecretName is the name of an existing Secret containing pgBackRest TLS certificates.
+                                The Secret must contain three keys: ca.crt, tls.crt, tls.key.
+                                This is directly compatible with cert-manager Certificate resources.
+                                When empty, the operator generates and rotates certificates automatically.
+                              type: string
                           type: object
                         s3:
                           description: |-

--- a/pkg/resource-handler/controller/shard/pool_statefulset.go
+++ b/pkg/resource-handler/controller/shard/pool_statefulset.go
@@ -103,12 +103,7 @@ func BuildPoolStatefulSet(
 						buildPgctldContainer(shard, poolSpec),
 						// buildPostgresContainer(shard, poolSpec),
 					},
-					Volumes: []corev1.Volume{
-						// buildPgctldVolume(),
-						buildSharedBackupVolume(shard, cellName),
-						buildSocketDirVolume(),
-						buildPgHbaVolume(),
-					},
+					Volumes:  buildPoolVolumes(shard, cellName),
 					Affinity: poolSpec.Affinity,
 				},
 			},

--- a/pkg/resource-handler/go.mod
+++ b/pkg/resource-handler/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/numtide/multigres-operator/pkg/cert v0.0.0-20260219163835-74566f7d164a // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/pkg/resource-handler/go.sum
+++ b/pkg/resource-handler/go.sum
@@ -100,6 +100,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/numtide/multigres-operator/api v0.0.0-20260219162905-462993285d78 h1:pkXFbn0AMbMcZKzgXLmhJnj916i2EPCDxIvcCeySwjM=
 github.com/numtide/multigres-operator/api v0.0.0-20260219162905-462993285d78/go.mod h1:7nlnBwoyLSbEloUaHHC6X3ncWZeuOvkOBnnF9cSW+Wg=
+github.com/numtide/multigres-operator/pkg/cert v0.0.0-20260219163835-74566f7d164a h1:/RkyTcbwQE//ijDFeARJUbTKQ5U0W38cZc8/ozZp1oc=
+github.com/numtide/multigres-operator/pkg/cert v0.0.0-20260219163835-74566f7d164a/go.mod h1:h2usdWP68hk2e9yApioAhwBzBeXGYjhNBG3isNeadEk=
 github.com/numtide/multigres-operator/pkg/monitoring v0.0.0-20260219162905-462993285d78 h1:4AEjt87L4353NMyMpVRStSr26/AcJtN0i15FJ3FNobw=
 github.com/numtide/multigres-operator/pkg/monitoring v0.0.0-20260219162905-462993285d78/go.mod h1:DVuFnEpCPMJHeV5mtHTKrqkjGks+o+y3L7XlT8rcKFY=
 github.com/numtide/multigres-operator/pkg/testutil v0.0.0-20260219162905-462993285d78 h1:3W80nqD7v4A3Wqy2jyON9+U94r/TQs0rhxV+1kZi8PY=


### PR DESCRIPTION
pgBackRest requires TLS for inter-node communication between replicas in a shard. Without it, multi-replica pools cannot perform backups, restores, or WAL archiving.

- Add PgBackRestTLSConfig to BackupConfig in common_types.go
- Add reconcilePgBackRestCerts to shard controller with dual-mode support: auto-generated (pkg/cert) or user-provided (cert-manager compatible)
- Add buildPgBackRestCertVolume using projected volumes with key renaming (tls.crt -> pgbackrest.crt) for both modes
- Wire cert args and volume mounts into pgctld and multipooler containers in containers.go
- Add APIReader to ShardReconciler for validating external Secrets that are invisible to the label-filtered cache
- Wire mgr.GetAPIReader() in main.go
- Add 13 unit tests covering volume builder, container args, and volume mount presence
- Update README.md and implementation-notes.md with TLS docs

Enables secure pgBackRest communication with zero-config auto-generated certs or seamless cert-manager integration.