### PR TITLE
  fix(shard): resolve status ownership conflict

### DIFF
--- a/pkg/data-handler/controller/shard/shard_controller.go
+++ b/pkg/data-handler/controller/shard/shard_controller.go
@@ -186,6 +186,7 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 		store, err := r.getTopoStore(shard)
 		if err == nil {
+			statusBase := shard.DeepCopy()
 			if shard.Status.PodRoles == nil {
 				shard.Status.PodRoles = make(map[string]string)
 			}
@@ -240,14 +241,8 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 
 			if rolesChanged {
-				if err := r.Status().Update(ctx, shard); err != nil {
-					if apierrors.IsConflict(err) {
-						logger.V(1).Info("Conflict updating shard pod roles, retrying")
-						childSpan.End()
-						return ctrl.Result{Requeue: true}, nil
-					}
+				if err := r.Status().Patch(ctx, shard, client.MergeFrom(statusBase)); err != nil {
 					logger.Error(err, "Failed to update shard pod roles")
-					// continue, non-fatal for drain
 				}
 			}
 
@@ -296,6 +291,7 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				err,
 			)
 		} else if result != nil {
+			backupBase := shard.DeepCopy()
 			prevHealthy := isConditionTrue(shard.Status.Conditions, conditionBackupHealthy)
 			applyBackupHealth(shard, result)
 
@@ -306,7 +302,7 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				r.Recorder.Eventf(shard, "Warning", "BackupStale", result.Message)
 			}
 
-			if err := r.Status().Update(ctx, shard); err != nil {
+			if err := r.Status().Patch(ctx, shard, client.MergeFrom(backupBase)); err != nil {
 				monitoring.RecordSpanError(childSpan, err)
 				childSpan.End()
 				logger.Error(err, "Failed to update shard backup status")

--- a/pkg/resource-handler/controller/shard/status.go
+++ b/pkg/resource-handler/controller/shard/status.go
@@ -81,6 +81,16 @@ func (r *ShardReconciler) updateStatus(
 	patchObj.Status.LastBackupTime = nil
 	patchObj.Status.LastBackupType = ""
 
+	// Filter conditions owned by the data-handler so this SSA patch does not
+	// claim ownership of BackupHealthy and revert data-handler updates.
+	var filtered []metav1.Condition
+	for _, c := range patchObj.Status.Conditions {
+		if c.Type != "BackupHealthy" {
+			filtered = append(filtered, c)
+		}
+	}
+	patchObj.Status.Conditions = filtered
+
 	// 2. Apply the Patch
 	if oldPhase != shard.Status.Phase {
 		r.Recorder.Eventf(


### PR DESCRIPTION
  Two controllers reconcile the same Shard status subresource. The
  data-handler's Status().Update() replaced the entire status, clobbering
  resource-handler fields. The resource-handler's SSA patch included
  BackupHealthy from its cache, reverting data-handler updates.

  - Filter BackupHealthy condition from resource-handler SSA patch in pkg/resource-handler/controller/shard/status.go
  - Switch data-handler PodRoles update from Status().Update() to MergeFrom patch in pkg/data-handler/controller/shard/shard_controller.go
  - Switch data-handler backup health update from Status().Update() to MergeFrom patch

  Prevents cross-controller status clobbering without introducing a
  second SSA field owner.