### PR TITLE
refactor(webhook): remove dead Options fields

### DIFF
--- a/pkg/webhook/doc.go
+++ b/pkg/webhook/doc.go
@@ -29,7 +29,6 @@ limitations under the License.
 // # Configuration
 //
 // The [Options] struct controls webhook behavior:
-//   - Enable: Whether to start the webhook server.
 //   - Namespace: Operator namespace for service account identity.
 //   - ServiceAccountName: Used to construct the operator principal for child
 //     resource validation (only the operator can modify its managed resources).

--- a/pkg/webhook/integration_test.go
+++ b/pkg/webhook/integration_test.go
@@ -116,9 +116,7 @@ func TestMain(m *testing.M) {
 	res := resolver.NewResolver(cachedClient, testNamespace)
 
 	if err := multigreswebhook.Setup(mgr, res, multigreswebhook.Options{
-		Enable:       true,
-		CertStrategy: "external",
-		Namespace:    testNamespace,
+		Namespace: testNamespace,
 	}); err != nil {
 		fmt.Printf("Failed to setup webhooks: %v\n", err)
 		os.Exit(1)

--- a/pkg/webhook/setup.go
+++ b/pkg/webhook/setup.go
@@ -13,9 +13,6 @@ import (
 
 // Options contains the configuration required to set up the webhook server.
 type Options struct {
-	Enable             bool
-	CertStrategy       string // Deprecated: Kept for compat but ignored
-	CertDir            string // Deprecated: Kept for compat but ignored
 	Namespace          string
 	ServiceAccountName string
 }

--- a/pkg/webhook/setup_test.go
+++ b/pkg/webhook/setup_test.go
@@ -114,17 +114,6 @@ func TestSetup(t *testing.T) {
 			resolver: baseResolver,
 			opts:     Options{Namespace: "default"}, // Empty ServiceAccountName
 		},
-		"Happy Path: Disabled": {
-			mgrFunc: func(t *testing.T) *mockManager {
-				return &mockManager{
-					schemeFunc: func() *runtime.Scheme { return baseScheme },
-					client:     baseClient,
-					server:     &mockServer{},
-				}
-			},
-			resolver: baseResolver,
-			opts:     Options{Enable: false},
-		},
 		"Error: Nil Resolver": {
 			mgrFunc: func(t *testing.T) *mockManager {
 				return &mockManager{server: &mockServer{}}


### PR DESCRIPTION
The Options struct carried Enable, CertStrategy, and CertDir fields that were never used by Setup(). Enable was gated by the caller in main.go, while CertStrategy and CertDir were explicitly marked as deprecated and ignored.

- Remove Enable, CertStrategy, CertDir from webhook.Options
- Remove "Happy Path: Disabled" test case for the dead Enable field
- Remove Enable and CertStrategy from integration test Options literal
- Update doc.go to drop stale Enable documentation

Reduces API surface to only the fields that matter: Namespace and ServiceAccountName.