### PR TITLE
fix(data-handler): skip topo cleanup on deletion when unreachable

### DIFF
--- a/pkg/data-handler/controller/cell/cell_controller_test.go
+++ b/pkg/data-handler/controller/cell/cell_controller_test.go
@@ -408,6 +408,27 @@ func TestReconcile(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"skips topo cleanup when topo unavailable during deletion": {
+			cell: &multigresv1alpha1.Cell{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cell",
+					Namespace:         "default",
+					Finalizers:        []string{finalizerName},
+					DeletionTimestamp: &metav1.Time{Time: metav1.Now().Time},
+				},
+				Spec: multigresv1alpha1.CellSpec{
+					Name: "zone-a",
+					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+						Address:        "localhost:2379",
+						RootPath:       "/test",
+						Implementation: "memory",
+					},
+				},
+			},
+			customTopoStoreFunc: func(c *multigresv1alpha1.Cell) (topoclient.Store, error) {
+				return nil, errors.New("Code: UNAVAILABLE\nno connection available")
+			},
+		},
 		"error on Update when removing finalizer": {
 			cell: &multigresv1alpha1.Cell{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
When deleting a MultigresCluster before the topo server is ready, data-handler finalizers on Shard and Cell resources blocked for minutes retrying etcd connections with exponential backoff.

- Skip topo unregistration in handleDeletion when isTopoUnavailable returns true for both shard and cell controllers
- Suppress UnregistrationFailed warning event when topo is unreachable to avoid noisy k8s events
- Add "skips topo cleanup when topo unavailable during deletion" test cases for both controllers

Reduces deletion time from minutes to ~2s when the topology server was never reachable.