### PR TITLE
fix(resolver): merge StorageSpec field-by-field

### DIFF
--- a/pkg/resolver/cluster.go
+++ b/pkg/resolver/cluster.go
@@ -293,7 +293,13 @@ func mergeEtcdSpec(base *multigresv1alpha1.EtcdSpec, override *multigresv1alpha1
 		base.Replicas = override.Replicas
 	}
 	if override.Storage.Size != "" {
-		base.Storage = override.Storage
+		base.Storage.Size = override.Storage.Size
+	}
+	if override.Storage.Class != "" {
+		base.Storage.Class = override.Storage.Class
+	}
+	if len(override.Storage.AccessModes) > 0 {
+		base.Storage.AccessModes = override.Storage.AccessModes
 	}
 	if !isResourcesZero(override.Resources) {
 		base.Resources = *override.Resources.DeepCopy()

--- a/pkg/resolver/shard.go
+++ b/pkg/resolver/shard.go
@@ -218,7 +218,13 @@ func mergePoolSpec(
 		out.ReplicasPerCell = override.ReplicasPerCell
 	}
 	if override.Storage.Size != "" {
-		out.Storage = override.Storage
+		out.Storage.Size = override.Storage.Size
+	}
+	if override.Storage.Class != "" {
+		out.Storage.Class = override.Storage.Class
+	}
+	if len(override.Storage.AccessModes) > 0 {
+		out.Storage.AccessModes = override.Storage.AccessModes
 	}
 	// Safety: Use DeepCopy to avoid sharing pointers to maps within ResourceRequirements
 	if !isResourcesZero(override.Postgres.Resources) {

--- a/pkg/resolver/shard_test.go
+++ b/pkg/resolver/shard_test.go
@@ -534,6 +534,136 @@ func TestMergeShardConfig(t *testing.T) {
 				},
 			},
 		},
+		"Storage Override Only Size Preserves Class And AccessModes": {
+			tpl: &multigresv1alpha1.ShardTemplate{
+				Spec: multigresv1alpha1.ShardTemplateSpec{
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"p1": {
+							Type: "read",
+							Storage: multigresv1alpha1.StorageSpec{
+								Size:  "10Gi",
+								Class: "fast-ssd",
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+							},
+						},
+					},
+				},
+			},
+			overrides: &multigresv1alpha1.ShardOverrides{
+				Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+					"p1": {Storage: multigresv1alpha1.StorageSpec{Size: "100Gi"}},
+				},
+			},
+			wantOrch: multigresv1alpha1.MultiOrchSpec{},
+			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"p1": {
+					Type: "read",
+					Storage: multigresv1alpha1.StorageSpec{
+						Size:        "100Gi",
+						Class:       "fast-ssd",
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+				},
+			},
+		},
+		"Storage Override Only Class Preserves Size": {
+			tpl: &multigresv1alpha1.ShardTemplate{
+				Spec: multigresv1alpha1.ShardTemplateSpec{
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"p1": {
+							Type:    "read",
+							Storage: multigresv1alpha1.StorageSpec{Size: "10Gi", Class: "standard"},
+						},
+					},
+				},
+			},
+			overrides: &multigresv1alpha1.ShardOverrides{
+				Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+					"p1": {Storage: multigresv1alpha1.StorageSpec{Class: "gp3"}},
+				},
+			},
+			wantOrch: multigresv1alpha1.MultiOrchSpec{},
+			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"p1": {
+					Type:    "read",
+					Storage: multigresv1alpha1.StorageSpec{Size: "10Gi", Class: "gp3"},
+				},
+			},
+		},
+		"Storage Override Only AccessModes Preserves Size And Class": {
+			tpl: &multigresv1alpha1.ShardTemplate{
+				Spec: multigresv1alpha1.ShardTemplateSpec{
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"p1": {
+							Type:    "read",
+							Storage: multigresv1alpha1.StorageSpec{Size: "10Gi", Class: "fast-ssd"},
+						},
+					},
+				},
+			},
+			overrides: &multigresv1alpha1.ShardOverrides{
+				Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+					"p1": {
+						Storage: multigresv1alpha1.StorageSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+						},
+					},
+				},
+			},
+			wantOrch: multigresv1alpha1.MultiOrchSpec{},
+			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"p1": {
+					Type: "read",
+					Storage: multigresv1alpha1.StorageSpec{
+						Size:        "10Gi",
+						Class:       "fast-ssd",
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+					},
+				},
+			},
+		},
+		"Storage Override All Fields": {
+			tpl: &multigresv1alpha1.ShardTemplate{
+				Spec: multigresv1alpha1.ShardTemplateSpec{
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"p1": {
+							Type: "read",
+							Storage: multigresv1alpha1.StorageSpec{
+								Size:  "10Gi",
+								Class: "standard",
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+							},
+						},
+					},
+				},
+			},
+			overrides: &multigresv1alpha1.ShardOverrides{
+				Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+					"p1": {
+						Storage: multigresv1alpha1.StorageSpec{
+							Size:        "500Gi",
+							Class:       "io2",
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+						},
+					},
+				},
+			},
+			wantOrch: multigresv1alpha1.MultiOrchSpec{},
+			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"p1": {
+					Type: "read",
+					Storage: multigresv1alpha1.StorageSpec{
+						Size:        "500Gi",
+						Class:       "io2",
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
mergePoolSpec and mergeEtcdSpec replaced the entire StorageSpec struct when only Size was non-empty. This wiped Class and AccessModes on partial overrides, and silently ignored overrides that only set Class (since the Size != "" gate blocked them).

- Replace struct-level assignment with per-field merging for Size, Class, and AccessModes in mergePoolSpec (shard.go) and mergeEtcdSpec (cluster.go)
- Follow the pattern already established in MergeBackupConfig in common_types.go

Partial storage overrides now preserve unrelated base fields, and Class-only or AccessModes-only overrides are no longer silently ignored. Test cases added for all permutations.