### PR TITLE
  fix(drain): resolve PRIMARY drain infinite loop

### DIFF
--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -30,6 +30,7 @@ import (
 	// Import topology implementations for Vitess
 	// TODO: This pulls in multigres/multigres upstream as the hard direct
 	// dependency from the main module, which we would like to avoid.
+	"github.com/multigres/multigres/go/common/rpcclient"
 	_ "github.com/multigres/multigres/go/common/topoclient/etcdtopo"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -442,11 +443,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&datahandlershardcontroller.ShardReconciler{
+	rpcClient := rpcclient.NewMultiPoolerClient(100)
+	defer rpcClient.Close()
+
+	dataHandlerReconciler := &datahandlershardcontroller.ShardReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("shard-datahandler"),
-	}).SetupWithManager(mgr); err != nil {
+	}
+	dataHandlerReconciler.SetRPCClient(rpcClient)
+	if err = dataHandlerReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Shard-DataHandler")
 		os.Exit(1)
 	}

--- a/config/samples/default-templates/shard.yaml
+++ b/config/samples/default-templates/shard.yaml
@@ -16,7 +16,7 @@ spec:
   pools:
     default:
       type: "readWrite"
-      replicasPerCell: 2
+      replicasPerCell: 3
       storage:
         size: "2Gi"
         class: "standard"

--- a/config/samples/no-templates.yaml
+++ b/config/samples/no-templates.yaml
@@ -81,7 +81,7 @@ spec:
                     type: "readWrite"
                     cells:
                       - "z1"
-                    replicasPerCell: 2
+                    replicasPerCell: 3
                     storage:
                       # class: "standard"
                       size: "100Gi"

--- a/config/samples/overrides.yaml
+++ b/config/samples/overrides.yaml
@@ -44,6 +44,6 @@ spec:
                     # Define a new pool not in template. This will produce a warning in case it's a typo.
                   "analytics":
                     type: "readOnly"
-                    replicasPerCell: 1
+                    replicasPerCell: 3
                     storage:
                       size: "50Gi"

--- a/config/samples/templates/shard.yaml
+++ b/config/samples/templates/shard.yaml
@@ -16,7 +16,7 @@ spec:
   pools:
     main-app:
       type: "readWrite"
-      replicasPerCell: 2
+      replicasPerCell: 3
       storage:
         class: "standard"
         size: "100Gi"

--- a/pkg/data-handler/controller/shard/drain.go
+++ b/pkg/data-handler/controller/shard/drain.go
@@ -75,146 +75,60 @@ func (r *ShardReconciler) executeDrainStateMachine(
 		}
 	}
 
