### PR TITLE
docs(design): sync api design with current implementation and pod logic

### DIFF
--- a/pkg/monitoring/recorder_test.go
+++ b/pkg/monitoring/recorder_test.go
@@ -140,6 +140,84 @@ func TestRecordWebhookRequest(t *testing.T) {
 	}
 }
 
+func TestSetPoolPodsDrifted(t *testing.T) {
+	t.Cleanup(func() { poolPodsDrifted.Reset() })
+
+	SetPoolPodsDrifted("cluster-1", "shard-1", "primary", "zone-a", "default", 3)
+
+	val := gaugeValue(t, poolPodsDrifted, "cluster-1", "shard-1", "primary", "zone-a", "default")
+	if val != 3 {
+		t.Errorf("expected poolPodsDrifted gauge to be 3, got %f", val)
+	}
+
+	SetPoolPodsDrifted("cluster-1", "shard-1", "primary", "zone-a", "default", 0)
+	val = gaugeValue(t, poolPodsDrifted, "cluster-1", "shard-1", "primary", "zone-a", "default")
+	if val != 0 {
+		t.Errorf("expected poolPodsDrifted gauge to be 0, got %f", val)
+	}
+}
+
+func TestSetLastBackupAge(t *testing.T) {
+	t.Cleanup(func() { lastBackupAgeSeconds.Reset() })
+
+	age := 30 * time.Minute
+	SetLastBackupAge("cluster-1", "shard-1", "default", age)
+
+	val := gaugeValue(t, lastBackupAgeSeconds, "cluster-1", "shard-1", "default")
+	if val != age.Seconds() {
+		t.Errorf("expected lastBackupAgeSeconds gauge to be %f, got %f", age.Seconds(), val)
+	}
+}
+
+func TestIncrementDrainOperations(t *testing.T) {
+	t.Cleanup(func() { drainOperationsTotal.Reset() })
+
+	IncrementDrainOperations("cluster-1", "shard-1", "success")
+	IncrementDrainOperations("cluster-1", "shard-1", "success")
+	IncrementDrainOperations("cluster-1", "shard-1", "error")
+
+	successVal := counterValue(t, drainOperationsTotal, "cluster-1", "shard-1", "success")
+	if successVal != 2 {
+		t.Errorf("expected drain success counter=2, got %f", successVal)
+	}
+	errorVal := counterValue(t, drainOperationsTotal, "cluster-1", "shard-1", "error")
+	if errorVal != 1 {
+		t.Errorf("expected drain error counter=1, got %f", errorVal)
+	}
+}
+
+func TestSetRollingUpdateInProgress(t *testing.T) {
+	t.Cleanup(func() { rollingUpdateInProgress.Reset() })
+
+	SetRollingUpdateInProgress("cluster-1", "shard-1", "primary", "zone-a", "default", true)
+	val := gaugeValue(
+		t,
+		rollingUpdateInProgress,
+		"cluster-1",
+		"shard-1",
+		"primary",
+		"zone-a",
+		"default",
+	)
+	if val != 1 {
+		t.Errorf("expected rollingUpdateInProgress=1 when true, got %f", val)
+	}
+
+	SetRollingUpdateInProgress("cluster-1", "shard-1", "primary", "zone-a", "default", false)
+	val = gaugeValue(
+		t,
+		rollingUpdateInProgress,
+		"cluster-1",
+		"shard-1",
+		"primary",
+		"zone-a",
+		"default",
+	)
+	if val != 0 {
+		t.Errorf("expected rollingUpdateInProgress=0 when false, got %f", val)
+	}
+}
+
 // --- helpers ---
 
 func gaugeValue(t *testing.T, vec *prometheus.GaugeVec, labels ...string) float64 {

--- a/pkg/resolver/cluster_test.go
+++ b/pkg/resolver/cluster_test.go
@@ -658,6 +658,52 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				},
 			},
 		},
