### PR TITLE
fix(shard): reconcile backup PVCs for all pool cells

### DIFF
--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -123,25 +123,28 @@ func (r *ShardReconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 
-	// Compute active cells once for MultiOrch and backup PVCs
-	activeCells, err := getMultiOrchCells(shard)
+	// Compute MultiOrch cells
+	multiOrchCells, err := getMultiOrchCells(shard)
 	if err != nil {
 		monitoring.RecordSpanError(span, err)
-		logger.Error(err, "Failed to determine active cells")
+		logger.Error(err, "Failed to determine MultiOrch cells")
 		r.Recorder.Eventf(
 			shard,
 			"Warning",
 			"ConfigError",
-			"Failed to determine active cells: %v",
+			"Failed to determine MultiOrch cells: %v",
 			err,
 		)
 		return ctrl.Result{}, err
 	}
 
+	// Compute pool cells for shared backup PVCs (only cells with pool pods need backup storage)
+	poolCells := getPoolCells(shard)
+
 	// Reconcile MultiOrch - one Deployment and Service per cell
 	{
 		ctx, childSpan := monitoring.StartChildSpan(ctx, "Shard.ReconcileMultiOrch")
-		for _, cell := range activeCells {
+		for _, cell := range multiOrchCells {
 			cellName := string(cell)
 
 			// Reconcile MultiOrch Deployment for this cell
@@ -182,7 +185,7 @@ func (r *ShardReconciler) Reconcile(
 	// Reconcile Shared Backup PVCs (one per cell)
 	{
 		ctx, childSpan := monitoring.StartChildSpan(ctx, "Shard.ReconcileBackupPVCs")
-		for _, cell := range activeCells {
+		for _, cell := range poolCells {
 			cellName := string(cell)
 			if err := r.reconcileSharedBackupPVC(ctx, shard, cellName); err != nil {
 				monitoring.RecordSpanError(childSpan, err)
@@ -517,6 +520,26 @@ func getMultiOrchCells(shard *multigresv1alpha1.Shard) ([]multigresv1alpha1.Cell
 
 	slices.Sort(cells)
 	return cells, nil
+}
+
+// getPoolCells returns the deduplicated, sorted set of cells from all pools.
+// Used for infrastructure that only needs to exist where pool pods run
+// (e.g., shared backup PVCs).
+func getPoolCells(shard *multigresv1alpha1.Shard) []multigresv1alpha1.CellName {
+	cellSet := make(map[multigresv1alpha1.CellName]bool)
+	for _, pool := range shard.Spec.Pools {
+		for _, cell := range pool.Cells {
+			cellSet[cell] = true
+		}
+	}
+
+	cells := make([]multigresv1alpha1.CellName, 0, len(cellSet))
+	for cell := range cellSet {
+		cells = append(cells, cell)
+	}
+
+	slices.Sort(cells)
+	return cells
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -91,6 +91,70 @@ func buildHashedMultiOrchName(shard *multigresv1alpha1.Shard, cellName string) s
 	)
 }
 
+func TestGetPoolCells(t *testing.T) {
+	tests := map[string]struct {
+		shard *multigresv1alpha1.Shard
+		want  []multigresv1alpha1.CellName
+	}{
+		"explicit multiorch and pools in different cells": {
+			shard: &multigresv1alpha1.Shard{
+				Spec: multigresv1alpha1.ShardSpec{
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						Cells: []multigresv1alpha1.CellName{"zone-a"},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"pool1": {Cells: []multigresv1alpha1.CellName{"zone-b"}},
+					},
+				},
+			},
+			want: []multigresv1alpha1.CellName{"zone-b"},
+		},
+		"only multiorch": {
+			shard: &multigresv1alpha1.Shard{
+				Spec: multigresv1alpha1.ShardSpec{
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						Cells: []multigresv1alpha1.CellName{"zone-a"},
+					},
+				},
+			},
+			want: []multigresv1alpha1.CellName{},
+		},
+		"only pools": {
+			shard: &multigresv1alpha1.Shard{
+				Spec: multigresv1alpha1.ShardSpec{
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"pool1": {Cells: []multigresv1alpha1.CellName{"zone-b"}},
+						"pool2": {Cells: []multigresv1alpha1.CellName{"zone-c"}},
+					},
+				},
+			},
+			want: []multigresv1alpha1.CellName{"zone-b", "zone-c"},
+		},
+		"overlapping cells": {
+			shard: &multigresv1alpha1.Shard{
+				Spec: multigresv1alpha1.ShardSpec{
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						Cells: []multigresv1alpha1.CellName{"zone-a", "zone-b"},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"pool1": {Cells: []multigresv1alpha1.CellName{"zone-b", "zone-c"}},
+					},
+				},
+			},
+			want: []multigresv1alpha1.CellName{"zone-b", "zone-c"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := getPoolCells(tc.shard)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("getPoolCells() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestSetConditions(t *testing.T) {
 	tests := map[string]struct {
 		generation int64

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -240,6 +240,74 @@ func TestShardReconciler_Reconcile(t *testing.T) {
 				}
 			},
 		},
+		"create backup PVCs for all active cells including pool-only cells": {
+			shard: &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pool-only-pvc-shard",
+					Namespace: "default",
+					Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+				},
+				Spec: multigresv1alpha1.ShardSpec{
+					DatabaseName:   "testdb",
+					TableGroupName: "default",
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type:       multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{},
+					},
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						Cells: []multigresv1alpha1.CellName{"zone1"},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"primary": {
+							Cells:           []multigresv1alpha1.CellName{"zone1"},
+							Type:            "replica",
+							ReplicasPerCell: ptr.To(int32(1)),
+							Storage: multigresv1alpha1.StorageSpec{
+								Size: "10Gi",
+							},
+						},
+						"readonly": {
+							Cells:           []multigresv1alpha1.CellName{"zone2"},
+							Type:            "readOnly",
+							ReplicasPerCell: ptr.To(int32(1)),
+							Storage: multigresv1alpha1.StorageSpec{
+								Size: "10Gi",
+							},
+						},
+					},
+				},
+			},
+			existingObjects: []client.Object{},
+			assertFunc: func(t *testing.T, c client.Client, shard *multigresv1alpha1.Shard) {
+				// Verify MultiOrch Deployment was ONLY created for zone1
+				hashedMo1 := buildHashedMultiOrchName(shard, "zone1")
+				if err := c.Get(t.Context(),
+					types.NamespacedName{Name: hashedMo1, Namespace: "default"},
+					&appsv1.Deployment{}); err != nil {
+					t.Errorf("MultiOrch Deployment for zone1 should exist: %v", err)
+				}
+				hashedMo2 := buildHashedMultiOrchName(shard, "zone2")
+				if err := c.Get(t.Context(),
+					types.NamespacedName{Name: hashedMo2, Namespace: "default"},
+					&appsv1.Deployment{}); err == nil {
+					t.Errorf("MultiOrch Deployment for zone2 should NOT exist")
+				}
+
+				// Verify Backup PVCs were created for BOTH zone1 AND zone2
+				hashedPvc1 := buildHashedBackupPVCName(shard, "zone1")
+				if err := c.Get(t.Context(),
+					types.NamespacedName{Name: hashedPvc1, Namespace: "default"},
+					&corev1.PersistentVolumeClaim{}); err != nil {
+					t.Errorf("Backup PVC for zone1 should exist: %v", err)
+				}
+				hashedPvc2 := buildHashedBackupPVCName(shard, "zone2")
+				if err := c.Get(t.Context(),
+					types.NamespacedName{Name: hashedPvc2, Namespace: "default"},
+					&corev1.PersistentVolumeClaim{}); err != nil {
+					t.Errorf("Backup PVC for zone2 should exist: %v", err)
+				}
+			},
+		},
 		"error when MultiOrch and pools have no cells specified": {
 			shard: &multigresv1alpha1.Shard{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Backup PVC reconciliation was using the same cell list as MultiOrch deployments. This caused cells hosting only data pools to miss their shared backup PVCs when MultiOrch cells were explicitly restricted, leaving postgres pods stuck in Pending.

- Added getPoolCells helper to extract cell names from all pool specs
- Refactored Reconcile loop to use getPoolCells for shared backup storage
- Decoupled MultiOrch deployment cells from backup infrastructure
- Added TestGetPoolCells unit test and integration test coverage

Ensures database pods in any cell can successfully mount backup volumes regardless of orchestrator placement.