### PR TITLE
refactor(operator): ensure unique ConfigMap and Secret names per Shard

### DIFF
--- a/pkg/resource-handler/controller/shard/configmap.go
+++ b/pkg/resource-handler/controller/shard/configmap.go
@@ -35,7 +35,7 @@ func BuildPgHbaConfigMap(
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      PgHbaConfigMapName,
+			Name:      PgHbaConfigMapName(shard.Name),
 			Namespace: shard.Namespace,
 			Labels:    labels,
 		},

--- a/pkg/resource-handler/controller/shard/configmap_test.go
+++ b/pkg/resource-handler/controller/shard/configmap_test.go
@@ -72,8 +72,8 @@ func TestBuildPgHbaConfigMap(t *testing.T) {
 				return
 			}
 
-			if cm.Name != PgHbaConfigMapName {
-				t.Errorf("ConfigMap name = %v, want %v", cm.Name, PgHbaConfigMapName)
+			if cm.Name != PgHbaConfigMapName(tc.shard.Name) {
+				t.Errorf("ConfigMap name = %v, want %v", cm.Name, PgHbaConfigMapName(tc.shard.Name))
 			}
 			if cm.Namespace != tc.shard.Namespace {
 				t.Errorf("ConfigMap namespace = %v, want %v", cm.Namespace, tc.shard.Namespace)

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -21,7 +21,8 @@ func TestBuildPostgresContainer(t *testing.T) {
 	}{
 		"default postgres image with no resources": {
 			shard: &multigresv1alpha1.Shard{
-				Spec: multigresv1alpha1.ShardSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-shard"},
+				Spec:       multigresv1alpha1.ShardSpec{},
 			},
 			poolSpec: multigresv1alpha1.PoolSpec{},
 			want: corev1.Container{
@@ -47,7 +48,7 @@ func TestBuildPostgresContainer(t *testing.T) {
 						Name:  "PGDATA",
 						Value: PgDataPath,
 					},
-					pgPasswordEnvVar(),
+					pgPasswordEnvVar("test-shard"),
 				},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser:    ptr.To(int64(999)),
@@ -81,6 +82,7 @@ func TestBuildPostgresContainer(t *testing.T) {
 		},
 		"custom postgres image": {
 			shard: &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-shard"},
 				Spec: multigresv1alpha1.ShardSpec{
 					Images: multigresv1alpha1.ShardImages{
 						Postgres: "postgres:16",
@@ -111,7 +113,7 @@ func TestBuildPostgresContainer(t *testing.T) {
 						Name:  "PGDATA",
 						Value: PgDataPath,
 					},
-					pgPasswordEnvVar(),
+					pgPasswordEnvVar("test-shard"),
 				},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser:    ptr.To(int64(999)),
@@ -145,7 +147,8 @@ func TestBuildPostgresContainer(t *testing.T) {
 		},
 		"with resource requirements": {
 			shard: &multigresv1alpha1.Shard{
-				Spec: multigresv1alpha1.ShardSpec{},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-shard"},
+				Spec:       multigresv1alpha1.ShardSpec{},
 			},
 			poolSpec: multigresv1alpha1.PoolSpec{
 				Postgres: multigresv1alpha1.ContainerConfig{
@@ -193,7 +196,7 @@ func TestBuildPostgresContainer(t *testing.T) {
 						Name:  "PGDATA",
 						Value: PgDataPath,
 					},
-					pgPasswordEnvVar(),
+					pgPasswordEnvVar("test-shard"),
 				},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser:    ptr.To(int64(999)),
@@ -329,7 +332,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 							},
 						},
 					},
-					connpoolAdminPasswordEnvVar(),
+					connpoolAdminPasswordEnvVar("test-shard"),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -434,7 +437,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 							},
 						},
 					},
-					connpoolAdminPasswordEnvVar(),
+					connpoolAdminPasswordEnvVar("custom-shard"),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -557,7 +560,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 							},
 						},
 					},
