### PR TITLE
  feat(validation): enforce replicasPerCell minimum and quorum warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,22 @@ You can customize the operator's behavior by passing flags to the binary (or edi
 
 ---
 
+## Pool Replication & Quorum
+
+Multigres uses the `ANY_2` durability policy by default, which requires every write to be acknowledged by at least 2 nodes (the primary + 1 synchronous standby). This has implications for how many replicas you should run per cell in `readWrite` pools.
+
+| Replicas per Cell | Configuration | Rolling Upgrade Behavior |
+| :--- | :--- | :--- |
+| **1** | 1 pod (primary only, no standbys) | **Downtime during upgrades.** No standby to maintain quorum. |
+| **2** | 1 primary + 1 standby | **Downtime during upgrades.** Draining the standby leaves zero synchronous standbys, violating `ANY_2`. Upstream multigres rejects the `UpdateSynchronousStandbyList REMOVE` because it would empty the synchronous standby list. |
+| **3** (recommended) | 1 primary + 2 standbys | **Zero-downtime upgrades.** One standby can be drained while the other maintains quorum. |
+
+The operator enforces a **hard minimum of 1** replica per cell (the CRD rejects `replicasPerCell: 0`). For `readWrite` pools with fewer than 3 replicas, the webhook returns an **admission warning** (not a rejection) explaining the quorum limitation.
+
+`readOnly` pools are not subject to this warning since they don't participate in write quorum.
+
+---
+
 ## Constraints & Limits (v1alpha1)
 
 Please be aware of the following constraints in the current version:

--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -77,7 +77,9 @@ type PoolSpec struct {
 
 	// ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
 	// Sidecars (like Multipooler) will scale alongside the Postgres pods.
-	// +kubebuilder:validation:Minimum=0
+	// Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
+	// (ANY_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
+	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=32
 	// +optional
 	ReplicasPerCell *int32 `json:"replicasPerCell,omitempty"`

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -5042,9 +5042,11 @@ spec:
                                             description: |-
                                               ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
                                               Sidecars (like Multipooler) will scale alongside the Postgres pods.
+                                              Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
+                                              (ANY_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
                                             format: int32
                                             maximum: 32
-                                            minimum: 0
+                                            minimum: 1
                                             type: integer
                                           storage:
                                             description: Storage defines the storage
@@ -7354,9 +7356,11 @@ spec:
                                             description: |-
                                               ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
                                               Sidecars (like Multipooler) will scale alongside the Postgres pods.
+                                              Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
+                                              (ANY_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
                                             format: int32
                                             maximum: 32
-                                            minimum: 0
+                                            minimum: 1
                                             type: integer
                                           storage:
                                             description: Storage defines the storage

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -2449,9 +2449,11 @@ spec:
                       description: |-
                         ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
                         Sidecars (like Multipooler) will scale alongside the Postgres pods.
+                        Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
+                        (ANY_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
                       format: int32
                       maximum: 32
-                      minimum: 0
+                      minimum: 1
                       type: integer
                     storage:
                       description: Storage defines the storage configuration for the

--- a/config/crd/bases/multigres.com_shardtemplates.yaml
+++ b/config/crd/bases/multigres.com_shardtemplates.yaml
@@ -2156,9 +2156,11 @@ spec:
                       description: |-
                         ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
                         Sidecars (like Multipooler) will scale alongside the Postgres pods.
+                        Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
+                        (ANY_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
                       format: int32
                       maximum: 32
-                      minimum: 0
+                      minimum: 1
                       type: integer
                     storage:
                       description: Storage defines the storage configuration for the

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -2596,9 +2596,11 @@ spec:
                             description: |-
                               ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
                               Sidecars (like Multipooler) will scale alongside the Postgres pods.
+                              Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
+                              (ANY_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
                             format: int32
                             maximum: 32
-                            minimum: 0
+                            minimum: 1
                             type: integer
                           storage:
                             description: Storage defines the storage configuration

--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -119,7 +119,15 @@ This allows you to set "sane defaults" at the Namespace level (Level 3), overrid
 
 ---
 
-## 5. Scenarios & Gotchas
+## 5. Pool Replica Requirements
+
+- **Minimum**: `replicasPerCell` must be at least **1** (CRD-enforced). Setting it to 0 is rejected.
+- **Recommended for `readWrite` pools**: at least **3** replicas per cell. The `ANY_2` durability policy requires 1 primary + 2 synchronous standbys so that one standby can be drained during rolling upgrades while the other maintains write quorum. The operator issues an admission warning if a `readWrite` pool has fewer than 3 replicas.
+- **`readOnly` pools**: no quorum requirement, so any value >= 1 is fine.
+
+---
+
+## 6. Scenarios & Gotchas
 
 ### Scenario A: Namespace Defaults (The "Happy Path")
 

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -458,7 +458,25 @@ func (r *Resolver) ValidateClusterLogic(
 				}
 
 				// ------------------------------------------------------------------
-				// 3. Backup Validation
+				// 3. Quorum Warning for readWrite pools
+				// ------------------------------------------------------------------
+				for poolName, pool := range pools {
+					replicas := int32(3) // default
+					if pool.ReplicasPerCell != nil {
+						replicas = *pool.ReplicasPerCell
+					}
+					if pool.Type == "readWrite" && replicas < 3 {
+						warnings = append(warnings, fmt.Sprintf(
+							"pool '%s' in shard '%s' has replicasPerCell=%d; readWrite pools need at least 3 "+
+								"for zero-downtime rolling upgrades (ANY_2 durability requires 1 primary + 2 standbys "+
+								"to maintain quorum while draining a replica)",
+							poolName, shard.Name, replicas,
+						))
+					}
+				}
+
+				// ------------------------------------------------------------------
+				// 4. Backup Validation
 				// ------------------------------------------------------------------
 				if backupCfg != nil && backupCfg.Type == multigresv1alpha1.BackupTypeFilesystem {
 					// Check if any pool has >1 replicas and we are using RWO
@@ -498,7 +516,7 @@ func (r *Resolver) ValidateClusterLogic(
 	}
 
 	// ------------------------------------------------------------------
-	// 4. StorageClass Validation
+	// 5. StorageClass Validation
 	// ------------------------------------------------------------------
 	// Collect all PVC-generating components that have no explicit storage class.
 	// If any exist, verify a default StorageClass is available in the cluster.

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -560,6 +561,85 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			customClient: noMatchingNodeClient,
 			wantWarnings: []string{
 				"no nodes currently match topology.kubernetes.io/region=eu-west-1",
+			},
+		},
+		// COVERAGE: quorum warning for readWrite pools with low replica count
+		"Quorum Warning: readWrite pool with 2 replicas": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"default": {
+											ReplicasPerCell: ptr.To(int32(2)),
+										},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			wantWarnings: []string{
+				"replicasPerCell=2; readWrite pools need at least 3",
+			},
+		},
+		"No Quorum Warning: readWrite pool with 3 replicas": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"default": {
+											ReplicasPerCell: ptr.To(int32(3)),
+										},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+		},
+		"No Quorum Warning: readOnly pool with 2 replicas": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name: "s0",
+								Spec: &multigresv1alpha1.ShardInlineSpec{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"readonly": {
+											Type:            "readOnly",
+											ReplicasPerCell: ptr.To(int32(2)),
+										},
+									},
+								},
+							}},
+						}},
+					}},
+				},
 			},
 		},
 		// COVERAGE: filesystem backup AccessModes branch (isRWO=false path)

