### PR TITLE
fix(shard): implement manual PVC GC to respect retention policies

### DIFF
--- a/pkg/resource-handler/controller/shard/pool_pvc.go
+++ b/pkg/resource-handler/controller/shard/pool_pvc.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/util/metadata"
@@ -87,10 +86,6 @@ func BuildPoolDataPVC(
 		pvc.Spec.StorageClassName = storageClass
 	}
 
-	if err := ctrl.SetControllerReference(shard, pvc, scheme); err != nil {
-		return nil, fmt.Errorf("failed to set controller reference: %w", err)
-	}
-
 	return pvc, nil
 }
 
@@ -167,10 +162,6 @@ func BuildSharedBackupPVC(
 
 	if pvcClass != nil && *pvcClass != "" {
 		pvc.Spec.StorageClassName = pvcClass
-	}
-
-	if err := ctrl.SetControllerReference(shard, pvc, scheme); err != nil {
-		return nil, fmt.Errorf("failed to set controller reference on backup PVC: %w", err)
 	}
 
 	return pvc, nil

--- a/pkg/resource-handler/controller/shard/pool_pvc_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pvc_test.go
@@ -23,11 +23,8 @@ func TestBuildPoolDataPVC_BasicStructure(t *testing.T) {
 		t.Errorf("namespace = %q, want %q", pvc.Namespace, "default")
 	}
 
-	if len(pvc.OwnerReferences) != 1 {
-		t.Fatalf("expected 1 owner reference, got %d", len(pvc.OwnerReferences))
-	}
-	if pvc.OwnerReferences[0].Name != "test-shard" {
-		t.Errorf("owner name = %q, want %q", pvc.OwnerReferences[0].Name, "test-shard")
+	if len(pvc.OwnerReferences) != 0 {
+		t.Fatalf("expected 0 owner references, got %d. OwnerReference overrides WhenDeleted policies.", len(pvc.OwnerReferences))
 	}
 
 	expectedLabels := map[string]string{

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -291,6 +291,57 @@ func (r *ShardReconciler) handleDeletion(
 		}
 	}
 
+	// Evaluate and process PVC deletions based on PVCDeletionPolicy before pod finalizers are removed
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(
+		ctx,
+		pvcList,
+		client.InNamespace(shard.Namespace),
+		client.MatchingLabels(selector),
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list PVCs for deletion: %w", err)
+	}
+
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+
+		// Determine the PVC policy
+		poolName := pvc.Labels[metadata.LabelMultigresPool]
+		var policy *multigresv1alpha1.PVCDeletionPolicy
+
+		if poolName != "" {
+			// Pool Data PVC
+			if poolSpec, exists := shard.Spec.Pools[multigresv1alpha1.PoolName(poolName)]; exists {
+				policy = multigresv1alpha1.MergePVCDeletionPolicy(
+					poolSpec.PVCDeletionPolicy,
+					shard.Spec.PVCDeletionPolicy,
+				)
+			} else {
+				policy = shard.Spec.PVCDeletionPolicy
+			}
+		} else {
+			// Shared Backup PVC
+			policy = shard.Spec.PVCDeletionPolicy
+		}
+
+		// Default to Retain
+		whenDeleted := multigresv1alpha1.RetainPVCRetentionPolicy
+		if policy != nil && policy.WhenDeleted != "" {
+			whenDeleted = policy.WhenDeleted
+		}
+
+		if whenDeleted == multigresv1alpha1.DeletePVCRetentionPolicy {
+			if pvc.DeletionTimestamp.IsZero() {
+				logger.Info("Deleting PVC per WhenDeleted: Delete policy", "pvc", pvc.Name)
+				if err := r.Delete(ctx, pvc); err != nil && !errors.IsNotFound(err) {
+					return ctrl.Result{}, fmt.Errorf("failed to delete PVC %s: %w", pvc.Name, err)
+				}
+			}
+		} else {
+			logger.Info("Retaining PVC per WhenDeleted: Retain policy", "pvc", pvc.Name)
+		}
+	}
+
 	// Remove finalizers from all pods to allow them to be deleted by GC
 	podsStillPresent := 0
 	for i := range podList.Items {


### PR DESCRIPTION
Kubernetes garbage collection was unconditionally deleting PVCs owned by the Shard, bypassing the configured WhenDeleted policy.

- Removed OwnerReference from data and backup PVCs in controller/shard/pool_pvc.go
- Implemented explicit PVC cleanup logic in controller/shard/shard_controller.go
- Updated controller/shard/pool_pvc_test.go to verify absence of owner references

Ensures data volumes are retained during Shard deletion when configured, while still allowing automatic cleanup for transient clusters.