-					connpoolAdminPasswordEnvVar(),
+					connpoolAdminPasswordEnvVar("resource-shard"),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{

--- a/pkg/resource-handler/controller/shard/integration_test.go
+++ b/pkg/resource-handler/controller/shard/integration_test.go
@@ -396,7 +396,7 @@ func TestShardReconciliation(t *testing.T) {
 												ValueFrom: &corev1.EnvVarSource{
 													SecretKeyRef: &corev1.SecretKeySelector{
 														LocalObjectReference: corev1.LocalObjectReference{
-															Name: shardcontroller.PostgresPasswordSecretName,
+															Name: shardcontroller.PostgresPasswordSecretName("test-shard"),
 														},
 														Key: shardcontroller.PostgresPasswordSecretKey,
 													},
@@ -438,7 +438,7 @@ func TestShardReconciliation(t *testing.T) {
 												ValueFrom: &corev1.EnvVarSource{
 													SecretKeyRef: &corev1.SecretKeySelector{
 														LocalObjectReference: corev1.LocalObjectReference{
-															Name: shardcontroller.PostgresPasswordSecretName,
+															Name: shardcontroller.PostgresPasswordSecretName("test-shard"),
 														},
 														Key: shardcontroller.PostgresPasswordSecretKey,
 													},
@@ -488,7 +488,7 @@ func TestShardReconciliation(t *testing.T) {
 										VolumeSource: corev1.VolumeSource{
 											ConfigMap: &corev1.ConfigMapVolumeSource{
 												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "pg-hba-template",
+													Name: shardcontroller.PgHbaConfigMapName("test-shard"),
 												},
 												DefaultMode: ptr.To(int32(420)),
 											},
@@ -805,7 +805,7 @@ func TestShardReconciliation(t *testing.T) {
 												ValueFrom: &corev1.EnvVarSource{
 													SecretKeyRef: &corev1.SecretKeySelector{
 														LocalObjectReference: corev1.LocalObjectReference{
-															Name: shardcontroller.PostgresPasswordSecretName,
+															Name: shardcontroller.PostgresPasswordSecretName("delete-policy-shard"),
 														},
 														Key: shardcontroller.PostgresPasswordSecretKey,
 													},
@@ -847,7 +847,7 @@ func TestShardReconciliation(t *testing.T) {
 												ValueFrom: &corev1.EnvVarSource{
 													SecretKeyRef: &corev1.SecretKeySelector{
 														LocalObjectReference: corev1.LocalObjectReference{
-															Name: shardcontroller.PostgresPasswordSecretName,
+															Name: shardcontroller.PostgresPasswordSecretName("delete-policy-shard"),
 														},
 														Key: shardcontroller.PostgresPasswordSecretKey,
 													},
@@ -890,7 +890,7 @@ func TestShardReconciliation(t *testing.T) {
 										VolumeSource: corev1.VolumeSource{
 											ConfigMap: &corev1.ConfigMapVolumeSource{
 												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "pg-hba-template",
+													Name: shardcontroller.PgHbaConfigMapName("delete-policy-shard"),
 												},
 												DefaultMode: ptr.To(int32(420)),
 											},
@@ -1240,7 +1240,7 @@ func TestShardReconciliation(t *testing.T) {
 										VolumeSource: corev1.VolumeSource{
 											ConfigMap: &corev1.ConfigMapVolumeSource{
 												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "pg-hba-template",
+													Name: shardcontroller.PgHbaConfigMapName("multi-cell-shard"),
 												},
 												DefaultMode: ptr.To(int32(420)),
 											},
@@ -1357,7 +1357,7 @@ func TestShardReconciliation(t *testing.T) {
 												ValueFrom: &corev1.EnvVarSource{
 													SecretKeyRef: &corev1.SecretKeySelector{
 														LocalObjectReference: corev1.LocalObjectReference{
-															Name: shardcontroller.PostgresPasswordSecretName,
+															Name: shardcontroller.PostgresPasswordSecretName("multi-cell-shard"),
 														},
 														Key: shardcontroller.PostgresPasswordSecretKey,
 													},
@@ -1399,7 +1399,7 @@ func TestShardReconciliation(t *testing.T) {
 												ValueFrom: &corev1.EnvVarSource{
 													SecretKeyRef: &corev1.SecretKeySelector{
 														LocalObjectReference: corev1.LocalObjectReference{
-															Name: shardcontroller.PostgresPasswordSecretName,
+															Name: shardcontroller.PostgresPasswordSecretName("multi-cell-shard"),
 														},
 														Key: shardcontroller.PostgresPasswordSecretKey,
 													},
@@ -1518,7 +1518,7 @@ func TestShardReconciliation(t *testing.T) {
 										VolumeSource: corev1.VolumeSource{
 											ConfigMap: &corev1.ConfigMapVolumeSource{
 												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "pg-hba-template",
+													Name: shardcontroller.PgHbaConfigMapName("multi-cell-shard"),
 												},
 												DefaultMode: ptr.To(int32(420)),
 											},
@@ -1635,7 +1635,7 @@ func TestShardReconciliation(t *testing.T) {
 												ValueFrom: &corev1.EnvVarSource{
 													SecretKeyRef: &corev1.SecretKeySelector{
 														LocalObjectReference: corev1.LocalObjectReference{
-															Name: shardcontroller.PostgresPasswordSecretName,
+															Name: shardcontroller.PostgresPasswordSecretName("multi-cell-shard"),
 														},
 														Key: shardcontroller.PostgresPasswordSecretKey,
 													},
@@ -1677,7 +1677,7 @@ func TestShardReconciliation(t *testing.T) {
 												ValueFrom: &corev1.EnvVarSource{
 													SecretKeyRef: &corev1.SecretKeySelector{
 														LocalObjectReference: corev1.LocalObjectReference{
-															Name: shardcontroller.PostgresPasswordSecretName,
+															Name: shardcontroller.PostgresPasswordSecretName("multi-cell-shard"),
 														},
 														Key: shardcontroller.PostgresPasswordSecretKey,
 													},
@@ -2041,7 +2041,7 @@ func TestReconcileDeletions(t *testing.T) {
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pg-hba-template",
+			Name:      shardcontroller.PgHbaConfigMapName("test-shard-deletion-reconcile"),
 			Namespace: "default",
 		},
 	}
@@ -2050,7 +2050,7 @@ func TestReconcileDeletions(t *testing.T) {
 	// We use polling to avoid strict content matching on Data
 	pollFound := false
 	for i := 0; i < 20; i++ {
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: "pg-hba-template", Namespace: "default"}, cm)
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: shardcontroller.PgHbaConfigMapName("test-shard-deletion-reconcile"), Namespace: "default"}, cm)
 		if err == nil {
 			pollFound = true
 			break
@@ -2085,7 +2085,7 @@ func TestReconcileDeletions(t *testing.T) {
 		default:
 		}
 
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: "pg-hba-template", Namespace: "default"}, cm)
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: shardcontroller.PgHbaConfigMapName("test-shard-deletion-reconcile"), Namespace: "default"}, cm)
 		if err == nil {
 			found = true
 			break

--- a/pkg/resource-handler/controller/shard/pool_statefulset_test.go
+++ b/pkg/resource-handler/controller/shard/pool_statefulset_test.go
@@ -157,7 +157,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 											Name:  "PGDATA",
 											Value: "/var/lib/pooler/pg_data",
 										},
-										pgPasswordEnvVar(),
+										pgPasswordEnvVar("test-shard"),
 									},
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser:    ptr.To(int64(999)),
@@ -204,7 +204,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 									"zone1",
 								),
 								buildSocketDirVolume(),
-								buildPgHbaVolume(),
+								buildPgHbaVolume("test-shard"),
 							},
 						},
 					},
@@ -369,7 +369,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 											Name:  "PGDATA",
 											Value: "/var/lib/pooler/pg_data",
 										},
-										pgPasswordEnvVar(),
+										pgPasswordEnvVar("shard-001"),
 									},
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser:    ptr.To(int64(999)),
@@ -416,7 +416,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 									"zone-west",
 								),
 								buildSocketDirVolume(),
-								buildPgHbaVolume(),
+								buildPgHbaVolume("shard-001"),
 							},
 						},
 					},
@@ -574,7 +574,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 											Name:  "PGDATA",
 											Value: "/var/lib/pooler/pg_data",
 										},
-										pgPasswordEnvVar(),
+										pgPasswordEnvVar("shard-002"),
 									},
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser:    ptr.To(int64(999)),
@@ -621,7 +621,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 									"zone1",
 								),
 								buildSocketDirVolume(),
-								buildPgHbaVolume(),
+								buildPgHbaVolume("shard-002"),
 							},
 						},
 					},
