### PR TITLE
docs: document silent HA loss with RWO filesystem backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,10 @@ The `filesystem` backend stores backups on a Persistent Volume Claim (PVC).
 **ReadWriteMany (RWX) Requirement:**
 If you have multiple replicas in the same Cell (e.g., `replicasPerCell: 3`), they must all mount the same PVC simultaneously.
 - **Option A (Recommended):** Use a StorageClass that supports `ReadWriteMany` (e.g., NFS, EFS, CephFS).
-- **Option B (Dev/Test):** If using standard block storage (RWO), you must ensure all 3 replicas are scheduled on the **same node**, or they will fail to start.
+- **Option B (Dev/Test):** If using standard block storage (RWO), all replicas must be on the **same node**.
+
+> [!CAUTION]
+> **Silent HA Loss with RWO:** If your StorageClass uses `WaitForFirstConsumer` binding (standard for EBS/gp2/gp3), Kubernetes will **automatically co-locate all replicas on the same node** to satisfy the RWO constraint. The cluster will appear healthy, but all replicas are on a single node — if that node fails, you lose all replicas simultaneously. Use S3 or RWX storage for production to ensure replicas spread across nodes.
 
 ```yaml
 spec:

--- a/config/samples/minimal.yaml
+++ b/config/samples/minimal.yaml
@@ -4,6 +4,9 @@ metadata:
   name: minimal
   namespace: default
 spec:
+  pvcDeletionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
   # A minimal cluster requires at least one cell definition.
   #
   # The operator will resolve configuration defaults in this order:

--- a/config/samples/no-templates.yaml
+++ b/config/samples/no-templates.yaml
@@ -16,7 +16,7 @@ spec:
       replicas: 3
       storage:
         size: "10Gi"
-        class: "standard"
+        # class: "standard"
       resources:
         requests:
           cpu: "100m"
@@ -83,7 +83,7 @@ spec:
                       - "z1"
                     replicasPerCell: 2
                     storage:
-                      class: "standard"
+                      # class: "standard"
                       size: "100Gi"
                     postgres:
                        resources:

--- a/plans/phase-1/implementation-notes.md
+++ b/plans/phase-1/implementation-notes.md
@@ -908,7 +908,7 @@ We implemented a **One Shared PVC per Shard per Cell** model.
     2.  **Collaboration:** Any authentic replica can perform a backup, and any other replica can restore from it (within the same cell).
 
 **Implications:**
-1.  **ReadWriteMany (RWX):** Since multiple pods (replicas) in the same cell need to mount the PVC, the underlying storage class MUST support `ReadWriteMany` (NFS, EFS, etc.). Using `ReadWriteOnce` with >1 replica per cell will cause scheduling failures unless they are scheduled on the same node.
+1.  **ReadWriteMany (RWX):** Since multiple pods (replicas) in the same cell need to mount the PVC, the underlying storage class MUST support `ReadWriteMany` (NFS, EFS, etc.). Using `ReadWriteOnce` with >1 replica per cell will cause the scheduler to **silently co-locate all replicas on the same node** (when using `WaitForFirstConsumer` binding, which is standard for EBS). The cluster will appear healthy but all replicas share a single point of failure. With `Immediate` binding, pods on different nodes will fail with `Multi-Attach` errors instead.
 2.  **Cell Isolation:** This shared PVC is **Cell-Local**. A backup created in `us-east-1a` (Cell A) is stored in Cell A's PVC. It is **NOT** available to Cell B (`us-east-1b`).
     - **Consequence:** You cannot failover to Cell B and restore from Cell A's filesystem backup.
     - **Solution:** Use **S3** for multi-cell clusters. S3 provides a single global repository accessible from all cells.


### PR DESCRIPTION
Users deploying filesystem backups with RWO storage (e.g. EBS gp2/gp3) may not realize that WaitForFirstConsumer binding silently co-locates all replicas on the same node. The cluster appears healthy but has a single point of failure.

- Add CAUTION block to README explaining WaitForFirstConsumer node pinning behavior and its impact on high availability
- Update implementation-notes to distinguish WaitForFirstConsumer (silent co-location) vs Immediate (Multi-Attach error) outcomes
- Set pvcDeletionPolicy to Delete in minimal sample for dev/test
- Comment out hardcoded storage class in no-templates sample so it uses the cluster default