### PR TITLE
fix(cert): add managed-by label to generated secrets

### DIFF
--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -378,6 +378,9 @@ func main() {
 				Owner:             ownerDep,
 				WaitForProjection: true,
 				ComponentName:     "webhook",
+				Labels: map[string]string{
+					"app.kubernetes.io/managed-by": "multigres-operator",
+				},
 				PostReconcileHook: func(ctx context.Context, caBundle []byte) error {
 					return multigreswebhook.PatchWebhookCABundle(ctx, tmpClient, caBundle)
 				},

--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -77,6 +77,13 @@ type Options struct {
 	// like patching webhook configurations with the CA bundle.
 	// If nil, no hook is called.
 	PostReconcileHook func(ctx context.Context, caBundle []byte) error
+
+	// Labels are applied to generated Secret objects. This is required when
+	// secrets are created outside the operator namespace, because the informer
+	// cache filters secrets by label (e.g., managed-by) in non-operator namespaces.
+	// Without the correct labels, secrets are invisible to the cached client,
+	// causing Get to return NotFound even after Create succeeds.
+	Labels map[string]string
 }
 
 func (o *Options) componentName() string {
@@ -193,6 +200,7 @@ func (m *CertRotator) ensureCA(ctx context.Context) (*CAArtifacts, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Options.CASecretName,
 			Namespace: m.Options.Namespace,
+			Labels:    m.Options.Labels,
 		},
 	}
 
@@ -259,6 +267,7 @@ func (m *CertRotator) ensureServerCert(ctx context.Context, ca *CAArtifacts) ([]
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Options.ServerSecretName,
 			Namespace: m.Options.Namespace,
+			Labels:    m.Options.Labels,
 		},
 	}
 

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -26,6 +26,7 @@ import (
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/cert"
 	"github.com/numtide/multigres-operator/pkg/monitoring"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
 	"github.com/numtide/multigres-operator/pkg/util/name"
 )
 
@@ -390,6 +391,7 @@ func (r *ShardReconciler) reconcilePgBackRestCerts(
 	}
 
 	// Auto-generate: use pkg/cert to create CA + server cert Secrets.
+	clusterName := shard.Labels[metadata.LabelMultigresCluster]
 	rotator := cert.NewManager(r.Client, r.Recorder, cert.Options{
 		Namespace:        shard.Namespace,
 		CASecretName:     shard.Name + "-pgbackrest-ca",
@@ -401,6 +403,7 @@ func (r *ShardReconciler) reconcilePgBackRestCerts(
 		Organization:  "Multigres",
 		Owner:         shard,
 		ComponentName: "pgbackrest",
+		Labels:        metadata.BuildStandardLabels(clusterName, "pgbackrest-tls"),
 	})
 	return rotator.Bootstrap(ctx)
 }

--- a/plans/phase-1/implementation-notes.md
+++ b/plans/phase-1/implementation-notes.md
@@ -238,6 +238,7 @@ The operator includes a generic, consumer-agnostic TLS certificate lifecycle man
 | `ComponentName` | Label for Kubernetes Events (e.g. `"webhook"`) | `"cert"` |
 | `RotationInterval` | How often the background loop checks | `1h` |
 | `PostReconcileHook` | Callback after each successful reconcile | `nil` |
+| `Labels` | Labels applied to generated Secret objects (required outside operator NS) | `nil` |
 | `Owner` | `metav1.Object` for owner references | `nil` |
 | `WaitForProjection` | Block until cert file matches Secret on disk | `false` |
 
@@ -308,7 +309,11 @@ func (r *MultigresClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 **Potential Issues:**
 If the controller logic *depended* on reading its own status to make decisions (e.g. "If status is 'Initializing', do X"), using this predicate would break that logic because the controller wouldn't wake up after setting 'Initializing'.
-*   *Mitigation:* Our controllers are designed to be level-triggered based on `Spec` and child resources. We do not use the primary resource's `Status` as a state machine driver; `Status` is purely an output observation.
+
+> [!CAUTION]
+> If you ever need a controller to make decisions based on its own `.status` fields, you **must remove** this predicate from that controller's `For` clause. Otherwise the controller will never re-reconcile after writing its own status, effectively deadlocking. This trade-off is acceptable only when status is purely observational output.
+
+*   *Current design:* Our controllers are level-triggered based on `Spec` and child resources. We do not use the primary resource's `Status` as a state machine driver; `Status` is purely an output observation.
 
 **Child Resources (Why we don't use it there):**
 We do *not* apply this predicate to child resources (`Owns`). We must react to child resource status transitions (e.g., a Deployment becoming Ready, a Pod changing state) to update the parent's status. Each parent only monitors the status of its *immediate* children (e.g. `MultigresCluster` watches `Cell`, but not `StatefulSet` directly if `Cell` owns it).


### PR DESCRIPTION
The CertRotator in pkg/cert created CA and TLS secrets without the app.kubernetes.io/managed-by label. When these secrets were created outside the operator namespace (e.g., pgBackRest TLS certs in user namespaces), the informer cache — which filters secrets by that label — could not see them. This caused ensureCA/ensureServerCert to enter infinite recursion: Get returns NotFound (cache miss), Create returns AlreadyExists (secret exists on API server), the AlreadyExists handler recursively retries, and the loop never terminates. The blocked goroutine prevented the shard controller from ever updating status, leaving MultigresCluster stuck in Progressing indefinitely.

- Add Labels field to cert.Options, applied to secrets in ensureCA and ensureServerCert in manager.go
- Pass metadata.BuildStandardLabels in shard_controller.go for pgBackRest cert secrets
- Add managed-by label to webhook cert Options in main.go for consistency
- Strengthen GenerationChangedPredicate warning and add Labels to cert.Options table in implementation-notes.md

Fixes shard controller deadlock; MultigresCluster now reaches Healthy.