+		// COVERAGE: inline AccessModes override replaces base AccessModes (mergeEtcdSpec branch)
+		"Inline AccessModes Override": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+						TemplateRef: "access-modes-base",
+						Etcd: &multigresv1alpha1.EtcdSpec{
+							Storage: multigresv1alpha1.StorageSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteMany,
+								},
+							},
+						},
+					},
+				},
+			},
+			objects: []client.Object{
+				&multigresv1alpha1.CoreTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "access-modes-base", Namespace: "default"},
+					Spec: multigresv1alpha1.CoreTemplateSpec{
+						GlobalTopoServer: &multigresv1alpha1.TopoServerSpec{
+							Etcd: &multigresv1alpha1.EtcdSpec{
+								Image: "base-image",
+								Storage: multigresv1alpha1.StorageSpec{
+									Size: "10Gi",
+									AccessModes: []corev1.PersistentVolumeAccessMode{
+										corev1.ReadWriteOnce,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &multigresv1alpha1.GlobalTopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{
+					Image:     "base-image",
+					Replicas:  ptr.To(DefaultEtcdReplicas),
+					Resources: DefaultResourcesEtcd(),
+					Storage: multigresv1alpha1.StorageSpec{
+						Size:        "10Gi",
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -87,6 +87,7 @@ func setupScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = multigresv1alpha1.AddToScheme(scheme)
 	_ = storagev1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 	return scheme
 }
 

--- a/pkg/resolver/shard_test.go
+++ b/pkg/resolver/shard_test.go
@@ -850,6 +850,18 @@ func TestDefaultBackupConfig(t *testing.T) {
 			t.Errorf("Filesystem should be nil for S3 type, got %+v", cfg.Filesystem)
 		}
 	})
+
+	t.Run("sets default type when empty", func(t *testing.T) {
+		t.Parallel()
+		cfg := &multigresv1alpha1.BackupConfig{}
+		defaultBackupConfig(cfg)
+		if cfg.Type != multigresv1alpha1.BackupTypeFilesystem {
+			t.Errorf("Type = %q, want %q", cfg.Type, multigresv1alpha1.BackupTypeFilesystem)
+		}
+		if cfg.Filesystem == nil {
+			t.Fatal("Filesystem = nil, want non-nil")
+		}
+	})
 }
 
 func TestResolveShard_InheritedBackup(t *testing.T) {

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -6,6 +6,7 @@ import (
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/testutil"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -181,6 +182,31 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 		Build()
 
 	noSCClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shardTpl).Build()
+
+	nodeZoneA := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-zone-a",
+			Labels: map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
+		},
+	}
+	nodeRegionEast := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-region-east",
+			Labels: map[string]string{"topology.kubernetes.io/region": "us-east-1"},
+		},
+	}
+	withZoneAClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(shardTpl, defaultSC, nodeZoneA).
+		Build()
+	withRegionClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(shardTpl, defaultSC, nodeRegionEast).
+		Build()
+	noMatchingNodeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(shardTpl, defaultSC).
+		Build()
 
 	tests := map[string]struct {
 		cluster        *multigresv1alpha1.MultigresCluster
@@ -452,6 +478,119 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 				},
 			},
 			// Uses fakeClient which HAS a default StorageClass