+	isPrimary := myPooler != nil && myPooler.Type == clustermetadatapb.PoolerType_PRIMARY
+
 	// We only want to handle valid states
 	switch state {
 	case metadata.DrainStateRequested:
-		if myPooler != nil && myPooler.Type == clustermetadatapb.PoolerType_PRIMARY {
-			// It is a primary. We need to initiate a failover first.
-			logger.Info("Pod is PRIMARY, triggering failover", "pod", pod.Name)
-
-			// Best effort: find another pooler to become primary
-			var otherPooler *topoclient.MultiPoolerInfo
-			for _, cell := range cells {
-				pp, _ := store.GetMultiPoolersByCell(ctx, cell, opt)
-				for _, p := range pp {
-					if p.Type != clustermetadatapb.PoolerType_PRIMARY &&
-						!podMatchesPooler(pod.Name, p) {
-						otherPooler = p
-						break
-					}
-				}
-				if otherPooler != nil {
-					break
-				}
-			}
-
-			if otherPooler != nil {
-				if r.rpcClient == nil {
-					logger.Info(
-						"RPC client not configured, cannot trigger failover",
-						"pod",
-						pod.Name,
-					)
-					return true, nil
-				}
-				_, err = r.rpcClient.Promote(
-					ctx,
-					otherPooler.MultiPooler,
-					&multipoolermanagerdatapb.PromoteRequest{},
-				)
-				if err != nil {
-					logger.Error(
-						err,
-						"Failed to appoint new leader",
-						"newPrimary",
-						otherPooler.GetHostname(),
-					)
-					return true, nil // Requeue and try again
-				}
-				r.Recorder.Eventf(
-					shard,
-					"Warning",
-					"FailoverInitiated",
-					"Initiated failover from %s to %s",
-					pod.Name,
-					otherPooler.GetHostname(),
-				)
-			} else {
-				// No replicas available — check if we've exceeded the drain timeout.
-				if reqAt, ok := pod.Annotations[metadata.AnnotationDrainRequestedAt]; ok {
-					if t, parseErr := time.Parse(
-						time.RFC3339,
-						reqAt,
-					); parseErr == nil &&
-						time.Since(t) > drainTimeout {
-						r.Recorder.Eventf(
-							shard,
-							"Warning",
-							"FailoverTimeout",
-							"Cannot failover PRIMARY pod %s: no eligible replicas found after %s",
-							pod.Name,
-							drainTimeout,
-						)
-						monitoring.IncrementDrainOperations(clusterName, shard.Name, "failure")
-						return false, fmt.Errorf(
-							"failover timeout: no replicas available for PRIMARY pod %s after %s",
-							pod.Name,
-							drainTimeout,
-						)
-					}
-				}
-				logger.Info("No replicas available for failover, will retry", "pod", pod.Name)
-			}
-			return true, nil // Requeue until it becomes a replica
-		}
-
-		// Proceed to draining (call UpdateSynchronousStandbyList REMOVE on primary)
-		logger.Info("Proceeding to drain pod", "pod", pod.Name)
-
-		// Get the current primary to remove this replica from synchronous standby
-		primary, err := findPrimaryPooler(ctx, store, shard, cells)
-		if err == nil && primary != nil && myPooler != nil && r.rpcClient != nil {
-			req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
-				Operation:  multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
-				StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
-			}
-			_, rpcErr := r.rpcClient.UpdateSynchronousStandbyList(ctx, primary, req)
-			if rpcErr != nil {
-				logger.Error(
-					rpcErr,
-					"Failed to remove pod from synchronous standby list",
-					"pod",
-					pod.Name,
-				)
-				return true, nil
-			}
-		}
-
-		return r.updateDrainState(ctx, pod, metadata.DrainStateDraining)
-
-	case metadata.DrainStateDraining:
-		// Verify that the standby removal actually took effect by re-attempting the
-		// idempotent REMOVE call on the primary. If the primary is unreachable, requeue.
-		primary, err := findPrimaryPooler(ctx, store, shard, cells)
-		if err != nil {
-			logger.Error(
-				err,
-				"Failed to find primary for drain verification, will retry",
-				"pod",
+		if isPrimary {
+			// Failover is multiorch's responsibility via its consensus protocol
+			// (BeginTerm + Promote). The operator proceeds with the drain and
+			// multiorch will elect a new leader once this pod is removed.
+			logger.Info("Draining PRIMARY pod, multiorch will handle failover", "pod", pod.Name)
+			r.Recorder.Eventf(
+				shard,
+				"Warning",
+				"PrimaryDrain",
+				"Draining PRIMARY pod %s; multiorch will elect a new leader",
 				pod.Name,
 			)
-			return true, nil
-		}
-		if primary != nil && myPooler != nil {
-			if r.rpcClient == nil {
-				logger.Info(
-					"RPC client not configured, skipping standby removal verification",
-					"pod",
-					pod.Name,
-				)
-			} else {
+		} else {
+			// Remove this replica from the synchronous standby list on the primary
+			// so that quorum calculations no longer include it.
+			logger.Info("Proceeding to drain replica pod", "pod", pod.Name)
+			primary, err := findPrimaryPooler(ctx, store, shard, cells)
+			if err == nil && primary != nil && myPooler != nil && r.rpcClient != nil {
 				req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
 					Operation:  multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
 					StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
 				}
 				_, rpcErr := r.rpcClient.UpdateSynchronousStandbyList(ctx, primary, req)
 				if rpcErr != nil {
-					logger.Error(
-						rpcErr,
-						"Standby removal verification failed, will retry",
-						"pod",
-						pod.Name,
-					)
+					logger.Error(rpcErr, "Failed to remove pod from synchronous standby list", "pod", pod.Name)
+					return true, nil
+				}
+			}
+		}
+
+		return r.updateDrainState(ctx, pod, metadata.DrainStateDraining)
+
+	case metadata.DrainStateDraining:
+		if !isPrimary {
+			// Verify that the standby removal actually took effect by re-attempting
+			// the idempotent REMOVE call on the primary.
+			primary, err := findPrimaryPooler(ctx, store, shard, cells)
+			if err != nil {
+				logger.Error(err, "Failed to find primary for drain verification, will retry", "pod", pod.Name)
+				return true, nil
+			}
+			if primary != nil && myPooler != nil && r.rpcClient != nil {
+				req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
+					Operation:  multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
+					StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
+				}
+				_, rpcErr := r.rpcClient.UpdateSynchronousStandbyList(ctx, primary, req)
+				if rpcErr != nil {
+					logger.Error(rpcErr, "Standby removal verification failed, will retry", "pod", pod.Name)
 					return true, nil
 				}
 			}

--- a/pkg/data-handler/controller/shard/drain_test.go
+++ b/pkg/data-handler/controller/shard/drain_test.go
@@ -489,15 +489,114 @@ func TestPrimaryDrainFlow(t *testing.T) {
 		Shard:      "0",
 	}, false)
 
+	// PRIMARY drain should advance to DrainStateDraining without calling Promote.
+	// Failover is multiorch's responsibility via its consensus protocol.
 	requeue, err := reconciler.executeDrainStateMachine(ctx, store, shardObj, pod)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !requeue {
-		t.Fatalf("expected requeue for primary to wait for role change")
+		t.Fatalf("expected requeue after state transition")
 	}
-	if !rpcMock.promoteCalled {
-		t.Fatalf("expected promote to be called on another replica")
+
+	_ = c.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+	if pod.Annotations[metadata.AnnotationDrainState] != metadata.DrainStateDraining {
+		t.Fatalf("expected PRIMARY pod to advance to draining, got %v",
+			pod.Annotations[metadata.AnnotationDrainState])
+	}
+	if rpcMock.promoteCalled {
+		t.Fatalf("Promote should not be called; failover is multiorch's responsibility")
+	}
+	if rpcMock.updateStandbyCalled {
+		t.Fatalf("UpdateSynchronousStandbyList should not be called when draining the PRIMARY")
+	}
+}
+
+func TestPrimaryDrainFlowNilRPCClient(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	shardObj := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-shard", Namespace: "default",
+			Labels: map[string]string{metadata.LabelMultigresCluster: "test"},
+		},
+		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:     "test-db",
+			TableGroupName:   "test-tg",
+			ShardName:        "0",
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{RootPath: "/test"},
+			Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"pool1": {Cells: []multigresv1alpha1.CellName{"cell1"}},
+			},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-0",
+			Namespace: "default",
+			Labels:    map[string]string{metadata.LabelMultigresCell: "cell1"},
+			Annotations: map[string]string{
+				metadata.AnnotationDrainState: metadata.DrainStateRequested,
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shardObj, pod).Build()
+	reconciler := &ShardReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		// rpcClient intentionally nil
+	}
+
+	_, factory := memorytopo.NewServerAndFactory(context.Background(), "cell1")
+
+	reconciler.createTopoStore = func(s *multigresv1alpha1.Shard) (topoclient.Store, error) {
+		return topoclient.NewWithFactory(
+			factory,
+			"",
+			[]string{""},
+			topoclient.NewDefaultTopoConfig(),
+		), nil
+	}
+
+	ctx := context.Background()
+	store := topoclient.NewWithFactory(factory, "", []string{""}, topoclient.NewDefaultTopoConfig())
+	defer func() { _ = store.Close() }()
+
+	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
+		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
+		Hostname: "test-pod-0", Type: clustermetadata.PoolerType_PRIMARY,
+		Database:   "test-db",
+		TableGroup: "test-tg",
+		Shard:      "0",
+	}, false)
+	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
+		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod"},
+		Hostname: "replica-pod", Type: clustermetadata.PoolerType_REPLICA,
+		Database:   "test-db",
+		TableGroup: "test-tg",
+		Shard:      "0",
+	}, false)
+
+	// With nil rpcClient, drain should proceed instead of looping forever
+	requeue, err := reconciler.executeDrainStateMachine(ctx, store, shardObj, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !requeue {
+		t.Fatalf("expected requeue after state transition")
+	}
+
+	_ = c.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+	if pod.Annotations[metadata.AnnotationDrainState] != metadata.DrainStateDraining {
+		t.Fatalf(
+			"expected PRIMARY pod to advance to draining when rpcClient is nil, got %v",
+			pod.Annotations[metadata.AnnotationDrainState],
+		)
 	}
 }
 