--- a/pkg/webhook/cel_validation_test.go
+++ b/pkg/webhook/cel_validation_test.go
@@ -615,6 +615,25 @@ func TestCEL_ExtendedValidation(t *testing.T) {
 			},
 			expectError: "less than or equal to 32",
 		},
+		{
+			name: "Invalid ReplicasPerCell Zero",
+			shard: &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{Name: "cel-replicas-per-cell-zero", Namespace: testNamespace},
+				Spec: multigresv1alpha1.ShardSpec{
+					DatabaseName: "postgres", TableGroupName: "default", ShardName: "0",
+					Images:           multigresv1alpha1.ShardImages{Postgres: "p", MultiOrch: "o", MultiPooler: "po"},
+					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{Address: "etcd", RootPath: "/", Implementation: "etcd"},
+					MultiOrch:        multigresv1alpha1.MultiOrchSpec{},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"rw": {
+							Cells:           []multigresv1alpha1.CellName{"cell-1"},
+							ReplicasPerCell: ptr.To(int32(0)), // < 1
+						},
+					},
+				},
+			},
+			expectError: "greater than or equal to 1",
+		},
 	}
 
 	for _, tc := range tests {

--- a/plans/phase-1/pod-management-design.md
+++ b/plans/phase-1/pod-management-design.md
@@ -174,7 +174,7 @@ These constraints are already enforced or need to be enforced via CEL validation
 | Constraint | Status | Risk |
 |---|---|---|
 | **Cell rename prevention** | ✅ **Implemented** | CEL append-only rule added to `MultigresCluster` and `Shard` CRDs. Cells cannot be removed or renamed after creation. |
-| **Pool replica count floor** | ❌ **Not validated** | User could set `replicasPerCell: 0`, which would delete all pods but leave etcd registrations behind. Consider minimum of 1. |
+| **Pool replica count floor** | ✅ **Validated** | CRD enforces minimum=1. Webhook warns for readWrite pools with <3 (ANY_2 quorum requires 1 primary + 2 standbys for rolling upgrades). |
 
 ### Explicitly NOT Supported (v1alpha1)
 


### PR DESCRIPTION
  Setting replicasPerCell: 0 deletes all pods but leaves stale etcd
  registrations behind. With ANY_2 durability, readWrite pools also need
  at least 3 replicas (1 primary + 2 standbys) for zero-downtime rolling
  upgrades — draining the only standby violates the synchronous commit
  policy.

  - Bump CRD minimum from 0 to 1 in api/v1alpha1/shard_types.go
  - Add admission warning in pkg/resolver/resolver.go for readWrite pools with replicasPerCell < 3 (warning, not rejection)
  - Regenerate CRD manifests (shards, multigresclusters, shardtemplates, tablegroups)
  - Add CEL test for replicasPerCell: 0 rejection
  - Add resolver tests for quorum warning (readWrite < 3, readWrite
    >= 3, readOnly < 3)
  - Document quorum requirements in README, samples README, and pod-management-design.md

  Prevents silent data-plane breakage from zero-replica pools and
  surfaces quorum risks before they cause rolling upgrade failures.