### PR TITLE
fix(shard): fix drain state matching and topology store residency

### DIFF
--- a/pkg/data-handler/controller/shard/drain.go
+++ b/pkg/data-handler/controller/shard/drain.go
@@ -3,6 +3,7 @@ package shard
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -27,6 +28,7 @@ const (
 // Returns true if reconciliation should be requeued.
 func (r *ShardReconciler) executeDrainStateMachine(
 	ctx context.Context,
+	store topoclient.Store,
 	shard *multigresv1alpha1.Shard,
 	pod *corev1.Pod,
 ) (bool, error) {
@@ -36,12 +38,6 @@ func (r *ShardReconciler) executeDrainStateMachine(
 	if state == "" || state == metadata.DrainStateReadyForDeletion {
 		return false, nil
 	}
-
-	store, err := r.getTopoStore(shard)
-	if err != nil {
-		return false, fmt.Errorf("creating topology store: %w", err)
-	}
-	defer func() { _ = store.Close() }()
 
 	clusterName := shard.Labels[metadata.LabelMultigresCluster]
 
@@ -73,9 +69,7 @@ func (r *ShardReconciler) executeDrainStateMachine(
 	}
 
 	for _, p := range poolers {
-		// In multigres, the pooler ID depends on the hostname which is the pod name
-		if fmt.Sprintf("%v", p.Id) == pod.Name ||
-			p.GetHostname() == pod.Name { // Fallback heuristics for matching
+		if podMatchesPooler(pod.Name, p) {
 			myPooler = p
 			break
 		}
@@ -94,7 +88,7 @@ func (r *ShardReconciler) executeDrainStateMachine(
 				pp, _ := store.GetMultiPoolersByCell(ctx, cell, opt)
 				for _, p := range pp {
 					if p.Type != clustermetadatapb.PoolerType_PRIMARY &&
-						(fmt.Sprintf("%v", p.Id) != pod.Name && p.GetHostname() != pod.Name) {
+						!podMatchesPooler(pod.Name, p) {
 						otherPooler = p
 						break
 					}
@@ -279,7 +273,7 @@ func (r *ShardReconciler) forceUnregister(
 	}
 
 	for _, p := range poolers {
-		if fmt.Sprintf("%v", p.Id) == pod.Name || p.GetHostname() == pod.Name {
+		if podMatchesPooler(pod.Name, p) {
 			return store.UnregisterMultiPooler(ctx, p.Id)
 		}
 	}
@@ -287,4 +281,13 @@ func (r *ShardReconciler) forceUnregister(
 		Info("No matching pooler found in topology for pod, skipping unregistration",
 			"pod", pod.Name, "cell", cellName)
 	return nil
+}
+
+// podMatchesPooler checks if the topology pooler record corresponds to the given Kubernetes pod name.
+func podMatchesPooler(podName string, p *topoclient.MultiPoolerInfo) bool {
+	if p.Id != nil && p.Id.Name == podName {
+		return true
+	}
+	h := p.GetHostname()
+	return h == podName || strings.HasPrefix(h, podName+".")
 }

--- a/pkg/data-handler/controller/shard/drain_test.go
+++ b/pkg/data-handler/controller/shard/drain_test.go
@@ -369,7 +369,7 @@ func TestReplicaDrainFlow(t *testing.T) {
 	}, false)
 
 	// Step 1: Requested -> Draining
-	requeue, err := reconciler.executeDrainStateMachine(ctx, shardObj, pod)
+	requeue, err := reconciler.executeDrainStateMachine(ctx, store, shardObj, pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -386,7 +386,7 @@ func TestReplicaDrainFlow(t *testing.T) {
 	}
 
 	// Step 2: Draining -> Acknowledged
-	_, _ = reconciler.executeDrainStateMachine(ctx, shardObj, pod)
+	_, _ = reconciler.executeDrainStateMachine(ctx, store, shardObj, pod)
 	_ = c.Get(ctx, client.ObjectKeyFromObject(pod), pod)
 	if pod.Annotations[metadata.AnnotationDrainState] != metadata.DrainStateAcknowledged {
 		t.Fatalf(
@@ -396,7 +396,7 @@ func TestReplicaDrainFlow(t *testing.T) {
 	}
 
 	// Step 3: Acknowledged -> ReadyForDeletion
-	_, _ = reconciler.executeDrainStateMachine(ctx, shardObj, pod)
+	_, _ = reconciler.executeDrainStateMachine(ctx, store, shardObj, pod)
 	_ = c.Get(ctx, client.ObjectKeyFromObject(pod), pod)
 	if pod.Annotations[metadata.AnnotationDrainState] != metadata.DrainStateReadyForDeletion {
 		t.Fatalf(
@@ -489,7 +489,7 @@ func TestPrimaryDrainFlow(t *testing.T) {
 		Shard:      "0",
 	}, false)
 
-	requeue, err := reconciler.executeDrainStateMachine(ctx, shardObj, pod)
+	requeue, err := reconciler.executeDrainStateMachine(ctx, store, shardObj, pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -564,7 +564,7 @@ func TestStuckTerminatingPod(t *testing.T) {
 	delTime := metav1.NewTime(time.Now().Add(-10 * time.Minute))
 	pod.DeletionTimestamp = &delTime
 
-	_, _ = reconciler.executeDrainStateMachine(ctx, shardObj, pod)
+	_, _ = reconciler.executeDrainStateMachine(ctx, store, shardObj, pod)
 	// Recreate a new inspector store to verify unregistration without reuse
 	inspectorStore := topoclient.NewWithFactory(
 		factory,

--- a/pkg/data-handler/controller/shard/shard_controller.go
+++ b/pkg/data-handler/controller/shard/shard_controller.go
@@ -255,7 +255,7 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			for i := range podList.Items {
 				pod := &podList.Items[i]
 				if pod.Annotations[metadata.AnnotationDrainState] != "" {
-					shouldRequeue, derr := r.executeDrainStateMachine(ctx, shard, pod)
+					shouldRequeue, derr := r.executeDrainStateMachine(ctx, store, shard, pod)
 					if derr != nil {
 						logger.Error(derr, "Failed to execute drain state machine", "pod", pod.Name)
 					}


### PR DESCRIPTION
The executeDrainStateMachine was creating a decoupled topology store that could fail to connect due to transient gRPC issues, causing silent drain failures. Additionally, pod-to-pooler matching was broken because it relied on raw string comparisons that failed against FQDNs and protobuf struct representations.

- Introduced podMatchesPooler helper to handle short names and FQDN prefixes correctly
- Updated executeDrainStateMachine to accept a pre-initialized topoclient.Store
- Removed redundant topology connection lifecycle management from the drain loop
- Updated Reconcile and unit tests to propagate the active topology store

Ensures reliable shard scale-down and failover by preventing silent topology connection drops and correctly identifying pods within the topology server.