@@ -814,7 +814,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 											Name:  "PGDATA",
 											Value: "/var/lib/pooler/pg_data",
 										},
-										pgPasswordEnvVar(),
+										pgPasswordEnvVar("shard-affinity"),
 									},
 									SecurityContext: &corev1.SecurityContext{
 										RunAsUser:    ptr.To(int64(999)),
@@ -861,7 +861,7 @@ func TestBuildPoolStatefulSet(t *testing.T) {
 									"zone1",
 								),
 								buildSocketDirVolume(),
-								buildPgHbaVolume(),
+								buildPgHbaVolume("shard-affinity"),
 							},
 							Affinity: &corev1.Affinity{
 								NodeAffinity: &corev1.NodeAffinity{

--- a/pkg/resource-handler/controller/shard/secret.go
+++ b/pkg/resource-handler/controller/shard/secret.go
@@ -30,7 +30,7 @@ func BuildPostgresPasswordSecret(
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      PostgresPasswordSecretName,
+			Name:      PostgresPasswordSecretName(shard.Name),
 			Namespace: shard.Namespace,
 			Labels:    labels,
 		},

--- a/pkg/resource-handler/controller/shard/secret_test.go
+++ b/pkg/resource-handler/controller/shard/secret_test.go
@@ -34,7 +34,7 @@ func TestBuildPostgresPasswordSecret(t *testing.T) {
 			scheme: scheme,
 			want: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      PostgresPasswordSecretName,
+					Name:      PostgresPasswordSecretName("test-shard"),
 					Namespace: "default",
 					Labels: map[string]string{
 						"app.kubernetes.io/name":       "multigres",

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -468,8 +468,8 @@ func TestReconcile_PatchError(t *testing.T) {
 					},
 				}
 			},
-			getFailObj: func(_ *multigresv1alpha1.Shard) string {
-				return PostgresPasswordSecretName
+			getFailObj: func(s *multigresv1alpha1.Shard) string {
+				return PostgresPasswordSecretName(s.Name)
 			},
 			reconcileFunc: func(r *ShardReconciler, ctx context.Context, shard *multigresv1alpha1.Shard) error {
 				return r.reconcilePostgresPasswordSecret(ctx, shard)
@@ -488,8 +488,8 @@ func TestReconcile_PatchError(t *testing.T) {
 					},
 				}
 			},
-			getFailObj: func(_ *multigresv1alpha1.Shard) string {
-				return PgHbaConfigMapName
+			getFailObj: func(s *multigresv1alpha1.Shard) string {
+				return PgHbaConfigMapName(s.Name)
 			},
 			reconcileFunc: func(r *ShardReconciler, ctx context.Context, shard *multigresv1alpha1.Shard) error {
 				return r.reconcilePgHbaConfigMap(ctx, shard)

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -417,7 +417,7 @@ func TestShardReconciler_Reconcile(t *testing.T) {
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "pg-hba-template",
+						Name:      PgHbaConfigMapName("existing-shard"),
 						Namespace: "default",
 					},
 				},
@@ -891,7 +891,7 @@ func TestShardReconciler_Reconcile(t *testing.T) {
 			},
 			failureConfig: &testutil.FailureConfig{
 				OnGet: func(key client.ObjectKey) error {
-					if key.Name == "pg-hba-template" {
+					if key.Name == PgHbaConfigMapName("test-shard-pghba-get-err") {
 						return testutil.ErrNetworkTimeout
 					}
 					return nil


### PR DESCRIPTION
Fixes Bug 1 by converting the hardcoded constants PgHbaConfigMapName and PostgresPasswordSecretName into functions that accept a string argument, allowing the operator to dynamically construct unique resource names based on the target Shard.

This prevents cross-shard ownership conflicts where multiple Shards in the same namespace would attempt to mutate the exact same Secret and ConfigMap resources.

Changes:
- Refactored PgHbaConfigMapName and PostgresPasswordSecretName to standard functions in containers.go.
- Threaded the specific Shard name downward through container and sidecar builder implementations (buildPgHbaVolume, pgPasswordEnvVar, connpoolAdminPasswordEnvVar, buildPostgresContainer, buildPgctldContainer, buildMultiPoolerSidecar).
- Refactored BuildPgHbaConfigMap in configmap.go and BuildPostgresPasswordSecret in secret.go.
- Updated all integration and unit test specifications across the shard and multigrescluster packages. Assured complete functionality and compliance for robust 100% statement coverage.