### PR TITLE
fix(rbac): add watch verb for storageclasses

### DIFF
--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -39,7 +39,7 @@ import (
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,resourceNames=multigres-operator-mutating-webhook-configuration,verbs=get;update;patch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,resourceNames=multigres-operator-validating-webhook-configuration,verbs=get;update;patch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=list
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=list;watch
 
 // ============================================================================
 // MultigresClusterSpec Spec (User-editable API)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -112,3 +112,4 @@ rules:
   - storageclasses
   verbs:
   - list
+  - watch


### PR DESCRIPTION
The resolver's hasDefaultStorageClass uses the cached client to list StorageClasses, but controller-runtime's informer cache requires both list and watch permissions to set up its ListWatch reflector.

Having only list caused the StorageClass informer to fail with "storageclasses.storage.k8s.io is forbidden" on every watch attempt, flooding operator logs with errors.