### PR TITLE
feat(webhook): add StorageClass validation

### DIFF
--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -39,6 +39,7 @@ import (
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,resourceNames=multigres-operator-mutating-webhook-configuration,verbs=get;update;patch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,resourceNames=multigres-operator-validating-webhook-configuration,verbs=get;update;patch
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=list
 
 // ============================================================================
 // MultigresClusterSpec Spec (User-editable API)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -106,3 +106,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - list

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -8,6 +8,7 @@ import (
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -85,6 +86,7 @@ func TestNewResolver(t *testing.T) {
 func setupScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
 	return scheme
 }
 

--- a/pkg/webhook/handlers/validator_test.go
+++ b/pkg/webhook/handlers/validator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/numtide/multigres-operator/pkg/testutil"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -22,6 +23,7 @@ import (
 func setupScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
 	return scheme
 }
 
@@ -526,6 +528,15 @@ func TestMultigresClusterValidator(t *testing.T) {
 								"default": {Type: "readWrite"}, // Only "default" pool exists
 							},
 						},
+					},
+					&storagev1.StorageClass{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "standard",
+							Annotations: map[string]string{
+								"storageclass.kubernetes.io/is-default-class": "true",
+							},
+						},
+						Provisioner: "k8s.io/fake",
 					},
 				}
 			}


### PR DESCRIPTION
Without a default StorageClass or explicit storage.class settings, PVCs get stuck in Pending and cause cascading failures that are difficult to recover from.

- Add section 4 to ValidateClusterLogic in resolver.go that collects PVC-generating components (pools, etcd, backup) missing an explicit storage.class and checks for a default StorageClass
- Add hasDefaultStorageClass helper that lists StorageClasses and checks both GA and beta is-default-class annotations
- Add RBAC marker for storageclasses list in multigrescluster_types.go
- Regenerate role.yaml with storage.k8s.io/storageclasses permission

Prevents unrecoverable cluster states by catching missing StorageClass at admission time with actionable error messages. Covered by 4 resolver unit tests, 2 webhook integration tests, and verified in Kind.