### PR TITLE
fix(data-handler): add smart topology cleanup during deletion

### DIFF
--- a/pkg/data-handler/controller/cell/cell_controller.go
+++ b/pkg/data-handler/controller/cell/cell_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/multigres/multigres/go/pb/clustermetadata"
 	"go.opentelemetry.io/otel/attribute"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,10 +23,16 @@ import (
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/monitoring"
+	"github.com/numtide/multigres-operator/pkg/util/status"
 )
 
 const (
 	finalizerName = "cell.data-handler.multigres.com/finalizer"
+
+	// conditionTopologyRegistered tracks whether the cell was ever
+	// successfully registered in the global topology. Used during deletion
+	// to distinguish "never initialized" from "temporarily unreachable".
+	conditionTopologyRegistered = "TopologyRegistered"
 
 	// topoUnavailableGracePeriod is the duration after resource creation during
 	// which topology UNAVAILABLE errors are silently requeued instead of being
@@ -36,6 +43,11 @@ const (
 	// topoUnavailableRequeueDelay is the delay before retrying when the topology
 	// server is unavailable during the grace period.
 	topoUnavailableRequeueDelay = 5 * time.Second
+
+	// topoCleanupTimeout is the maximum duration to retry topology cleanup
+	// during deletion when the topology was previously registered but is now
+	// unreachable. After this period, the finalizer is removed with a warning.
+	topoCleanupTimeout = 2 * time.Minute
 )
 
 // CellReconciler reconciles Cell data plane operations.
@@ -157,6 +169,22 @@ func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		childSpan.End()
 	}
 
