### PR TITLE
build(images): pin multigres image defaults to SHA tags

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -3,23 +3,23 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:main"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-a9789ff"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiAdminImage is the default container image for the MultiAdmin component.
-	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:main"
+	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-a9789ff"
 
 	// DefaultMultiAdminWebImage is the default container image for the MultiAdminWeb component.
-	DefaultMultiAdminWebImage = "ghcr.io/multigres/multiadmin-web:main"
+	DefaultMultiAdminWebImage = "ghcr.io/multigres/multiadmin-web:sha-b505c90"
 
 	// DefaultMultiOrchImage is the default container image for the MultiOrch component.
-	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:main"
+	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-a9789ff"
 
 	// DefaultMultiPoolerImage is the default container image for the MultiPooler component.
-	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:main"
+	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-a9789ff"
 
 	// DefaultMultiGatewayImage is the default container image for the MultiGateway component.
-	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:main"
+	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-a9789ff"
 )


### PR DESCRIPTION
- Update DefaultPostgresImage to sha-a9789ff
- Update DefaultMultiAdminImage to sha-a9789ff
- Update DefaultMultiAdminWebImage to sha-b505c90
- Update DefaultMultiOrchImage to sha-a9789ff
- Update DefaultMultiPoolerImage to sha-a9789ff
- Update DefaultMultiGatewayImage to sha-a9789ff

This ensures that the operator release is deterministic and independent of upstream main branch changes.

Deterministic releases prevent unexpected breakage due to image drift.