### PR TITLE
fix(data-handler): resolve cross-shard state bleed and status memory leak

### DIFF
--- a/pkg/data-handler/controller/shard/backup_health.go
+++ b/pkg/data-handler/controller/shard/backup_health.go
@@ -51,7 +51,7 @@ func (r *ShardReconciler) evaluateBackupHealth(
 	defer func() { _ = store.Close() }()
 
 	cells := collectCells(shard)
-	primary, err := findPrimaryPooler(ctx, store, cells)
+	primary, err := findPrimaryPooler(ctx, store, shard, cells)
 	if err != nil {
 		return nil, fmt.Errorf("finding primary pooler: %w", err)
 	}
@@ -87,10 +87,18 @@ func (r *ShardReconciler) getBackups(
 func findPrimaryPooler(
 	ctx context.Context,
 	store topoclient.Store,
+	shard *multigresv1alpha1.Shard,
 	cells []string,
 ) (*clustermetadatapb.MultiPooler, error) {
 	for _, cell := range cells {
-		poolers, err := store.GetMultiPoolersByCell(ctx, cell, nil)
+		opt := &topoclient.GetMultiPoolersByCellOptions{
+			DatabaseShard: &topoclient.DatabaseShard{
+				Database:   string(shard.Spec.DatabaseName),
+				TableGroup: string(shard.Spec.TableGroupName),
+				Shard:      string(shard.Spec.ShardName),
+			},
+		}
+		poolers, err := store.GetMultiPoolersByCell(ctx, cell, opt)
 		if err != nil {
 			if isTopoUnavailable(err) {
 				continue

--- a/pkg/data-handler/controller/shard/drain.go
+++ b/pkg/data-handler/controller/shard/drain.go
@@ -48,7 +48,7 @@ func (r *ShardReconciler) executeDrainStateMachine(
 	// Node Failure Safety: If the pod is stuck terminating for > 5 minutes, force unregister.
 	if !pod.DeletionTimestamp.IsZero() && time.Since(pod.DeletionTimestamp.Time) > drainTimeout {
 		logger.Info("Pod is stuck terminating, forcing unregistration", "pod", pod.Name)
-		if err := r.forceUnregister(ctx, store, pod); err != nil {
+		if err := r.forceUnregister(ctx, store, shard, pod); err != nil {
 			return false, fmt.Errorf("forcing unregistration: %w", err)
 		}
 		return r.updateDrainState(ctx, pod, metadata.DrainStateReadyForDeletion)
@@ -57,9 +57,17 @@ func (r *ShardReconciler) executeDrainStateMachine(
 	cells := collectCells(shard)
 	cellName := pod.Labels[metadata.LabelMultigresCell]
 
+	opt := &topoclient.GetMultiPoolersByCellOptions{
+		DatabaseShard: &topoclient.DatabaseShard{
+			Database:   string(shard.Spec.DatabaseName),
+			TableGroup: string(shard.Spec.TableGroupName),
+			Shard:      string(shard.Spec.ShardName),
+		},
+	}
+
 	// Find the pooler entry for this pod
 	var myPooler *topoclient.MultiPoolerInfo
-	poolers, err := store.GetMultiPoolersByCell(ctx, cellName, nil)
+	poolers, err := store.GetMultiPoolersByCell(ctx, cellName, opt)
 	if err != nil && !isTopoUnavailable(err) {
 		return false, fmt.Errorf("listing poolers in cell %q: %w", cellName, err)
 	}
@@ -83,7 +91,7 @@ func (r *ShardReconciler) executeDrainStateMachine(
 			// Best effort: find another pooler to become primary
 			var otherPooler *topoclient.MultiPoolerInfo
 			for _, cell := range cells {
-				pp, _ := store.GetMultiPoolersByCell(ctx, cell, nil)
+				pp, _ := store.GetMultiPoolersByCell(ctx, cell, opt)
 				for _, p := range pp {
 					if p.Type != clustermetadatapb.PoolerType_PRIMARY &&
 						(fmt.Sprintf("%v", p.Id) != pod.Name && p.GetHostname() != pod.Name) {
@@ -160,7 +168,7 @@ func (r *ShardReconciler) executeDrainStateMachine(
 		logger.Info("Proceeding to drain pod", "pod", pod.Name)
 
 		// Get the current primary to remove this replica from synchronous standby
-		primary, err := findPrimaryPooler(ctx, store, cells)
+		primary, err := findPrimaryPooler(ctx, store, shard, cells)
 		if err == nil && primary != nil && myPooler != nil && r.rpcClient != nil {
 			req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
 				Operation:  multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
@@ -183,7 +191,7 @@ func (r *ShardReconciler) executeDrainStateMachine(
 	case metadata.DrainStateDraining:
 		// Verify that the standby removal actually took effect by re-attempting the
 		// idempotent REMOVE call on the primary. If the primary is unreachable, requeue.
-		primary, err := findPrimaryPooler(ctx, store, cells)
+		primary, err := findPrimaryPooler(ctx, store, shard, cells)
 		if err != nil {
 			logger.Error(
 				err,
@@ -218,7 +226,7 @@ func (r *ShardReconciler) executeDrainStateMachine(
 	case metadata.DrainStateAcknowledged:
 		// Finally, call UnregisterMultiPooler
 		if myPooler != nil {
-			if err := r.forceUnregister(ctx, store, pod); err != nil {
+			if err := r.forceUnregister(ctx, store, shard, pod); err != nil {
 				return false, fmt.Errorf("unregistering pooler: %w", err)
 			}
 		}
@@ -250,6 +258,7 @@ func (r *ShardReconciler) updateDrainState(
 func (r *ShardReconciler) forceUnregister(
 	ctx context.Context,
 	store topoclient.Store,
+	shard *multigresv1alpha1.Shard,
 	pod *corev1.Pod,
 ) error {
 	cellName := pod.Labels[metadata.LabelMultigresCell]
@@ -257,7 +266,14 @@ func (r *ShardReconciler) forceUnregister(
 		return nil
 	}
 
-	poolers, err := store.GetMultiPoolersByCell(ctx, cellName, nil)
+	opt := &topoclient.GetMultiPoolersByCellOptions{
+		DatabaseShard: &topoclient.DatabaseShard{
+			Database:   string(shard.Spec.DatabaseName),
+			TableGroup: string(shard.Spec.TableGroupName),
+			Shard:      string(shard.Spec.ShardName),
+		},
+	}
+	poolers, err := store.GetMultiPoolersByCell(ctx, cellName, opt)
 	if err != nil {
 		return err
 	}

--- a/pkg/data-handler/controller/shard/drain_test.go
+++ b/pkg/data-handler/controller/shard/drain_test.go
@@ -301,6 +301,9 @@ func TestReplicaDrainFlow(t *testing.T) {
 			},
 		},
 		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:     "test-db",
+			TableGroupName:   "test-tg",
+			ShardName:        "0",
 			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{RootPath: "/test"},
 			Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"pool1": {Cells: []multigresv1alpha1.CellName{"cell1"}},
@@ -348,15 +351,21 @@ func TestReplicaDrainFlow(t *testing.T) {
 
 	// Add primary
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
-		Hostname: "primary-pod",
-		Type:     clustermetadata.PoolerType_PRIMARY,
+		Id:         &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
+		Hostname:   "primary-pod",
+		Type:       clustermetadata.PoolerType_PRIMARY,
+		Database:   "test-db",
+		TableGroup: "test-tg",
+		Shard:      "0",
 	}, false)
 	// Add our replica pod
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
-		Hostname: "test-pod-0",
-		Type:     clustermetadata.PoolerType_REPLICA,
+		Id:         &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
+		Hostname:   "test-pod-0",
+		Type:       clustermetadata.PoolerType_REPLICA,
+		Database:   "test-db",
+		TableGroup: "test-tg",
+		Shard:      "0",
 	}, false)
 
 	// Step 1: Requested -> Draining
@@ -420,6 +429,9 @@ func TestPrimaryDrainFlow(t *testing.T) {
 			Labels: map[string]string{metadata.LabelMultigresCluster: "test"},
 		},
 		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:     "test-db",
+			TableGroupName:   "test-tg",
+			ShardName:        "0",
 			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{RootPath: "/test"},
 			Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"pool1": {Cells: []multigresv1alpha1.CellName{"cell1"}},
@@ -465,10 +477,16 @@ func TestPrimaryDrainFlow(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
 		Hostname: "test-pod-0", Type: clustermetadata.PoolerType_PRIMARY,
+		Database:   "test-db",
+		TableGroup: "test-tg",
+		Shard:      "0",
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod"},
 		Hostname: "replica-pod", Type: clustermetadata.PoolerType_REPLICA,
+		Database:   "test-db",
+		TableGroup: "test-tg",
+		Shard:      "0",
 	}, false)
 
 	requeue, err := reconciler.executeDrainStateMachine(ctx, shardObj, pod)
@@ -494,6 +512,9 @@ func TestStuckTerminatingPod(t *testing.T) {
 			Labels: map[string]string{metadata.LabelMultigresCluster: "test"},
 		},
 		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:     "test-db",
+			TableGroupName:   "test-tg",
+			ShardName:        "0",
 			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{RootPath: "/test"},
 			Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"pool1": {Cells: []multigresv1alpha1.CellName{"cell1"}},
@@ -530,6 +551,9 @@ func TestStuckTerminatingPod(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
 		Hostname: "test-pod-0", Type: clustermetadata.PoolerType_REPLICA,
+		Database:   "test-db",
+		TableGroup: "test-tg",
+		Shard:      "0",
 	}, false)
 
 	// Delete the pod using the client to set DeletionTimestamp

--- a/pkg/data-handler/controller/shard/shard_controller.go
+++ b/pkg/data-handler/controller/shard/shard_controller.go
@@ -190,10 +190,19 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				shard.Status.PodRoles = make(map[string]string)
 			}
 			rolesChanged := false
+			seenHostnames := make(map[string]bool)
+			topoQuerySuccess := true
 
 			cells := collectCells(shard)
 			for _, cell := range cells {
-				poolers, cerr := store.GetMultiPoolersByCell(ctx, cell, nil)
+				opt := &topoclient.GetMultiPoolersByCellOptions{
+					DatabaseShard: &topoclient.DatabaseShard{
+						Database:   string(shard.Spec.DatabaseName),
+						TableGroup: string(shard.Spec.TableGroupName),
+						Shard:      string(shard.Spec.ShardName),
+					},
+				}
+				poolers, cerr := store.GetMultiPoolersByCell(ctx, cell, opt)
 				if cerr == nil {
 					for _, p := range poolers {
 						roleName := "REPLICA"
@@ -208,10 +217,24 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 							hostname = fmt.Sprintf("%v", p.Id)
 						}
 
+						seenHostnames[hostname] = true
+
 						if shard.Status.PodRoles[hostname] != roleName {
 							shard.Status.PodRoles[hostname] = roleName
 							rolesChanged = true
 						}
+					}
+				} else {
+					topoQuerySuccess = false
+				}
+			}
+
+			// Prune entries for poolers that no longer exist in the topology.
+			if topoQuerySuccess {
+				for hostname := range shard.Status.PodRoles {
+					if !seenHostnames[hostname] {
+						delete(shard.Status.PodRoles, hostname)
+						rolesChanged = true
 					}
 				}
 			}


### PR DESCRIPTION
The shard controller was fetching all poolers in a cell without filtering by database or shard, leading to status contamination. Additionally, PodRoles status was never pruned, causing a memory leak as pods were deleted.

- Applied DatabaseShard filters to all GetMultiPoolersByCell calls in the shard controller.
- Implemented status pruning in shard_controller.go to remove stale pod entries.
- Added safety check to only prune status if all topology queries succeed.
- Updated internal helper signatures and integration tests to support filtering.

Prevents incorrect health reporting between separate database shards and eliminates CRD status bloat from deleted pods.