### PR TITLE
fix(shard): include ValueFrom and EnvFrom in spec-hash calculation

### DIFF
--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -186,6 +186,16 @@ func hashContainers(h hash.Hash32, containers []corev1.Container) {
 		}
 		for _, e := range c.Env {
 			_, _ = fmt.Fprintf(h, "env=%s=%s", e.Name, e.Value)
+			if e.ValueFrom != nil {
+				if b, err := json.Marshal(e.ValueFrom); err == nil {
+					_, _ = fmt.Fprintf(h, "envValFrom=%s=%s", e.Name, b)
+				}
+			}
+		}
+		for _, ef := range c.EnvFrom {
+			if b, err := json.Marshal(ef); err == nil {
+				_, _ = fmt.Fprintf(h, "envFromSrc=%s", b)
+			}
 		}
 		if b, err := json.Marshal(c.Resources); err == nil {
 			_, _ = fmt.Fprintf(h, "res=%s", b)

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -301,6 +301,60 @@ func TestComputeSpecHash_ChangesOnDrift(t *testing.T) {
 	}
 }
 
+func TestComputeSpecHash_ChangesOnValueFromDrift(t *testing.T) {
+	pod1, _ := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	pod1.Spec.Containers[0].Env = append(pod1.Spec.Containers[0].Env, corev1.EnvVar{
+		Name: "TEST_ENV",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "secret1"},
+				Key:                  "key1",
+			},
+		},
+	})
+
+	pod2, _ := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	pod2.Spec.Containers[0].Env = append(pod2.Spec.Containers[0].Env, corev1.EnvVar{
+		Name: "TEST_ENV",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "secret2"},
+				Key:                  "key1",
+			},
+		},
+	})
+
+	hash1 := ComputeSpecHash(pod1)
+	hash2 := ComputeSpecHash(pod2)
+
+	if hash1 == hash2 {
+		t.Error("spec hash should differ when ValueFrom secret name changes")
+	}
+}
+
+func TestComputeSpecHash_ChangesOnEnvFromDrift(t *testing.T) {
+	pod1, _ := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	pod1.Spec.Containers[0].EnvFrom = append(pod1.Spec.Containers[0].EnvFrom, corev1.EnvFromSource{
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "config1"},
+		},
+	})
+
+	pod2, _ := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	pod2.Spec.Containers[0].EnvFrom = append(pod2.Spec.Containers[0].EnvFrom, corev1.EnvFromSource{
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "config2"},
+		},
+	})
+
+	hash1 := ComputeSpecHash(pod1)
+	hash2 := ComputeSpecHash(pod2)
+
+	if hash1 == hash2 {
+		t.Error("spec hash should differ when EnvFrom config map name changes")
+	}
+}
+
 func TestBuildPoolPodName_Truncation(t *testing.T) {
 	shard := newTestShard()
 	shard.Labels["multigres.com/cluster"] = "very-long-cluster-name-for-testing"


### PR DESCRIPTION
The spec-hash drift detection previously ignored environment variables defined via ValueFrom or EnvFrom. This meant that changing a Secret or ConfigMap reference (e.g., rotating credentials) would not trigger a rolling update of the pods.

- Updated hashContainers in pkg/resource-handler/controller/shard/pool_pod.go to hash ValueFrom and EnvFrom sources
- Added TestComputeSpecHash_ChangesOnValueFromDrift and TestComputeSpecHash_ChangesOnEnvFromDrift to pkg/resource-handler/controller/shard/pool_pod_test.go

Ensures pods are correctly rolled out when environment variable sources or secret references are updated.