### PR TITLE
fix(data-handler): prevent nil pointer panic in drain state machine

### DIFF
--- a/pkg/data-handler/controller/shard/drain.go
+++ b/pkg/data-handler/controller/shard/drain.go
@@ -194,19 +194,23 @@ func (r *ShardReconciler) executeDrainStateMachine(
 			return true, nil
 		}
 		if primary != nil && myPooler != nil {
-			req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
-				Operation:  multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
-				StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
-			}
-			_, rpcErr := r.rpcClient.UpdateSynchronousStandbyList(ctx, primary, req)
-			if rpcErr != nil {
-				logger.Error(
-					rpcErr,
-					"Standby removal verification failed, will retry",
-					"pod",
-					pod.Name,
-				)
-				return true, nil
+			if r.rpcClient == nil {
+				logger.Info("RPC client not configured, skipping standby removal verification", "pod", pod.Name)
+			} else {
+				req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
+					Operation:  multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
+					StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
+				}
+				_, rpcErr := r.rpcClient.UpdateSynchronousStandbyList(ctx, primary, req)
+				if rpcErr != nil {
+					logger.Error(
+						rpcErr,
+						"Standby removal verification failed, will retry",
+						"pod",
+						pod.Name,
+					)
+					return true, nil
+				}
 			}
 		}
 		return r.updateDrainState(ctx, pod, metadata.DrainStateAcknowledged)


### PR DESCRIPTION
The executeDrainStateMachine function was missing a nil check for the RPC client in the DrainStateDraining state, causing the operator to panic and crash if the client was not configured.

- Nested rpcClient nil check inside the primary and pooler guard in DrainStateDraining
- Added logging for when standby removal verification is skipped due to unconfigured RPC client
- Ensured state transition proceeds seamlessly even if RPC client is nil

Prevents operator crashes and ensures reliable pod draining when running without an initialized RPC client. Avoids misleading logs by only logging the missing client when a primary and pooler are actually present.