+		},
+		// COVERAGE: validateCellTopology zone/region branches
+		"Cell Zone matches node - no topology warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-a", Zone: "us-east-1a"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			customClient: withZoneAClient,
+		},
+		"Cell Zone no matching node - topology warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-b", Zone: "us-west-2a"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			customClient: noMatchingNodeClient,
+			wantWarnings: []string{
+				"no nodes currently match topology.kubernetes.io/zone=us-west-2a",
+			},
+		},
+		"Cell Region matches node - no topology warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "region-east", Region: "us-east-1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			customClient: withRegionClient,
+		},
+		"Cell Region no matching node - topology warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "region-eu", Region: "eu-west-1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			customClient: noMatchingNodeClient,
+			wantWarnings: []string{
+				"no nodes currently match topology.kubernetes.io/region=eu-west-1",
+			},
+		},
+		// COVERAGE: filesystem backup AccessModes branch (isRWO=false path)
+		"Filesystem RWX backup suppresses replica warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Storage: multigresv1alpha1.StorageSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteMany,
+								},
+							},
+						},
+					},
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			// wantWarnings is nil: ReadWriteMany sets isRWO=false, suppressing the replica warning
 		},
 		"SC list error propagated": {
 			cluster: &multigresv1alpha1.MultigresCluster{

--- a/plans/phase-1/api-design/multigres-operator-api-v1alpha1-design.md
+++ b/plans/phase-1/api-design/multigres-operator-api-v1alpha1-design.md
@@ -1,6 +1,9 @@
 # MultigresCluster API v1alpha1
 
-This is the final design we will be using to implement the operator based on discussions with the Multigres team.
+This is the API design for the Multigres Operator, based on discussions with the Multigres team. The design is approved and implemented — see [pod-management-architecture.md](../pod-management-architecture.md) for operational details.
+
+> [!NOTE]
+> This document is kept as a living reference. Sections are updated as the implementation evolves as a best effort. The Go types in `api/v1alpha1/` are the authoritative source of truth for field names, types, and validation rules. This document provides architectural context and rationale.
 
 ## Summary
 
@@ -52,21 +55,31 @@ The formalized parent/child model addresses these by ensuring:
       │
       ├── 🤖 MultiAdmin Resources ← 📄 Uses [CoreTemplate] OR inline [spec]
       │
-      ├── 💠 [Cell] (Child CR) ← 📄 Uses [CellTemplate] OR inline [spec]
+      ├── 🌐 MultiAdminWeb Resources ← � Uses [CoreTemplate] OR inline [spec]
+      │
+      ├── �💠 [Cell] (Child CR) ← 📄 Uses [CellTemplate] OR inline [spec]
       │    │
-      │    ├── 🚪 MultiGateway Resources
+      │    ├── 🚪 MultiGateway Resources (Deployment + Service)
       │    └── 📡 [LocalTopoServer] (Child CR, optional)
       │
       └── 🗃️ [TableGroup] (Child CR)
            │
            └── 📦 [Shard] (Child CR) ← 📄 Uses [ShardTemplate] OR inline [spec]
                 │
-                ├── 🧠 MultiOrch Resources (Deployment/Pod)
-                └── 🏊 Pools (StatefulSets for Postgres+MultiPooler)
+                ├── 🧠 MultiOrch Resources (Deployment per cell)
+                └── 🏊 Pools (per cell):
+                     ├── Pod-0  ← operator-managed, owns data PVC-0
+                     ├── Pod-1  ← operator-managed, owns data PVC-1
+                     ├── PVC-0, PVC-1  ← operator-managed (data)
+                     ├── PodDisruptionBudget  ← per pool per cell
+                     ├── Headless Service  ← for pod DNS resolution
+                     ├── ConfigMap  ← spec-hash for drift detection
+                     └── Backup PVC (shared, filesystem only)
 
 📄 [CoreTemplate] (User-editable, scoped config)
    ├── globalTopoServer
-   └── multiadmin
+   ├── multiadmin
+   └── multiadminWeb
 
 📄 [CellTemplate] (User-editable, scoped config)
    ├── multigateway
@@ -76,6 +89,9 @@ The formalized parent/child model addresses these by ensuring:
    ├── multiorch
    └── pools (postgres + multipooler)
 ```
+
+> [!IMPORTANT]
+> **Pool pods are managed directly by the operator, not via StatefulSets.** The operator creates Pods and PVCs explicitly, handling sequential provisioning, rolling updates with primary awareness, and a drain state machine for graceful scale-down. See [pod-management-architecture.md](../pod-management-architecture.md) for details.
 
 ## Design Details: API Specification
 
@@ -99,7 +115,7 @@ The formalized parent/child model addresses these by ensuring:
 apiVersion: multigres.com/v1alpha1
 kind: MultigresCluster
 metadata:
-  name: example-cluster
+  name: example-cluster  # max 25 characters (CEL enforced)
   namespace: example
 spec:
   # ----------------------------------------------------------------
@@ -116,6 +132,7 @@ spec:
     multiorch: "multigres/multigres:latest"
     multipooler: "multigres/multigres:latest"
     multiadmin: "multigres/multigres:latest"
+    multiadminWeb: "multigres/multigres:latest"  # MultiAdmin Web UI
     postgres: "postgres:15.3"
 
   # ----------------------------------------------------------------
@@ -192,6 +209,19 @@ spec:
     # --- OPTION 2: Explicit Template Reference ---
     # templateRef: "my-explicit-core-template"
 
+  # MultiAdminWeb is a singleton. It follows the same pattern as MultiAdmin.
+  # It deploys the MultiAdmin Web UI component.
+  # multiadminWeb:
+  #   spec:
+  #     replicas: 1
+  #     resources:
+  #       requests:
+  #         cpu: "100m"
+  #         memory: "128Mi"
+  #       limits:
+  #         cpu: "200m"
+  #         memory: "256Mi"
+
   # ----------------------------------------------------------------
   # Cells Configuration
   # ----------------------------------------------------------------
@@ -250,11 +280,14 @@ spec:
     # bootstrap resources (System Catalog).
     - name: "postgres"
       default: true
+      # backup: override the global backup for this database (optional)
       tablegroups:
         - name: "default"
           default: true
+          # backup: override the database backup for this tablegroup (optional)
+          # pvcDeletionPolicy: override the cluster policy for this tablegroup (optional)
           shards:
-            - name: "0"
+            - name: "0-inf"  # v1alpha1: must be exactly "0-inf" (CEL enforced)
               # define resources for the system default shard
               shardTemplate: "standard-shard-ha"
 
@@ -373,8 +406,58 @@ spec:
                      cells:
                        - "us-east-1c"
 
+  # ----------------------------------------------------------------
+  # PVC Lifecycle Management
+  # ----------------------------------------------------------------
+  # Controls what happens to PVCs when the cluster is deleted or scaled down.
+  # Defaults to Retain/Retain for production safety.
+  pvcDeletionPolicy:
+    whenDeleted: "Retain"  # or "Delete"
+    whenScaled: "Retain"   # or "Delete"
+
+  # ----------------------------------------------------------------
+  # Backup Configuration
+  # ----------------------------------------------------------------
+  # Global backup settings, overridable at database, tablegroup, or shard level.
+  backup:
+    type: "filesystem"  # or "s3"
+    filesystem:
+      path: "/backups"
+      storage:
+        size: "10Gi"
+        class: "standard-rwx"
+    # s3:
+    #   bucket: "my-backups"
+    #   region: "us-east-1"
+    #   endpoint: "http://minio:9000"  # optional, for S3-compatible stores
+    #   keyPrefix: "my-cluster"        # optional
+    #   useEnvCredentials: true         # optional, for IRSA/pod-level creds
+    #   credentialsSecret: "aws-creds" # optional
+    pgbackrestTLS:
+      secretName: ""  # empty = auto-generated by operator; set to use cert-manager
+
+  # ----------------------------------------------------------------
+  # Observability (OpenTelemetry)
+  # ----------------------------------------------------------------
+  # Configures OTEL for data-plane components (multipooler, multiorch, etc.).
+  # When nil, components inherit the operator's own OTEL env vars.
+  # observability:
+  #   otlpEndpoint: "http://otel-collector:4318"  # or "disabled" to turn off
+  #   otlpProtocol: "http/protobuf"  # or "grpc"
+  #   tracesExporter: "otlp"  # otlp, none, console
+  #   metricsExporter: "otlp"
+  #   logsExporter: "otlp"
+  #   metricExportInterval: "30000"  # milliseconds
+  #   metricsTemporality: "cumulative"  # or "delta"
+  #   histogramAggregation: "base2_exponential_bucket_histogram"
+  #   tracesSampler: "parentbased_traceidratio"
+  #   samplingConfigRef:
+  #     name: "otel-sampling-config"  # ConfigMap name
+  #     key: "sampling-config.yaml"
+
 status:
   observedGeneration: 1
+  phase: "Healthy"  # Initializing, Progressing, Healthy, Degraded, Unknown
   conditions:
     - type: Available
       status: "True"
@@ -395,6 +478,11 @@ status:
     production_db:
       readyShards: 3
       totalShards: 3
+  # Tracks which templates were resolved (for template-change enqueuing)
+  resolvedTemplates:
+    coreTemplates: ["cluster-wide-core"]
+    cellTemplates: ["cluster-wide-cell", "standard-cell-ha"]
+    shardTemplates: ["cluster-wide-shard", "standard-shard-ha"]
 ```
 
 ### User Managed CR: CoreTemplate
@@ -513,8 +601,10 @@ spec:
 * When created, templates are not reconciled until referenced by a `MultigresCluster`.
 * Similar to `CellTemplate`, this is a pure configuration object. It defines the "shape" of a shard: its orchestration and its data pools.
 * **`pools` is a MAP, keyed by the pool name:** Using a map structure ensures that overrides are resilient to changes in the underlying template; unlike list arrays where inserting or reordering items shifts indices—potentially causing an override targeting "index 1" to accidentally apply to the wrong pool if the template order changes—keyed maps guarantee that an override for a specific pool (e.g., `main-app`) always targets that exact logical resource, regardless of how other pools are added or organized in the template.
+* **Pools and cells are append-only:** Once a pool or cell is added, it cannot be renamed or removed. This is enforced via CEL rules (`oldSelf.all(k, k in self)`).
 * **MultiOrch Placement:** `multiorch` is deployed to the cells listed in `multiorch.cells`. If this list is empty or omitted, it defaults to all cells where pools are defined.
 * **Pool Placement:** `pools` uses a `cells` list. For `readWrite` pools, this list typically contains only a few cells rather than using all available cells. For `readOnly` pools, this list can contain multiple cells to apply the same configuration across multiple zones and regions.
+* **PVC management:** Pool pods are managed directly by the operator (no StatefulSets). PVC lifecycle is controlled by `PVCDeletionPolicy` at the pool, shard, tablegroup, or cluster level.
 
 ```yaml
 apiVersion: multigres.com/v1alpha1
@@ -576,6 +666,10 @@ spec:
                 operator: In
                 values:
                 - ssd
+      # PVC lifecycle can be controlled per-pool (overrides shard/tablegroup/cluster defaults)
+      # pvcDeletionPolicy:
+      #   whenDeleted: "Delete"
+      #   whenScaled: "Delete"
     dr-replica:
       type: "readOnly"
       # This pool will be deployed to all cells listed here.
@@ -752,7 +846,14 @@ spec:
     registerCell: true
     prunePoolers: true
 
+  # Observability configuration inherited from MultigresCluster
+  # observability:
+  #   otlpEndpoint: "http://otel-collector:4318"
+  #   tracesExporter: "otlp"
+
 status:
+  observedGeneration: 1
+  phase: "Healthy"
   conditions:
   - type: Available
     status: "True"
@@ -919,7 +1020,30 @@ spec:
                   cpu: "2"
                   memory: "1Gi"
 
+  # PVC lifecycle management, inherited from MultigresCluster
+  pvcDeletionPolicy:
+    whenDeleted: "Retain"
+    whenScaled: "Retain"
+
+  # Observability inherited from MultigresCluster
+  # observability:
+  #   otlpEndpoint: "http://otel-collector:4318"
+
+  # Backup config inherited from MultigresCluster -> Database -> TableGroup chain
+  # backup:
+  #   type: "filesystem"
+  #   ...
+
+  # Cell topology labels for nodeSelector injection
+  cellTopologyLabels:
+    us-east-1a:
+      topology.kubernetes.io/zone: "us-east-1a"
+    us-east-1b:
+      topology.kubernetes.io/zone: "us-east-1b"
+
 status:
+  observedGeneration: 1
+  phase: "Healthy"
   readyShards: 3
   totalShards: 3
 ```
@@ -1003,11 +1127,54 @@ spec:
               limits:
                 cpu: "2"
                 memory: "1Gi"
+
+  # PVC lifecycle management, inherited from cluster/tablegroup/shard settings
+  pvcDeletionPolicy:
+    whenDeleted: "Retain"
+    whenScaled: "Retain"
+
+  # Backup configuration, inherited from cluster -> database -> tablegroup chain
+  backup:
+    type: "filesystem"
+    filesystem:
+      path: "/backups"
+      storage:
+        size: "10Gi"
+        class: "standard-rwx"
+    pgbackrestTLS:
+      secretName: ""
+
+  # Observability configuration, inherited from cluster
+  observability:
+    otlpEndpoint: "http://otel-collector:4318"
+    tracesExporter: "otlp"
+    metricsExporter: "otlp"
+
+  # Cell topology labels for nodeSelector injection
+  cellTopologyLabels:
+    us-east-1a:
+      topology.kubernetes.io/zone: "us-east-1a"
+
+  # Total replicas across all pools (for HPA/PDB scale subresource)
+  replicas: 2
+
 status:
+  observedGeneration: 1
+  phase: "Healthy"
+  conditions:
+    - type: Available
+      status: "True"
+      lastTransitionTime: "2025-11-07T12:01:00Z"
   cells:
     - "us-east-1a"
   orchReady: True
   poolsReady: True
+  readyReplicas: 2
+  lastBackupTime: "2025-11-07T06:00:00Z"
+  lastBackupType: "full"
+  podRoles:
+    example-cluster-production-db-orders-tg-0-main-app-us-east-1a-0: "PRIMARY"
+    example-cluster-production-db-orders-tg-0-main-app-us-east-1a-1: "REPLICA"
 ```
 
 ## Defaults & Webhooks
@@ -1055,20 +1222,27 @@ Webhooks are used *only* for fast, synchronous, and semantic validation to preve
 
   * **On `CREATE` and `UPDATE`:**
       * **Template Existence:** Validates that all templates referenced in `spec.templateDefaults` or explicitly in components (Core, Cell, or Shard templates) exist *at the time of application*.
-      * **Component Spec Mutex:** Enforces that `etcd`, `external`, and `templateRef` are mutually exclusive for components like `GlobalTopoServer`.
-      * **Uniqueness:** Validates that all names are unique within their respective scopes:
+      * **Component Spec Mutex:** Enforces that `etcd`, `external`, and `templateRef` are mutually exclusive for components like `GlobalTopoServer` (CEL: exactly one of the three must be set).
+      * **Uniqueness:** Validated via `+listType=map` and `+listMapKey=name` markers, which ensure unique names within their respective scopes:
           * Cell names in `spec.cells`.
           * Database names in `spec.databases`.
           * TableGroup names within a Database.
           * Shard names within a TableGroup.
       * **Topology Integrity:** Verifies that if a Shard is pinned to a specific cell (via overrides), that cell exists in the `spec.cells` list.
-      * **Name Length Safety:** Validates that the combined length of `ClusterName` + `DatabaseName` + `TableGroupName` does not exceed **50 characters**.
-          * *Reasoning:* These names are concatenated to form the TableGroup and Shard names. Kubernetes labels and StatefulSet service names have a strict 63-character limit. Enforcing this limit early prevents downstream deployment failures (e.g., `example-cluster-production-db-orders-tg-0-main-app` must be < 63 chars).
+      * **Name Length Safety:**
+          * `MultigresCluster` name must be ≤ 25 characters (CEL enforced at resource level).
+          * Individual name types have their own limits: `DatabaseName` ≤ 30, `TableGroupName` ≤ 25, `ShardName` ≤ 25, `PoolName` ≤ 25, `CellName` ≤ 30.
+      * **Append-Only Enforcement (CEL Rules):** Several fields use CEL transition rules to prevent potentially destructive removals:
+          * **Cells:** `oldSelf.all(c, c.name in self.map(x, x.name))` — cells cannot be removed or renamed.
+          * **Pool cells:** `oldSelf.all(c, c in self)` — cells cannot be removed from a pool.
+          * **Pool names:** `oldSelf.all(k, k in self)` — pools cannot be removed or renamed.
       * **v1alpha1 Constraints (CEL Rules):** Due to current Multigres Gateway limitations, the following strict validations are applied via CEL:
           * `MaxItems: 1` for `spec.databases`.
           * The single database MUST be named `"postgres"` and marked `default: true`.
           * Any TableGroup marked `default: true` MUST be named `"default"`.
-          * **Mandatory Default TableGroup:** Every defined database must contain exactly one TableGroup marked `default: true`. This prevents users from defining custom tablegroups while forgetting the mandatory "default" catch-all group required by the Gateway.
+          * **Mandatory Default TableGroup:** Every defined database must contain exactly one TableGroup marked `default: true`.
+          * **Shard name:** Must be exactly `"0-inf"` in this version.
+          * **Local TopoServer:** CellInlineSpec blocks `localTopoServer` via CEL (`not yet supported`).
 
 -----
 
@@ -1170,7 +1344,7 @@ spec:
       - name: "default" # Was "tg1"
         default: true   # Added for v1alpha1 validity
         shards:
-          - name: "0"
+          - name: "0-inf"
             # 'spec' and 'shardTemplate' are omitted, so "dev-defaults-shard" is used.
             # We still need to override the 'cell' for the main-app pool.
             overrides:
@@ -1178,13 +1352,6 @@ spec:
                 main-app:
                   cells:
                     - "us-east-1a"
-          - name: "1"
-            # 'spec' and 'shardTemplate' are omitted, so "dev-defaults-shard" is used.
-            overrides:
-              pools:
-                main-app:
-                  cells:
-                    - "us-west-2a"
 ```
 
 ### 3\. The Power User (Explicit Overrides)
@@ -1270,7 +1437,7 @@ spec:
         - name: "default" # Was "auth"
           default: true   # Added for v1alpha1 validity
           shards:
-            - name: "0"
+            - name: "0-inf"
               shardTemplate: "geo-distributed-shard"
               overrides:
                 # MAP-BASED OVERRIDE: Safely targeting 'main-app' pool
@@ -1287,13 +1454,6 @@ spec:
                        limits:
                          cpu: "8"
                          memory: "16Gi"
-            - name: "1"
-              shardTemplate: "geo-distributed-shard"
-              overrides:
-                pools:
-                  main-app:
-                    cells:
-                      - "us-west-2a"
 ```
 
 ## Implementation History
@@ -1310,6 +1470,12 @@ spec:
   * **2025-11-18:** Reverted to the 2025-11-11 monolithic `MultigresCluster` design to align with client requirements for Postgres-native "System Catalog" management. The `MultigresDatabase` CRD was rejected. We will instead support the DDL workflow via a synchronization controller that patches the monolithic `MultigresCluster` CR based on the `SystemCatalog` state.
   * **2025-11-25:** Moved `multiorch` and `pool` placement from single `cell` fields to explicit `cells` lists. This supports multi-cell pool definitions (e.g., for uniform read replicas) and decouples MultiOrch placement from pool presence, while maintaining safety via a "defaults to all" logic.
   * **2026-01-02:** Introduced "System Catalog Smart Defaulting" and strict CEL validation for v1alpha1 to align the API with the current single-database routing limitations of the Multigres Gateway.
+  * **2026-01-15:** Added `PVCDeletionPolicy` at cluster, tablegroup, shard, and pool levels with hierarchical merge logic. Added `BackupConfig` type supporting `filesystem` and `s3` backends, with per-database and per-tablegroup overrides. Added `PgBackRestTLSConfig` for pgBackRest inter-node TLS.
+  * **2026-01-20:** Added `ObservabilityConfig` to propagate OpenTelemetry settings from `MultigresCluster` to data-plane Pods. Settings are resolved from operator environment variables by default.
+  * **2026-01-25:** Added `MultiAdminWebConfig` for the MultiAdmin Web UI component. Added `multiadminWeb` image to `ClusterImages`. Added `podAnnotations` and `podLabels` to `StatelessSpec`.
+  * **2026-02-01:** Added CEL rules for append-only cells, pools, and pool-cell lists to prevent accidental destructive operations. Enforced `MultigresCluster` name ≤ 25 chars. Set shard name to `"0-inf"` for v1alpha1.
+  * **2026-02-10:** Added `CellTopologyLabels` to `ShardSpec` to propagate zone/region labels without the shard controller needing to look up Cell CRs directly. Added `ResolvedTemplates` to `MultigresClusterStatus` for efficient template-change triggered reconciliation.
+  * **2026-02-20:** Pool management migrated from StatefulSets to direct operator-managed Pods and PVCs. Added scale subresource to Shard CRD (`.spec.replicas` / `.status.readyReplicas`). Added `PodRoles`, `LastBackupTime`, `LastBackupType` to `ShardStatus`.
 
 ## Drawbacks
 

--- a/plans/phase-1/pod-management-architecture.md
+++ b/plans/phase-1/pod-management-architecture.md
@@ -155,13 +155,13 @@ The drain state machine coordinates pod removal between two controllers:
                     ┌──────────────▼───────────────────┐
                     │     Pod selected for drain       │
                     │  (non-ready > non-primary >      │
-                    │   highest index)                  │
+                    │   highest index)                 │
                     └──────────────┬───────────────────┘
                                    │
                     ┌──────────────▼───────────────────┐
                     │  Annotation: state=requested     │
-                    │  + drain-requested-at timestamp   │
-                    │  (set by resource-handler)        │
+                    │  + drain-requested-at timestamp  │
+                    │  (set by resource-handler)       │
                     └──────────────┬───────────────────┘
                                    │
                     ┌──────────────▼───────────────────┐
@@ -265,11 +265,13 @@ The `updatePoolsStatus` function directly lists pods by label selector and aggre
 | `shard.Status.Phase` | `Healthy` when both pools and orch are ready; `Progressing` otherwise |
 | `shard.Status.Cells` | Observed cells from pod labels |
 | `shard.Status.PodRoles` | Pod → role mapping (populated by data-handler from etcd) |
-| `shard.Status.Conditions` | `Available` condition with `AllPodsReady` or `NotAllPodsReady` |
+| `shard.Status.LastBackupTime` | Timestamp of last completed backup (from `GetBackups` RPC via data-handler) |
+| `shard.Status.LastBackupType` | Type of last backup (full/diff/incr) |
+| `shard.Status.Conditions` | `Available`, `BackupHealthy`, `RollingUpdate` |
 
 Terminating pods (with a non-zero `DeletionTimestamp`) are excluded from counts.
 
-Metrics are emitted per pool via `monitoring.SetShardPoolReplicas()`. A `PoolEmpty` warning event is emitted when a cell has zero ready replicas but the desired count is > 0.
+Metrics are emitted per pool via `monitoring.SetShardPoolReplicas()`. A `PoolEmpty` warning event is emitted when a cell has zero ready replicas but the desired count is > 0. Backup age is emitted via `monitoring.SetLastBackupAge()`.
 
 ---
 
@@ -296,6 +298,9 @@ Metrics are emitted per pool via `monitoring.SetShardPoolReplicas()`. A `PoolEmp
 | **pgBackRest TLS certificates** | Auto-generated or user-provided (cert-manager compatible) |
 | **S3 and filesystem backup support** | Full backup configuration propagation |
 | **PVC deletion policy** | Hierarchical merge, Retain/Delete per whenDeleted/whenScaled |
+| **Etcd topology cleanup** | `UnregisterMultiPooler` called during drain flow; stale entries removed on pod termination |
+| **Backup health reporting** | Data-handler calls `GetBackups` RPC, sets `BackupHealthy` condition and `LastBackupTime` status |
+| **DRAINED pod replacement** | Pods with `DRAINED` role in etcd are detected and replaced via the drain state machine |
 | **Observability** | Events, conditions, metrics, tracing spans |
 
 ### Not Yet Implemented (Blocked on Upstream Multigres)
@@ -306,7 +311,6 @@ These features are designed and documented in `pod-management-design.md` but req
 |---|---|---|
 | **WAL archiving failure detection** | Gap 1 | Needs multipooler to expose `pg_stat_archiver` via etcd |
 | **Standby waiting-for-backup surfacing** | Gap 4 | Needs multipooler to expose `monitor_reason` via etcd |
-| **Graceful decommission RPC** | Gap 8 | Nice-to-have; drain state machine covers safety |
 | **Point-in-Time Recovery** | Gap 9 | Separate product feature, not urgent |
 
 ### Not Implemented (Design Decision)
@@ -314,9 +318,6 @@ These features are designed and documented in `pod-management-design.md` but req
 | Feature | Reason |
 |---|---|
 | **Scheduled base backups** | Per design review meeting, kept peripheral to operator |
-| **Etcd topology cleanup** | API exists (`UnregisterMultiPooler`), wired through data-handler drain flow |
-| **Backup health reporting** | `GetBackups` RPC exists; data-handler integration is scoped for future work |
-| **DRAINED pod replacement** | Detection and replacement flow designed; requires data-handler etcd reads at runtime |
 
 ---
 
@@ -443,11 +444,13 @@ Through the data-handler:
 |---|---|
 | Pod creation and recreation | Direct pod management via reconcile loop |
 | Scale-up (new replicas) | Create PVC + Pod, multigres handles the rest |
-| Scale-down | Drain state machine with standby removal |
+| Scale-down | Drain state machine with standby removal + etcd unregistration |
 | Rolling update | Spec-hash detection, ordered recreation |
+| DRAINED pod replacement | Detects DRAINED role from etcd, initiates drain + replacement |
+| Backup health reporting | Calls `GetBackups` RPC, sets `BackupHealthy` condition |
 | PVC lifecycle | Direct creation/deletion per policy |
 | Certificate provisioning | `pkg/cert` for pgBackRest TLS |
-| Status reporting | Aggregate from pod conditions and etcd roles |
+| Status reporting | Aggregate from pod conditions, etcd roles, and backup metadata |
 
 ---
 
@@ -459,14 +462,10 @@ Through the data-handler:
 |---|---|---|
 | WAL archiving failure detection | [#654](https://github.com/multigres/multigres/issues/654) | Multipooler should report `pg_stat_archiver` status via etcd |
 | Standby stuck waiting for backup | [#652](https://github.com/multigres/multigres/issues/652) | Multipooler should expose `monitor_reason` in etcd |
-| Graceful decommission RPC | [#653](https://github.com/multigres/multigres/issues/653) | Nice-to-have; drain state machine covers safety |
 
 ### Operator-Side Future Work
 
-- **Backup health reporting**: The `GetBackups` gRPC RPC exists and can be called to populate `ShardStatus` with backup metadata. Designed but not yet integrated.
 - **Scheduled base backups**: Designed as a controller-timer approach (like CloudNativePG) but deferred per team decision.
-- **DRAINED pod replacement**: The design calls for detecting DRAINED pods via etcd and creating replacements while cleaning up the drained pod. The scale-up logic already handles the "create replacement" part; the detection and cleanup need the data-handler to surface DRAINED status at runtime.
-- **Primary switchover for rolling updates**: Currently, rolling update of the primary defers to the same drain mechanism. A dedicated switchover flow (request switchover → wait for data-handler confirmation → then drain) would be more graceful and is mostly plumbed.
 
 ### Design Constraints (v1alpha1)
 

--- a/plans/phase-1/pod-management-design.md
+++ b/plans/phase-1/pod-management-design.md
@@ -1,8 +1,10 @@
 # Pod Management Design: StatefulSet → Direct Pod Management
 
-> **Status**: Approved — Ready for Implementation
+> **Status**: Approved and Implemented
 >
 > **Goal**: Document the design for replacing StatefulSets with direct pod management in the operator, covering pod identity, decommissioning, failure scenarios, and scope limitations.
+>
+> **Implementation reference**: See [pod-management-architecture.md](./pod-management-architecture.md) for the current implementation details.
 
 ---
 
@@ -171,7 +173,7 @@ These constraints are already enforced or need to be enforced via CEL validation
 
 | Constraint | Status | Risk |
 |---|---|---|
-| **Cell rename prevention** | ❌ **No CEL rule exists** | Renaming a cell would create pods with new names while orphaning old ones. The old pods' etcd registrations would become stale. **Action needed: add CEL rule.** |
+| **Cell rename prevention** | ✅ **Implemented** | CEL append-only rule added to `MultigresCluster` and `Shard` CRDs. Cells cannot be removed or renamed after creation. |
 | **Pool replica count floor** | ❌ **Not validated** | User could set `replicasPerCell: 0`, which would delete all pods but leave etcd registrations behind. Consider minimum of 1. |
 
 ### Explicitly NOT Supported (v1alpha1)
@@ -295,6 +297,8 @@ This means:
 
 > [!NOTE]
 > The stale etcd entry problem **already exists today with StatefulSets**. When a user reduces `replicasPerCell` on a pool, the StatefulSet controller deletes the tail pod, but the operator does nothing to clean up that pod's etcd registration. The same 4-hour stale window applies. Moving to direct pod management does not make this worse — it just gives us the opportunity to do better.
+>
+> **Update (post-implementation)**: The drain state machine now calls `UnregisterMultiPooler` during the `ACKNOWLEDGED` state, fully cleaning up etcd entries on scale-down. Stale entries are no longer an issue.
 
 ### Implications for the Operator
 
@@ -471,10 +475,9 @@ Scale-down uses the drain state machine described in [§6](#graceful-scale-down-
 
 1. Operator selects which pod to remove using the pod selection algorithm below
 2. Operator annotates the pod to begin the drain sequence
-3. Drain progresses over multiple reconcile loops: remove from sync standby list → verify → delete
+3. Drain progresses over multiple reconcile loops: remove from sync standby list → verify → unregister from etcd → delete
 4. Operator deletes the PVC (if `PVCDeletionPolicy` says so)
-5. After 4 hours, multiorch's `forgetLongUnseenInstances` cleans its internal store
-6. Etcd topology entry persists (see [§6](#6-pod-lifecycle--decommissioning))
+5. Etcd topology entry is cleaned up during the drain flow (via `UnregisterMultiPooler`)
 
 ### Pod Selection Algorithm
 
@@ -829,8 +832,8 @@ Neither use case is currently automatable through multigres. Future versions cou
 
 | Entity | Risk | Recommendation |
 |---|---|---|
-| **Cell names** | Renaming a cell would orphan pods and their etcd registrations. Old pods would continue running with old names while new pods start with new names. | **Add CEL rule**: cells should be treated as append-only, same as pools. |
-| **Removing cells from a pool** | Same orphaning problem. Old pods in the removed cell continue running. | **Add CEL rule**: cells array should be append-only within each pool. |
+| **Cell names** | ✅ **Implemented** — CEL append-only rule added to `MultigresCluster` and `Shard` CRDs. |
+| **Removing cells from a pool** | ✅ **Implemented** — Covered by the same CEL append-only rule. |
 
 ---
 
@@ -1062,9 +1065,9 @@ Both modes use a unified volume mounting strategy:
 
 ---
 
-### Gap 8: Graceful Decommission RPC
+### Gap 8: Graceful Decommission RPC — Closed
 
-**Status**: GH Issue filed ([multigres/multigres#653](https://github.com/multigres/multigres/issues/653)). Sugu noted in the 2026-02-23 meeting that there is ongoing internal debate in the multigres team about handling this. Additionally, the team discussed that it is acceptable for the operator to read from the topology to determine pod status (like `DRAINED`), provided we track these topology accesses carefully.
+**Status**: GH Issue closed ([multigres/multigres#653](https://github.com/multigres/multigres/issues/653)). The operator's drain state machine now handles all safety-critical decommission steps (sync standby removal, etcd cleanup, PVC deletion). The remaining benefit (graceful connection draining) is marginal — by the time the pod is deleted, it is already unregistered from etcd and `terminationGracePeriodSeconds` (600s) gives in-flight queries time to complete.
 
 **Problem**: Before the operator deletes a pod during scale-down, it would be ideal to tell the multipooler to decommission itself gracefully: drain active connections, remove itself from `synchronous_standby_names`, set type to `DRAINED` in etcd, and then exit cleanly. Currently the operator must do this piecemeal by calling `UpdateSynchronousStandbyList(REMOVE)` on the primary, then deleting the pod.
 
@@ -1109,10 +1112,10 @@ Once multigres exposes PITR via gRPC, the operator could surface it as a `Multig
 | 2 | Scheduled base backups | Operator (using multigres `Backup` RPC) | **High** | Will NOT implement with the operator |
 | 3 | ~~S3 backup support in operator~~ | Operator | ✅ **Done** | Resolved — API, data handler, and resource handler fully wired |
 | 4 | Standby stuck without backup (not surfaced) | Multigres | **Medium** | [Issue #652](https://github.com/multigres/multigres/issues/652) (Upstream observability improvement needed) |
-| 5 | ~~Etcd cleanup on scale-down~~ | Operator (using multigres `UnregisterMultiPooler` API) | ✅ **API Exists** | Resolved — `UnregisterMultiPooler` exists in `CellStore` interface |
-| 6 | Backup health reporting | Operator (calling `multiadmin` `GetBackups` RPC) | **Medium** | ✅ **API Exists** — Resolved without upstream multigres changes |
+| 5 | ~~Etcd cleanup on scale-down~~ | Operator (using multigres `UnregisterMultiPooler` API) | ✅ **Done** | Implemented — drain state machine calls `UnregisterMultiPooler` in `ACKNOWLEDGED` state |
+| 6 | ~~Backup health reporting~~ | Operator (calling `GetBackups` RPC on multipooler) | ✅ **Done** | Implemented — `backup_health.go` calls `GetBackups`, sets `BackupHealthy` condition and metrics |
 | 7 | ~~pgBackRest TLS certificate handling~~ | Operator | ✅ **Done** | Resolved — `pkg/cert` infra, volume builder, and APIReader fully wired |
-| 8 | Graceful decommission RPC | Multigres | Low | [Issue #653](https://github.com/multigres/multigres/issues/653) |
+| 8 | ~~Graceful decommission RPC~~ | Multigres | ✅ **Closed** | [Issue #653](https://github.com/multigres/multigres/issues/653) — operator drain state machine covers all safety-critical steps |
 | 9 | Point-in-Time Recovery | Multigres | Low | Skipped |
 
 > [!NOTE]


### PR DESCRIPTION
The API design document was significantly outdated, still referencing StatefulSets and missing key v1alpha1 fields. Additionally, pod management docs incorrectly listed upstream issue #653 as a blocker, whereas the operator's drain state machine now implementation handles this safety-critical logic.

- Updated api-design/multigres-operator-api-v1alpha1-design.md to reflect direct pod management and new spec/status fields
- Updated pod-management-architecture.md and design.md to reflect the closure of GH Issue #653
- Corrected topology diagrams to show operator-managed Pods and PVCs
- Enhanced test coverage in recorder and resolver packages (cluster, shard, validation)

Ensures documentation accurately reflects the codebase and operational logic, providing a reliable source of truth for v1alpha1. Mentioned test coverage improvements as a minor update.