--- a/pkg/data-handler/controller/shard/shard_controller.go
+++ b/pkg/data-handler/controller/shard/shard_controller.go
@@ -568,6 +568,12 @@ func (r *ShardReconciler) getTopoStore(shard *multigresv1alpha1.Shard) (topoclie
 	return defaultCreateTopoStore(shard)
 }
 
+// SetRPCClient sets the gRPC client used for pooler management operations
+// such as failover promotion and standby list updates during drain.
+func (r *ShardReconciler) SetRPCClient(c rpcclient.MultiPoolerClient) {
+	r.rpcClient = c
+}
+
 // SetCreateTopoStore sets a custom topology store creation function for testing.
 func (r *ShardReconciler) SetCreateTopoStore(
 	f func(*multigresv1alpha1.Shard) (topoclient.Store, error),


### PR DESCRIPTION
  The drain state machine looped forever when draining PRIMARY pods.
  Two bugs: rpcClient was never wired up in main.go, and the Promote
  RPC was called without the required BeginTerm consensus protocol.

  - Wire up rpcclient.NewMultiPoolerClient in main.go and add SetRPCClient setter on ShardReconciler
  - Remove broken Promote logic from drain.go; delegate failover to multiorch which owns the BeginTerm+Promote consensus protocol
  - PRIMARY pods now proceed through drain states directly; multiorch elects a new leader after the pod is removed
  - Preserve UpdateSynchronousStandbyList REMOVE for replica drains
  - Update all sample manifests to replicasPerCell: 3 (quorum minimum)
  - Add/update drain tests for new PRIMARY drain behavior

  Eliminates the infinite requeue loop reported during rolling upgrades
  when changing multipooler resource limits.