+	// Mark the cell as registered in topology so deletion knows cleanup is needed.
+	if !status.IsConditionTrue(cell.Status.Conditions, conditionTopologyRegistered) {
+		statusBase := cell.DeepCopy()
+		status.SetCondition(&cell.Status.Conditions, metav1.Condition{
+			Type:               conditionTopologyRegistered,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Registered",
+			Message:            "Cell registered in topology",
+			ObservedGeneration: cell.Generation,
+			LastTransitionTime: metav1.Now(),
+		})
+		if err := r.Status().Patch(ctx, cell, client.MergeFrom(statusBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("setting TopologyRegistered condition: %w", err)
+		}
+	}
+
 	logger.V(1).Info("reconcile complete", "duration", time.Since(start).String())
 	logger.Info("Cell registered in topology successfully")
 	r.Recorder.Event(cell, "Normal", "Synced", "Successfully reconciled Cell topology")
@@ -174,7 +202,22 @@ func (r *CellReconciler) handleDeletion(
 		// Clean up cell data from topology
 		if err := r.unregisterCellFromTopology(ctx, cell); err != nil {
 			if isTopoUnavailable(err) {
-				logger.Info("Topology server unreachable during deletion, skipping cleanup")
+				if !status.IsConditionTrue(cell.Status.Conditions, conditionTopologyRegistered) {
+					logger.Info("Topology never initialized, skipping cleanup")
+				} else {
+					deletionAge := time.Since(cell.DeletionTimestamp.Time)
+					if deletionAge > topoCleanupTimeout {
+						logger.Info("Topology unreachable beyond cleanup timeout, forcing finalizer removal",
+							"deletionAge", deletionAge.Round(time.Second).String())
+						r.Recorder.Eventf(cell, "Warning", "CleanupSkipped",
+							"Topology unreachable for %s during deletion, skipping cleanup",
+							deletionAge.Round(time.Second))
+					} else {
+						logger.Info("Topology temporarily unreachable, will retry cleanup",
+							"deletionAge", deletionAge.Round(time.Second).String())
+						return ctrl.Result{RequeueAfter: topoUnavailableRequeueDelay}, nil
+					}
+				}
 			} else {
 				r.Recorder.Eventf(
 					cell,

--- a/pkg/data-handler/controller/cell/cell_controller_test.go
+++ b/pkg/data-handler/controller/cell/cell_controller_test.go
@@ -112,6 +112,25 @@ func TestReconcile(t *testing.T) {
 				if diff := cmp.Diff(wantCell, gotCell, opts); diff != "" {
 					t.Errorf("Cell in topology mismatch (-want +got):\n%s", diff)
 				}
+
+				// Verify TopologyRegistered condition is set
+				updatedCell := &multigresv1alpha1.Cell{}
+				if err := c.Get(context.Background(), types.NamespacedName{
+					Name:      cellObj.Name,
+					Namespace: cellObj.Namespace,
+				}, updatedCell); err != nil {
+					t.Fatalf("Failed to get Cell: %v", err)
+				}
+				var found bool
+				for _, cond := range updatedCell.Status.Conditions {
+					if cond.Type == "TopologyRegistered" && cond.Status == metav1.ConditionTrue {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Error("TopologyRegistered condition should be True after registration")
+				}
 			},
 		},
 		"skips registration when disabled": {
@@ -408,7 +427,7 @@ func TestReconcile(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		"skips topo cleanup when topo unavailable during deletion": {
+		"skips topo cleanup when topo unavailable and never registered": {
 			cell: &multigresv1alpha1.Cell{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-cell",
@@ -422,6 +441,69 @@ func TestReconcile(t *testing.T) {
 						Address:        "localhost:2379",
 						RootPath:       "/test",
 						Implementation: "memory",
+					},
+				},
+			},
+			customTopoStoreFunc: func(c *multigresv1alpha1.Cell) (topoclient.Store, error) {
+				return nil, errors.New("Code: UNAVAILABLE\nno connection available")
+			},
+		},
+		"retries cleanup when topo unavailable but was registered": {
+			cell: &multigresv1alpha1.Cell{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cell",
+					Namespace:         "default",
+					Finalizers:        []string{finalizerName},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: multigresv1alpha1.CellSpec{
+					Name: "zone-a",
+					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+						Address:        "localhost:2379",
+						RootPath:       "/test",
+						Implementation: "memory",
+					},
+				},
+				Status: multigresv1alpha1.CellStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "TopologyRegistered",
+							Status:             metav1.ConditionTrue,
+							Reason:             "Registered",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			customTopoStoreFunc: func(c *multigresv1alpha1.Cell) (topoclient.Store, error) {
+				return nil, errors.New("Code: UNAVAILABLE\nno connection available")
+			},
+			wantRequeue: true,
+		},
+		"forces cleanup skip after timeout when topo permanently gone": {
+			cell: &multigresv1alpha1.Cell{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cell",
+					Namespace:         "default",
+					Finalizers:        []string{finalizerName},
+					DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+				},
+				Spec: multigresv1alpha1.CellSpec{
+					Name: "zone-a",
+					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+						Address:        "localhost:2379",
+						RootPath:       "/test",
+						Implementation: "memory",
+					},
+				},
+				Status: multigresv1alpha1.CellStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "TopologyRegistered",
+							Status:             metav1.ConditionTrue,
+							Reason:             "Registered",
+							LastTransitionTime: metav1.Now(),
+						},
 					},
 				},
 			},

--- a/pkg/data-handler/controller/shard/backup_health.go
+++ b/pkg/data-handler/controller/shard/backup_health.go
@@ -13,6 +13,7 @@ import (
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/monitoring"
+	"github.com/numtide/multigres-operator/pkg/util/status"
 )
 
 const (
@@ -214,24 +215,7 @@ func applyBackupHealth(shard *multigresv1alpha1.Shard, result *backupHealthResul
 		condition.Reason = "BackupStale"
 	}
 
-	setCondition(&shard.Status.Conditions, condition)
-}
-
-// setCondition adds or updates a condition in the slice.
-func setCondition(conditions *[]metav1.Condition, condition metav1.Condition) {
-	for i, c := range *conditions {
-		if c.Type == condition.Type {
-			if c.Status != condition.Status {
-				(*conditions)[i] = condition
-			} else {
-				// Preserve transition time when status hasn't changed.
-				condition.LastTransitionTime = c.LastTransitionTime
-				(*conditions)[i] = condition
-			}
-			return
-		}
-	}
-	*conditions = append(*conditions, condition)
+	status.SetCondition(&shard.Status.Conditions, condition)
 }
 
 // collectCells returns the deduplicated set of cell names from the shard's pools.
@@ -247,14 +231,4 @@ func collectCells(shard *multigresv1alpha1.Shard) []string {
 		cells = append(cells, cell)
 	}
 	return cells
-}
-
-// isConditionTrue returns true if the named condition exists and has status True.
-func isConditionTrue(conditions []metav1.Condition, condType string) bool {
-	for _, c := range conditions {
-		if c.Type == condType {
-			return c.Status == metav1.ConditionTrue
-		}
-	}
-	return false
 }

--- a/pkg/data-handler/controller/shard/shard_controller.go
+++ b/pkg/data-handler/controller/shard/shard_controller.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,10 +31,16 @@ import (
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/monitoring"
 	"github.com/numtide/multigres-operator/pkg/util/metadata"
+	"github.com/numtide/multigres-operator/pkg/util/status"
 )
 
 const (
 	finalizerName = "multigres.com/shard-data-protection"
+
+	// conditionDatabaseRegistered tracks whether the database was ever
+	// successfully registered in the global topology. Used during deletion
+	// to distinguish "never initialized" from "temporarily unreachable".
+	conditionDatabaseRegistered = "DatabaseRegistered"
 
 	// topoUnavailableGracePeriod is the duration after resource creation during
 	// which topology UNAVAILABLE errors are silently requeued instead of being
@@ -44,6 +51,11 @@ const (
 	// topoUnavailableRequeueDelay is the delay before retrying when the topology
 	// server is unavailable during the grace period.
 	topoUnavailableRequeueDelay = 5 * time.Second
+
+	// topoCleanupTimeout is the maximum duration to retry topology cleanup
+	// during deletion when the database was previously registered but is now
+	// unreachable. After this period, the finalizer is removed with a warning.
+	topoCleanupTimeout = 2 * time.Minute
 )
 
 // ShardReconciler reconciles Shard data plane operations.
@@ -161,6 +173,22 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			return ctrl.Result{}, err
 		}
 		childSpan.End()
+	}
+
+	// Mark the database as registered in topology so deletion knows cleanup is needed.
+	if !status.IsConditionTrue(shard.Status.Conditions, conditionDatabaseRegistered) {
+		statusBase := shard.DeepCopy()
+		status.SetCondition(&shard.Status.Conditions, metav1.Condition{
+			Type:               conditionDatabaseRegistered,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Registered",
+			Message:            "Database registered in topology",
+			ObservedGeneration: shard.Generation,
+			LastTransitionTime: metav1.Now(),
+		})
+		if err := r.Status().Patch(ctx, shard, client.MergeFrom(statusBase)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("setting DatabaseRegistered condition: %w", err)
+		}
 	}
 
 	// Update PodRoles and execute Drain State Machine
@@ -292,7 +320,7 @@ func (r *ShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			)
 		} else if result != nil {
 			backupBase := shard.DeepCopy()
-			prevHealthy := isConditionTrue(shard.Status.Conditions, conditionBackupHealthy)
+			prevHealthy := status.IsConditionTrue(shard.Status.Conditions, conditionBackupHealthy)
 			applyBackupHealth(shard, result)
 
 			// Emit transition events.
@@ -330,7 +358,22 @@ func (r *ShardReconciler) handleDeletion(
 		// Clean up database data from topology
 		if err := r.unregisterDatabaseFromTopology(ctx, shard); err != nil {
 			if isTopoUnavailable(err) {
-				logger.Info("Topology server unreachable during deletion, skipping cleanup")
+				if !status.IsConditionTrue(shard.Status.Conditions, conditionDatabaseRegistered) {
+					logger.Info("Topology never initialized, skipping cleanup")
+				} else {
+					deletionAge := time.Since(shard.DeletionTimestamp.Time)
+					if deletionAge > topoCleanupTimeout {
+						logger.Info("Topology unreachable beyond cleanup timeout, forcing finalizer removal",
+							"deletionAge", deletionAge.Round(time.Second).String())
+						r.Recorder.Eventf(shard, "Warning", "CleanupSkipped",
+							"Topology unreachable for %s during deletion, skipping cleanup",
+							deletionAge.Round(time.Second))
+					} else {
+						logger.Info("Topology temporarily unreachable, will retry cleanup",
+							"deletionAge", deletionAge.Round(time.Second).String())
+						return ctrl.Result{RequeueAfter: topoUnavailableRequeueDelay}, nil
+					}
+				}
 			} else {
 				r.Recorder.Eventf(
 					shard,

--- a/pkg/data-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/data-handler/controller/shard/shard_controller_internal_test.go
@@ -29,6 +29,7 @@ import (
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/testutil"
 	"github.com/numtide/multigres-operator/pkg/util/metadata"
+	"github.com/numtide/multigres-operator/pkg/util/status"
 )
 
 // TestDefaultCreateTopoStore tests error paths in defaultCreateTopoStore
@@ -695,8 +696,8 @@ func TestIsConditionTrue(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if got := isConditionTrue(conditions, tc.condType); got != tc.want {
-				t.Errorf("isConditionTrue(%q) = %v, want %v", tc.condType, got, tc.want)
+			if got := status.IsConditionTrue(conditions, tc.condType); got != tc.want {
+				t.Errorf("IsConditionTrue(%q) = %v, want %v", tc.condType, got, tc.want)
 			}
 		})
 	}
@@ -714,7 +715,7 @@ func TestSetCondition(t *testing.T) {
 			Reason:  "AllGood",
 			Message: "everything is fine",
 		}
-		setCondition(&conditions, cond)
+		status.SetCondition(&conditions, cond)
 		if len(conditions) != 1 {
 			t.Fatalf("expected 1 condition, got %d", len(conditions))
 		}
@@ -740,7 +741,7 @@ func TestSetCondition(t *testing.T) {
 			Reason:             "NotReady",
 			LastTransitionTime: metav1.Now(),
 		}
-		setCondition(&conditions, newCond)
+		status.SetCondition(&conditions, newCond)
 		if len(conditions) != 1 {
 			t.Fatalf("expected 1 condition, got %d", len(conditions))
 		}
@@ -771,7 +772,7 @@ func TestSetCondition(t *testing.T) {
 				Reason:  "StillGood",
 				Message: "updated message",
 			}
-			setCondition(&conditions, newCond)
+			status.SetCondition(&conditions, newCond)
 			if len(conditions) != 1 {
 				t.Fatalf("expected 1 condition, got %d", len(conditions))
 			}
@@ -2233,7 +2234,7 @@ func TestReconcile_BackupStaleTransition(t *testing.T) {
 
 	updatedShard := &multigresv1alpha1.Shard{}
 	_ = c.Get(ctx, types.NamespacedName{Name: "test-shard", Namespace: "default"}, updatedShard)
-	if isConditionTrue(updatedShard.Status.Conditions, conditionBackupHealthy) {
+	if status.IsConditionTrue(updatedShard.Status.Conditions, conditionBackupHealthy) {
 		t.Error("expected backup condition to be False for stale backup")
 	}
 }

--- a/pkg/data-handler/controller/shard/shard_controller_test.go
+++ b/pkg/data-handler/controller/shard/shard_controller_test.go
@@ -135,6 +135,25 @@ func TestReconcile(t *testing.T) {
 				if diff := cmp.Diff(wantDB, gotDB, opts); diff != "" {
 					t.Errorf("Database in topology mismatch (-want +got):\n%s", diff)
 				}
+
+				// Verify DatabaseRegistered condition is set
+				updatedShard := &multigresv1alpha1.Shard{}
+				if err := c.Get(context.Background(), types.NamespacedName{
+					Name:      shardObj.Name,
+					Namespace: shardObj.Namespace,
+				}, updatedShard); err != nil {
+					t.Fatalf("Failed to get Shard: %v", err)
+				}
+				var found bool
+				for _, cond := range updatedShard.Status.Conditions {
+					if cond.Type == "DatabaseRegistered" && cond.Status == metav1.ConditionTrue {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Error("DatabaseRegistered condition should be True after registration")
+				}
 			},
 		},
 		"idempotent - database already exists": {
@@ -478,7 +497,7 @@ func TestReconcile(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		"skips topo cleanup when topo unavailable during deletion": {
+		"skips topo cleanup when topo unavailable and never registered": {
 			shard: &multigresv1alpha1.Shard{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-shard",
@@ -497,6 +516,81 @@ func TestReconcile(t *testing.T) {
 					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 						"primary": {
 							Cells: []multigresv1alpha1.CellName{"zone-a"},
+						},
+					},
+				},
+			},
+			customTopoStoreFunc: func(s *multigresv1alpha1.Shard) (topoclient.Store, error) {
+				return nil, errors.New("Code: UNAVAILABLE\nno connection available")
+			},
+		},
+		"retries cleanup when topo unavailable but was registered": {
+			shard: &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-shard",
+					Namespace:         "default",
+					Finalizers:        []string{finalizerName},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: multigresv1alpha1.ShardSpec{
+					DatabaseName:   "postgres",
+					TableGroupName: "default",
+					ShardName:      "0",
+					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+						Address:  "localhost:2379",
+						RootPath: "/test",
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"primary": {
+							Cells: []multigresv1alpha1.CellName{"zone-a"},
+						},
+					},
+				},
+				Status: multigresv1alpha1.ShardStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "DatabaseRegistered",
+							Status:             metav1.ConditionTrue,
+							Reason:             "Registered",
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			customTopoStoreFunc: func(s *multigresv1alpha1.Shard) (topoclient.Store, error) {
+				return nil, errors.New("Code: UNAVAILABLE\nno connection available")
+			},
+			wantRequeue: true,
+		},
+		"forces cleanup skip after timeout when topo permanently gone": {
+			shard: &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-shard",
+					Namespace:         "default",
+					Finalizers:        []string{finalizerName},
+					DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+				},
+				Spec: multigresv1alpha1.ShardSpec{
+					DatabaseName:   "postgres",
+					TableGroupName: "default",
+					ShardName:      "0",
+					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+						Address:  "localhost:2379",
+						RootPath: "/test",
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"primary": {
+							Cells: []multigresv1alpha1.CellName{"zone-a"},
+						},
+					},
+				},
+				Status: multigresv1alpha1.ShardStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               "DatabaseRegistered",
+							Status:             metav1.ConditionTrue,
+							Reason:             "Registered",
+							LastTransitionTime: metav1.Now(),
 						},
 					},
 				},

--- a/pkg/util/go.mod
+++ b/pkg/util/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/numtide/multigres-operator/api v0.0.0-20260227164937-a814c298f75d
 	k8s.io/api v0.35.0
+	k8s.io/apimachinery v0.35.0
 )
 
 require (
@@ -22,7 +23,6 @@ require (
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/apimachinery v0.35.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect

--- a/pkg/util/status/conditions.go
+++ b/pkg/util/status/conditions.go
@@ -1,0 +1,32 @@
+package status
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SetCondition adds or updates a condition in the slice. When the status
+// has not changed, the existing LastTransitionTime is preserved.
+func SetCondition(conditions *[]metav1.Condition, condition metav1.Condition) {
+	for i, c := range *conditions {
+		if c.Type == condition.Type {
+			if c.Status != condition.Status {
+				(*conditions)[i] = condition
+			} else {
+				condition.LastTransitionTime = c.LastTransitionTime
+				(*conditions)[i] = condition
+			}
+			return
+		}
+	}
+	*conditions = append(*conditions, condition)
+}
+
+// IsConditionTrue returns true if the named condition exists and has status True.
+func IsConditionTrue(conditions []metav1.Condition, condType string) bool {
+	for _, c := range conditions {
+		if c.Type == condType {
+			return c.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/util/status/doc.go
+++ b/pkg/util/status/doc.go
@@ -1,0 +1,14 @@
+// Package status provides shared helpers for managing the lifecycle state of
+// Multigres Custom Resources.
+//
+// It contains utilities for:
+//   - Computing resource Phase (Initializing / Progressing / Healthy) from
+//     replica counts via ComputePhase.
+//   - Managing metav1.Condition slices (SetCondition, IsConditionTrue) used
+//     by data-handler controllers to track topology registration, backup
+//     health, and similar observable state.
+//
+// These helpers are intentionally kept in a shared package so that both the
+// Cell and Shard data-handler controllers (and any future controllers) use
+// a single implementation rather than duplicating condition logic.
+package status

--- a/pkg/util/status/phase.go
+++ b/pkg/util/status/phase.go
@@ -14,12 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package status provides utilities for managing and calculating the Phase
-// and Status conditions of Multigres Custom Resources.
-//
-// It defines shared helper functions like ComputePhase to ensure consistent
-// lifecycle management across different resources such as TopoServer, Cell,
-// Shard, TableGroup, and MultigresCluster.
 package status
 
 import (

--- a/plans/phase-1/pod-management-architecture.md
+++ b/plans/phase-1/pod-management-architecture.md
@@ -205,6 +205,15 @@ Instead, the resource-handler removes pod finalizers directly and deletes pods. 
 
 The drain state machine remains fully functional for **rolling updates** and **scale-down**, where the cluster is alive and the data-handler is actively reconciling.
 
+#### Topology Cleanup Timeout
+
+During deletion, both Cell and Shard controllers use a `TopologyRegistered` / `DatabaseRegistered` status condition to determine whether topology cleanup is needed. This prevents two failure modes:
+
+- **Never initialized**: If the condition was never set (e.g., the topology server was unreachable since creation), cleanup is skipped immediately — there's nothing to clean up.
+- **Transient failure**: If the condition is `True` but the topology is temporarily unreachable, the controller retries for up to `topoCleanupTimeout` (currently 2 minutes). After the timeout, the controller force-skips cleanup with a `CleanupSkipped` warning event and removes the finalizer.
+
+> **Future consideration**: The 2-minute timeout is conservative for the current deployment model. As real-world usage patterns emerge, this value may need tuning. It could also be made configurable via the MultigresCluster spec if operators need per-cluster control.
+
 ---
 
 ## 6. Rolling Updates
@@ -296,7 +305,7 @@ The `updatePoolsStatus` function directly lists pods by label selector and aggre
 | `shard.Status.PodRoles` | Pod → role mapping (populated by data-handler from etcd) |
 | `shard.Status.LastBackupTime` | Timestamp of last completed backup (from `GetBackups` RPC via data-handler) |
 | `shard.Status.LastBackupType` | Type of last backup (full/diff/incr) |
-| `shard.Status.Conditions` | `Available`, `BackupHealthy`, `RollingUpdate` |
+| `shard.Status.Conditions` | `Available`, `BackupHealthy`, `DatabaseRegistered`, `RollingUpdate` |
 
 Terminating pods (with a non-zero `DeletionTimestamp`) are excluded from counts.
 


### PR DESCRIPTION
The old deletion logic unconditionally skipped topology cleanup whenever the topo server was unreachable. This meant a transient API hiccup at deletion time could silently leave orphaned cell/database entries in etcd, while succeeding from the operator's perspective.

- Add TopologyRegistered condition to Cell controller and DatabaseRegistered condition to Shard controller, set after successful registration via a status patch
- Rewrite handleDeletion in both controllers with three-tier logic: never registered (skip), transiently unavailable (retry for 2min), permanently unavailable (force-skip with CleanupSkipped warning)
- Return status patch errors instead of swallowing them, preventing a silent loss of the registration condition
- Extract shared SetCondition/IsConditionTrue helpers into pkg/util/status/conditions.go, removing duplicates from backup_health.go and cell_controller.go
- Add doc.go for the status utility package
- Document the topology cleanup timeout mechanism in pod-management-architecture.md with a note on future configurability
- Add unit tests covering all three deletion tiers for both controllers

Prevents orphaned topology data from transient topo unavailability during deletion, while still allowing immediate cleanup skip when the topology was genuinely never initialized.