### PR TITLE
  fix(api): repair S3 CEL validation rules

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -164,8 +164,8 @@ type FilesystemBackupConfig struct {
 }
 
 // S3BackupConfig defines S3-compatible backup storage settings.
-// +kubebuilder:validation:XValidation:rule="!(has(self.serviceAccountName) && self.serviceAccountName != ” && has(self.credentialsSecret) && self.credentialsSecret != ”)",message="serviceAccountName and credentialsSecret are mutually exclusive"
-// +kubebuilder:validation:XValidation:rule="!(has(self.serviceAccountName) && self.serviceAccountName != ” && self.useEnvCredentials)",message="serviceAccountName and useEnvCredentials are mutually exclusive — IRSA credentials are handled automatically"
+// +kubebuilder:validation:XValidation:rule="!(has(self.serviceAccountName) && size(self.serviceAccountName) > 0 && has(self.credentialsSecret) && size(self.credentialsSecret) > 0)",message="serviceAccountName and credentialsSecret are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.serviceAccountName) && size(self.serviceAccountName) > 0 && has(self.useEnvCredentials) && self.useEnvCredentials)",message="serviceAccountName and useEnvCredentials are mutually exclusive — IRSA credentials are handled automatically"
 type S3BackupConfig struct {
 	Bucket            string `json:"bucket"`
 	Region            string `json:"region"`

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -137,13 +137,13 @@ spec:
                     x-kubernetes-validations:
                     - message: serviceAccountName and credentialsSecret are mutually
                         exclusive
-                      rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                        != ” && has(self.credentialsSecret) && self.credentialsSecret
-                        != ”)'
+                      rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                        > 0 && has(self.credentialsSecret) && size(self.credentialsSecret)
+                        > 0)'
                     - message: serviceAccountName and useEnvCredentials are mutually
                         exclusive — IRSA credentials are handled automatically
-                      rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                        != ” && self.useEnvCredentials)'
+                      rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                        > 0 && has(self.useEnvCredentials) && self.useEnvCredentials)'
                   type:
                     description: Type is the backup storage backend (filesystem or
                       s3).
@@ -2546,13 +2546,13 @@ spec:
                           x-kubernetes-validations:
                           - message: serviceAccountName and credentialsSecret are
                               mutually exclusive
-                            rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                              != ” && has(self.credentialsSecret) && self.credentialsSecret
-                              != ”)'
+                            rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                              > 0 && has(self.credentialsSecret) && size(self.credentialsSecret)
+                              > 0)'
                           - message: serviceAccountName and useEnvCredentials are
                               mutually exclusive — IRSA credentials are handled automatically
-                            rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                              != ” && self.useEnvCredentials)'
+                            rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                              > 0 && has(self.useEnvCredentials) && self.useEnvCredentials)'
                         type:
                           description: Type is the backup storage backend (filesystem
                             or s3).
@@ -2670,14 +2670,14 @@ spec:
                                 x-kubernetes-validations:
                                 - message: serviceAccountName and credentialsSecret
                                     are mutually exclusive
-                                  rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                                    != ” && has(self.credentialsSecret) && self.credentialsSecret
-                                    != ”)'
+                                  rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                                    > 0 && has(self.credentialsSecret) && size(self.credentialsSecret)
+                                    > 0)'
                                 - message: serviceAccountName and useEnvCredentials
                                     are mutually exclusive — IRSA credentials are
                                     handled automatically
-                                  rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                                    != ” && self.useEnvCredentials)'
+                                  rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                                    > 0 && has(self.useEnvCredentials) && self.useEnvCredentials)'
                               type:
                                 description: Type is the backup storage backend (filesystem
                                   or s3).
@@ -2823,14 +2823,14 @@ spec:
                                       x-kubernetes-validations:
                                       - message: serviceAccountName and credentialsSecret
                                           are mutually exclusive
-                                        rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                                          != ” && has(self.credentialsSecret) && self.credentialsSecret
-                                          != ”)'
+                                        rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                                          > 0 && has(self.credentialsSecret) && size(self.credentialsSecret)
+                                          > 0)'
                                       - message: serviceAccountName and useEnvCredentials
                                           are mutually exclusive — IRSA credentials
                                           are handled automatically
-                                        rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                                          != ” && self.useEnvCredentials)'
+                                        rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                                          > 0 && has(self.useEnvCredentials) && self.useEnvCredentials)'
                                     type:
                                       description: Type is the backup storage backend
                                         (filesystem or s3).

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -135,13 +135,13 @@ spec:
                     x-kubernetes-validations:
                     - message: serviceAccountName and credentialsSecret are mutually
                         exclusive
-                      rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                        != ” && has(self.credentialsSecret) && self.credentialsSecret
-                        != ”)'
+                      rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                        > 0 && has(self.credentialsSecret) && size(self.credentialsSecret)
+                        > 0)'
                     - message: serviceAccountName and useEnvCredentials are mutually
                         exclusive — IRSA credentials are handled automatically
-                      rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                        != ” && self.useEnvCredentials)'
+                      rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                        > 0 && has(self.useEnvCredentials) && self.useEnvCredentials)'
                   type:
                     description: Type is the backup storage backend (filesystem or
                       s3).

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -134,13 +134,13 @@ spec:
                     x-kubernetes-validations:
                     - message: serviceAccountName and credentialsSecret are mutually
                         exclusive
-                      rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                        != ” && has(self.credentialsSecret) && self.credentialsSecret
-                        != ”)'
+                      rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                        > 0 && has(self.credentialsSecret) && size(self.credentialsSecret)
+                        > 0)'
                     - message: serviceAccountName and useEnvCredentials are mutually
                         exclusive — IRSA credentials are handled automatically
-                      rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                        != ” && self.useEnvCredentials)'
+                      rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                        > 0 && has(self.useEnvCredentials) && self.useEnvCredentials)'
                   type:
                     description: Type is the backup storage backend (filesystem or
                       s3).
@@ -470,13 +470,13 @@ spec:
                           x-kubernetes-validations:
                           - message: serviceAccountName and credentialsSecret are
                               mutually exclusive
-                            rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                              != ” && has(self.credentialsSecret) && self.credentialsSecret
-                              != ”)'
+                            rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                              > 0 && has(self.credentialsSecret) && size(self.credentialsSecret)
+                              > 0)'
                           - message: serviceAccountName and useEnvCredentials are
                               mutually exclusive — IRSA credentials are handled automatically
-                            rule: '!(has(self.serviceAccountName) && self.serviceAccountName
-                              != ” && self.useEnvCredentials)'
+                            rule: '!(has(self.serviceAccountName) && size(self.serviceAccountName)
+                              > 0 && has(self.useEnvCredentials) && self.useEnvCredentials)'
                         type:
                           description: Type is the backup storage backend (filesystem
                             or s3).


### PR DESCRIPTION
  The S3BackupConfig XValidation markers used '' (empty single-quoted
  CEL strings) for non-empty checks. gofmt/gofumpt (Go 1.19+) silently
  replaces '' with Unicode smart quotes in comments (golang/go#54312),
  corrupting the CEL expressions and breaking CRD installation.

  - Replace != '' with size() > 0 in S3BackupConfig CEL rules in api/v1alpha1/common_types.go
  - Guard useEnvCredentials access with has() to prevent runtime error when the optional bool field is absent
  - Regenerate CRD manifests for shards, multigresclusters, and tablegroups

  Unblocks CRD installation and is immune to gofumpt reformatting.