### PR TITLE
fix(cert): handle AlreadyExists race in secret creation

### DIFF
--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -220,6 +220,9 @@ func (m *CertRotator) ensureCA(ctx context.Context) (*CAArtifacts, error) {
 		}
 
 		if err := m.Client.Create(ctx, secret); err != nil {
+			if errors.IsAlreadyExists(err) {
+				return m.ensureCA(ctx)
+			}
 			return nil, fmt.Errorf("failed to create CA secret: %w", err)
 		}
 
@@ -291,6 +294,9 @@ func (m *CertRotator) ensureServerCert(ctx context.Context, ca *CAArtifacts) ([]
 		}
 
 		if err := m.Client.Create(ctx, secret); err != nil {
+			if errors.IsAlreadyExists(err) {
+				return m.ensureServerCert(ctx, ca)
+			}
 			return nil, fmt.Errorf("failed to create server cert secret: %w", err)
 		}
 


### PR DESCRIPTION
When multiple reconcilers create certs for the same shard concurrently, the Get-then-Create pattern in ensureCA and ensureServerCert races: one succeeds while the other gets AlreadyExists, producing noisy error logs on every requeue after pod restart.

- Handle AlreadyExists in ensureCA by retrying via recursion
- Handle AlreadyExists in ensureServerCert with the same pattern
- Follows existing convention used for corrupt/expiring cert recovery

Eliminates spurious pgBackRest CertError warnings after operator restart.