### PR TITLE
fix(shard): prevent PVC deletion during rolling updates

### DIFF
--- a/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
+++ b/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
@@ -367,7 +367,7 @@ func (r *ShardReconciler) handleScaleDown(
 	// Cleanup pods ready for deletion: remove finalizer first, then delete
 	for _, pod := range readyForDeletion {
 		logger.Info("Cleaning up pod in ready-for-deletion state", "pod", pod.Name)
-		if err := r.cleanupDrainedPod(ctx, shard, pod, poolName, poolSpec); err != nil {
+		if err := r.cleanupDrainedPod(ctx, shard, pod, poolName, poolSpec, replicas); err != nil {
 			return actionTaken, inProgress, fmt.Errorf(
 				"failed to cleanup drained pod %s: %w",
 				pod.Name,
@@ -609,6 +609,7 @@ func (r *ShardReconciler) cleanupDrainedPod(
 	pod *corev1.Pod,
 	poolName string,
 	poolSpec multigresv1alpha1.PoolSpec,
+	replicas int32,
 ) error {
 	logger := log.FromContext(ctx)
 
@@ -635,20 +636,24 @@ func (r *ShardReconciler) cleanupDrainedPod(
 
 	if policy.WhenScaled == multigresv1alpha1.DeletePVCRetentionPolicy {
 		idx := resolvePodIndex(pod.Name)
-		cellName := pod.Labels[metadata.LabelMultigresCell]
-		pvcName := BuildPoolDataPVCName(shard, poolName, cellName, idx)
-		pvc := &corev1.PersistentVolumeClaim{}
-		err := r.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pvcName}, pvc)
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				logger.Error(err, "Failed to fetch PVC for deletion", "pvc", pvcName)
+		if idx >= int(replicas) {
+			cellName := pod.Labels[metadata.LabelMultigresCell]
+			pvcName := BuildPoolDataPVCName(shard, poolName, cellName, idx)
+			pvc := &corev1.PersistentVolumeClaim{}
+			err := r.Get(ctx, client.ObjectKey{Namespace: pod.Namespace, Name: pvcName}, pvc)
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					logger.Error(err, "Failed to fetch PVC for deletion", "pvc", pvcName)
+				}
+			} else {
+				if err := r.Delete(ctx, pvc); err != nil && !errors.IsNotFound(err) {
+					logger.Error(err, "Failed to delete PVC for scaled down pod", "pvc", pvcName)
+				} else {
+					logger.Info("Deleted PVC for scaled down pod", "pvc", pvcName)
+				}
 			}
 		} else {
-			if err := r.Delete(ctx, pvc); err != nil && !errors.IsNotFound(err) {
-				logger.Error(err, "Failed to delete PVC for scaled down pod", "pvc", pvcName)
-			} else {
-				logger.Info("Deleted PVC for scaled down pod", "pvc", pvcName)
-			}
+			logger.Info("Retaining PVC for pod during rolling update", "pod", pod.Name, "index", idx, "replicas", replicas)
 		}
 	}
 


### PR DESCRIPTION
PVCs were being deleted during rolling updates because the cleanup logic for drained pods lacked a check to verify if the pod was actually being scaled down or just updated.

- Added replica count parameter to cleanupDrainedPod function
- Implemented bounds check to ensure PVC deletion only occurs if pod index is >= desired replicas
- Updated handleScaleDown to pass the current desired replica count during cleanup

Prevents accidental data loss during rolling updates when the WhenScaled: Delete retention policy is active.