### PR TITLE
fix(resource-handler): correct Shard status to use desired replica counts

### DIFF
--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -1243,11 +1243,11 @@ func TestShardReconciler_UpdateStatus(t *testing.T) {
 		foundTrue := false
 		for _, cond := range updatedShard.Status.Conditions {
 			if cond.Type == "Available" {
-				if cond.Status != metav1.ConditionTrue {
-					t.Errorf("Condition status = %s, want %s", cond.Status, metav1.ConditionTrue)
+				if cond.Status != metav1.ConditionFalse {
+					t.Errorf("Condition status = %s, want %s", cond.Status, metav1.ConditionFalse)
 				}
-				if cond.Reason != "AllPodsReady" {
-					t.Errorf("Condition reason = %s, want %s", cond.Reason, "AllPodsReady")
+				if cond.Reason != "NotAllPodsReady" {
+					t.Errorf("Condition reason = %s, want %s", cond.Reason, "NotAllPodsReady")
 				}
 				foundTrue = true
 			}
@@ -1255,13 +1255,13 @@ func TestShardReconciler_UpdateStatus(t *testing.T) {
 		if !foundTrue {
 			t.Errorf("Condition %s not found", "Available")
 		}
-		if !updatedShard.Status.PoolsReady {
-			t.Error("PoolsReady should be true when all pools are ready")
+		if updatedShard.Status.PoolsReady {
+			t.Error("PoolsReady should be false when 1/3 pools are ready")
 		}
-		if updatedShard.Status.Phase != multigresv1alpha1.PhaseHealthy {
+		if updatedShard.Status.Phase != multigresv1alpha1.PhaseProgressing {
 			t.Errorf(
 				"Expected Phase to be %s, got %s",
-				multigresv1alpha1.PhaseHealthy,
+				multigresv1alpha1.PhaseProgressing,
 				updatedShard.Status.Phase,
 			)
 		}
@@ -1458,9 +1458,9 @@ func TestShardReconciler_UpdateStatus(t *testing.T) {
 			t.Fatalf("updatePoolsStatus failed: %v", err)
 		}
 
-		// Verify aggregate: 3 (zone1) + 2 (zone2) = 5
-		if totalPods != 5 {
-			t.Errorf("totalPods = %d, want 5", totalPods)
+		// Verify aggregate: desired for primary is 3 pods per cell * 2 cells = 6 pods
+		if totalPods != 6 {
+			t.Errorf("totalPods = %d, want 6", totalPods)
 		}
 		if readyPods != 5 {
 			t.Errorf("readyPods = %d, want 5", readyPods)

--- a/pkg/resource-handler/controller/shard/status.go
+++ b/pkg/resource-handler/controller/shard/status.go
@@ -104,7 +104,7 @@ func (r *ShardReconciler) updateStatus(
 }
 
 // updatePoolsStatus aggregates status from all pool pods.
-// Returns total pods, ready pods, and tracks cells in the cellsSet.
+// Returns total desired pods, ready pods, and tracks cells in the cellsSet.
 func (r *ShardReconciler) updatePoolsStatus(
 	ctx context.Context,
 	shard *multigresv1alpha1.Shard,
@@ -114,7 +114,7 @@ func (r *ShardReconciler) updatePoolsStatus(
 	clusterName := shard.Labels[metadata.LabelMultigresCluster]
 
 	for poolName, poolSpec := range shard.Spec.Pools {
-		var poolTotal, poolReady int32
+		var poolDesired, poolReady int32
 
 		// TODO(#91): Pool.Cells may contain duplicates - add +listType=set validation at API level
 		for _, cell := range poolSpec.Cells {
@@ -134,7 +134,7 @@ func (r *ShardReconciler) updatePoolsStatus(
 				return 0, 0, fmt.Errorf("failed to list pods for status: %w", err)
 			}
 
-			var cellTotal, cellReady int32
+			var cellReady int32
 			for i := range podList.Items {
 				pod := &podList.Items[i]
 
@@ -142,8 +142,6 @@ func (r *ShardReconciler) updatePoolsStatus(
 				if !pod.DeletionTimestamp.IsZero() {
 					continue
 				}
-
-				cellTotal++
 
 				// Check if pod is ready
 				isReady := false
@@ -174,16 +172,16 @@ func (r *ShardReconciler) updatePoolsStatus(
 				)
 			}
 
-			poolTotal += cellTotal
+			poolDesired += replicas
 			poolReady += cellReady
 		}
 
-		totalPods += poolTotal
+		totalPods += poolDesired
 		readyPods += poolReady
 
 		monitoring.SetShardPoolReplicas(
 			clusterName, shard.Name, string(poolName), "", shard.Namespace,
-			poolTotal, poolReady,
+			poolDesired, poolReady,
 		)
 	}
 


### PR DESCRIPTION
Shard status was reporting "Healthy" prematurely during scale-ups because it used actual running pod counts instead of desired replicas as the baseline for readiness. This also broke Prometheus alerts which received actual counts as the "desired" value.

- Modified updatePoolsStatus in status.go to compute and return desired replicas per pool
- Updated monitoring.SetShardPoolReplicas to use the desired replica count
- Adjusted TestShardReconciler_UpdateStatus in shard_controller_test.go to assert correct "Progressing" phase during scale-ups

Ensures accurate Shard phase reporting and functional monitoring alerts.