### PR TITLE
fix(cluster-handler): listen on dual-stack for multiadmin-web

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/builders_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global.go
@@ -256,6 +256,10 @@ func BuildMultiAdminWebDeployment(
 							Image: string(cluster.Spec.Images.MultiAdminWeb),
 							Env: []corev1.EnvVar{
 								{
+									Name:  "HOSTNAME",
+									Value: "::",
+								},
+								{
 									Name:  "MULTIADMIN_API_URL",
 									Value: fmt.Sprintf("http://%s-multiadmin:18000", cluster.Name),
 								},


### PR DESCRIPTION
The upstream Dockerfile sets HOSTNAME=0.0.0.0 (IPv4-only), causing liveness probe failures on dual-stack EKS clusters where the kubelet probes via the pod's IPv6 address.

- Set HOSTNAME=:: env var on the multiadmin-web container so Next.js listens on both IPv4 and IPv6 via IPv4-mapped addresses

Fixes CrashLoopBackOff on dual-stack Kubernetes clusters.