### PR TITLE
feat(operator): add tolerations, fix backup spam, add tracking labels

### DIFF
--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -100,6 +100,10 @@ type PoolSpec struct {
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 
+	// Tolerations defines the pod tolerations for scheduling onto tainted nodes.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
 	// PVCDeletionPolicy controls PVC lifecycle for this pool.
 	// Overrides Shard, TableGroup, and MultigresCluster settings.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -936,6 +936,13 @@ func (in *PoolSpec) DeepCopyInto(out *PoolSpec) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.PVCDeletionPolicy != nil {
 		in, out := &in.PVCDeletionPolicy, &out.PVCDeletionPolicy
 		*out = new(PVCDeletionPolicy)

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -5142,6 +5142,48 @@ spec:
                                                 pattern: ^([0-9]+)(.+)$
                                                 type: string
                                             type: object
+                                          tolerations:
+                                            description: Tolerations defines the pod
+                                              tolerations for scheduling onto tainted
+                                              nodes.
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  format: int64
+                                                  type: integer
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                              type: object
+                                            type: array
                                           type:
                                             allOf:
                                             - enum:
@@ -7456,6 +7498,48 @@ spec:
                                                 pattern: ^([0-9]+)(.+)$
                                                 type: string
                                             type: object
+                                          tolerations:
+                                            description: Tolerations defines the pod
+                                              tolerations for scheduling onto tainted
+                                              nodes.
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  format: int64
+                                                  type: integer
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                              type: object
+                                            type: array
                                           type:
                                             allOf:
                                             - enum:

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -2494,6 +2494,47 @@ spec:
                           pattern: ^([0-9]+)(.+)$
                           type: string
                       type: object
+                    tolerations:
+                      description: Tolerations defines the pod tolerations for scheduling
+                        onto tainted nodes.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
                     type:
                       allOf:
                       - enum:

--- a/config/crd/bases/multigres.com_shardtemplates.yaml
+++ b/config/crd/bases/multigres.com_shardtemplates.yaml
@@ -2184,6 +2184,47 @@ spec:
                           pattern: ^([0-9]+)(.+)$
                           type: string
                       type: object
+                    tolerations:
+                      description: Tolerations defines the pod tolerations for scheduling
+                        onto tainted nodes.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
                     type:
                       allOf:
                       - enum:

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -2658,6 +2658,47 @@ spec:
                                 pattern: ^([0-9]+)(.+)$
                                 type: string
                             type: object
+                          tolerations:
+                            description: Tolerations defines the pod tolerations for
+                              scheduling onto tainted nodes.
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
                           type:
                             allOf:
                             - enum:

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -130,6 +130,39 @@ func (r *MultigresClusterReconciler) Reconcile(
 		}
 	}
 
+	// Apply tracking labels for efficient webhook template-in-use lookups.
+	{
+		trackingLabels := collectTrackingLabels(cluster)
+		labelsChanged := false
+		if cluster.Labels == nil {
+			cluster.Labels = make(map[string]string)
+		}
+		patch := client.MergeFrom(cluster.DeepCopy())
+		trackingKeys := []string{
+			metadata.LabelUsesCoreTemplate,
+			metadata.LabelUsesCellTemplate,
+			metadata.LabelUsesShardTemplate,
+		}
+		for _, key := range trackingKeys {
+			if want, ok := trackingLabels[key]; ok {
+				if cluster.Labels[key] != want {
+					cluster.Labels[key] = want
+					labelsChanged = true
+				}
+			} else if _, exists := cluster.Labels[key]; exists {
+				delete(cluster.Labels, key)
+				labelsChanged = true
+			}
+		}
+		if labelsChanged {
+			if err := r.Patch(ctx, cluster, patch); err != nil {
+				l.Error(err, "Failed to patch tracking labels")
+				return ctrl.Result{}, fmt.Errorf("failed to patch tracking labels: %w", err)
+			}
+			l.V(1).Info("Patched tracking labels on cluster")
+		}
+	}
+
 	if !cluster.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, cluster)
 	}
@@ -457,4 +490,57 @@ func collectResolvedTemplates(
 	})
 
 	return rt
+}
+
+// collectTrackingLabels walks the cluster spec and returns boolean tracking
+// labels indicating which template kinds are referenced. These labels enable
+// efficient pre-filtering in the template deletion webhook.
+func collectTrackingLabels(cluster *multigresv1alpha1.MultigresCluster) map[string]string {
+	labels := make(map[string]string)
+
+	usesCore := cluster.Spec.TemplateDefaults.CoreTemplate != "" ||
+		(cluster.Spec.GlobalTopoServer != nil && cluster.Spec.GlobalTopoServer.TemplateRef != "") ||
+		(cluster.Spec.MultiAdmin != nil && cluster.Spec.MultiAdmin.TemplateRef != "") ||
+		(cluster.Spec.MultiAdminWeb != nil && cluster.Spec.MultiAdminWeb.TemplateRef != "")
+	if usesCore {
+		labels[metadata.LabelUsesCoreTemplate] = "true"
+	}
+
+	usesCell := cluster.Spec.TemplateDefaults.CellTemplate != ""
+	if !usesCell {
+		for _, cell := range cluster.Spec.Cells {
+			if cell.CellTemplate != "" {
+				usesCell = true
+				break
+			}
+		}
+	}
+	if usesCell {
+		labels[metadata.LabelUsesCellTemplate] = "true"
+	}
+
+	usesShard := cluster.Spec.TemplateDefaults.ShardTemplate != ""
+	if !usesShard {
+		for _, db := range cluster.Spec.Databases {
+			for _, tg := range db.TableGroups {
+				for _, s := range tg.Shards {
+					if s.ShardTemplate != "" {
+						usesShard = true
+						break
+					}
+				}
+				if usesShard {
+					break
+				}
+			}
+			if usesShard {
+				break
+			}
+		}
+	}
+	if usesShard {
+		labels[metadata.LabelUsesShardTemplate] = "true"
+	}
+
+	return labels
 }

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/testutil"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
 	"github.com/numtide/multigres-operator/pkg/util/name"
 )
 
@@ -1125,6 +1126,132 @@ func TestCollectResolvedTemplates(t *testing.T) {
 
 		if len(rt.CoreTemplates) != 1 || rt.CoreTemplates[0] != "web-core" {
 			t.Errorf("CoreTemplates = %v, want [web-core]", rt.CoreTemplates)
+		}
+	})
+}
+
+func TestCollectTrackingLabels(t *testing.T) {
+	t.Run("All template kinds referenced", func(t *testing.T) {
+		cluster := &multigresv1alpha1.MultigresCluster{
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				TemplateDefaults: multigresv1alpha1.TemplateDefaults{
+					CoreTemplate:  "default-core",
+					CellTemplate:  "default-cell",
+					ShardTemplate: "default-shard",
+				},
+			},
+		}
+
+		labels := collectTrackingLabels(cluster)
+
+		if labels[metadata.LabelUsesCoreTemplate] != "true" {
+			t.Error("Expected uses-core-template=true")
+		}
+		if labels[metadata.LabelUsesCellTemplate] != "true" {
+			t.Error("Expected uses-cell-template=true")
+		}
+		if labels[metadata.LabelUsesShardTemplate] != "true" {
+			t.Error("Expected uses-shard-template=true")
+		}
+	})
+
+	t.Run("No templates (pure inline)", func(t *testing.T) {
+		cluster := &multigresv1alpha1.MultigresCluster{
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{
+					{Name: "z1", Spec: &multigresv1alpha1.CellInlineSpec{}},
+				},
+			},
+		}
+
+		labels := collectTrackingLabels(cluster)
+
+		if len(labels) != 0 {
+			t.Errorf("Expected no tracking labels for inline-only cluster, got %v", labels)
+		}
+	})
+
+	t.Run("Only cell template from per-cell ref", func(t *testing.T) {
+		cluster := &multigresv1alpha1.MultigresCluster{
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{
+					{Name: "z1", CellTemplate: "cell-ha"},
+				},
+			},
+		}
+
+		labels := collectTrackingLabels(cluster)
+
+		if _, ok := labels[metadata.LabelUsesCoreTemplate]; ok {
+			t.Error("Unexpected uses-core-template label")
+		}
+		if labels[metadata.LabelUsesCellTemplate] != "true" {
+			t.Error("Expected uses-cell-template=true")
+		}
+		if _, ok := labels[metadata.LabelUsesShardTemplate]; ok {
+			t.Error("Unexpected uses-shard-template label")
+		}
+	})
+
+	t.Run("Only shard template from per-shard ref", func(t *testing.T) {
+		cluster := &multigresv1alpha1.MultigresCluster{
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Databases: []multigresv1alpha1.DatabaseConfig{
+					{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{
+							{
+								Shards: []multigresv1alpha1.ShardConfig{
+									{ShardTemplate: "shard-prod"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		labels := collectTrackingLabels(cluster)
+
+		if _, ok := labels[metadata.LabelUsesCoreTemplate]; ok {
+			t.Error("Unexpected uses-core-template label")
+		}
+		if _, ok := labels[metadata.LabelUsesCellTemplate]; ok {
+			t.Error("Unexpected uses-cell-template label")
+		}
+		if labels[metadata.LabelUsesShardTemplate] != "true" {
+			t.Error("Expected uses-shard-template=true")
+		}
+	})
+
+	t.Run("Core from GlobalTopoServer templateRef", func(t *testing.T) {
+		cluster := &multigresv1alpha1.MultigresCluster{
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+					TemplateRef: "gts-core",
+				},
+			},
+		}
+
+		labels := collectTrackingLabels(cluster)
+
+		if labels[metadata.LabelUsesCoreTemplate] != "true" {
+			t.Error("Expected uses-core-template=true from GlobalTopoServer ref")
+		}
+	})
+
+	t.Run("Core from MultiAdminWeb templateRef", func(t *testing.T) {
+		cluster := &multigresv1alpha1.MultigresCluster{
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				MultiAdminWeb: &multigresv1alpha1.MultiAdminWebConfig{
+					TemplateRef: "web-core",
+				},
+			},
+		}
+
+		labels := collectTrackingLabels(cluster)
+
+		if labels[metadata.LabelUsesCoreTemplate] != "true" {
+			t.Error("Expected uses-core-template=true from MultiAdminWeb ref")
 		}
 	})
 }

--- a/pkg/resolver/shard.go
+++ b/pkg/resolver/shard.go
@@ -236,6 +236,9 @@ func mergePoolSpec(
 	if override.Affinity != nil {
 		out.Affinity = override.Affinity.DeepCopy()
 	}
+	if len(override.Tolerations) > 0 {
+		out.Tolerations = override.Tolerations
+	}
 	if override.PVCDeletionPolicy != nil {
 		out.PVCDeletionPolicy = override.PVCDeletionPolicy
 	}

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -94,6 +94,7 @@ func BuildPoolPod(
 			},
 			Volumes:      volumes,
 			Affinity:     poolSpec.Affinity,
+			Tolerations:  poolSpec.Tolerations,
 			NodeSelector: shard.Spec.CellTopologyLabels[multigresv1alpha1.CellName(cellName)],
 			// Hostname is set to the pod name for DNS resolution via headless service.
 			Hostname:  podName,
@@ -153,6 +154,12 @@ func ComputeSpecHash(pod *corev1.Pod) string {
 
 	if spec.Affinity != nil {
 		if b, err := json.Marshal(spec.Affinity); err == nil {
+			_, _ = h.Write(b)
+		}
+	}
+
+	if len(spec.Tolerations) > 0 {
+		if b, err := json.Marshal(spec.Tolerations); err == nil {
 			_, _ = h.Write(b)
 		}
 	}

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -224,6 +224,56 @@ func TestBuildPoolPod_Affinity(t *testing.T) {
 	}
 }
 
+func TestBuildPoolPod_Tolerations(t *testing.T) {
+	pool := newTestPoolSpec()
+	pool.Tolerations = []corev1.Toleration{
+		{
+			Key:      "dedicated",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "database",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+
+	pod, err := BuildPoolPod(newTestShard(), "main", "z1", pool, 0, testScheme())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pod.Spec.Tolerations) != 1 {
+		t.Fatalf("expected 1 toleration, got %d", len(pod.Spec.Tolerations))
+	}
+	if pod.Spec.Tolerations[0].Key != "dedicated" {
+		t.Errorf("toleration key = %q, want %q", pod.Spec.Tolerations[0].Key, "dedicated")
+	}
+	if pod.Spec.Tolerations[0].Value != "database" {
+		t.Errorf("toleration value = %q, want %q", pod.Spec.Tolerations[0].Value, "database")
+	}
+}
+
+func TestComputeSpecHash_ChangesOnTolerations(t *testing.T) {
+	pool1 := newTestPoolSpec()
+	pod1, _ := BuildPoolPod(newTestShard(), "main", "z1", pool1, 0, testScheme())
+
+	pool2 := newTestPoolSpec()
+	pool2.Tolerations = []corev1.Toleration{
+		{
+			Key:      "dedicated",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "database",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	pod2, _ := BuildPoolPod(newTestShard(), "main", "z1", pool2, 0, testScheme())
+
+	hash1 := ComputeSpecHash(pod1)
+	hash2 := ComputeSpecHash(pod2)
+
+	if hash1 == hash2 {
+		t.Error("spec hash should differ when tolerations change")
+	}
+}
+
 func TestBuildPoolPod_NodeSelector(t *testing.T) {
 	shard := newTestShard()
 	shard.Spec.CellTopologyLabels = map[multigresv1alpha1.CellName]map[string]string{

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane.go
@@ -90,7 +90,7 @@ func (r *ShardReconciler) reconcileDataPlane(
 
 			if result.Healthy && !prevHealthy {
 				r.Recorder.Event(shard, "Normal", "BackupHealthy", result.Message)
-			} else if !result.Healthy {
+			} else if !result.Healthy && prevHealthy {
 				r.Recorder.Eventf(shard, "Warning", "BackupStale", result.Message)
 			}
 

--- a/pkg/util/metadata/labels.go
+++ b/pkg/util/metadata/labels.go
@@ -124,6 +124,17 @@ const (
 	LabelMultigresShardTemplate = "multigres.com/shard-template"
 )
 
+const (
+	// LabelUsesCoreTemplate is set to "true" on clusters that reference any CoreTemplate.
+	LabelUsesCoreTemplate = "multigres.com/uses-core-template"
+
+	// LabelUsesCellTemplate is set to "true" on clusters that reference any CellTemplate.
+	LabelUsesCellTemplate = "multigres.com/uses-cell-template"
+
+	// LabelUsesShardTemplate is set to "true" on clusters that reference any ShardTemplate.
+	LabelUsesShardTemplate = "multigres.com/uses-shard-template"
+)
+
 // BuildStandardLabels returns a map of standard kubernetes labels.
 // clusterName should be the name of the MultigresCluster CR (used for instance label).
 // component is the name of the component (e.g. multigateway, multiorch, pool).

--- a/pkg/webhook/handlers/validator.go
+++ b/pkg/webhook/handlers/validator.go
@@ -15,6 +15,7 @@ import (
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/monitoring"
 	"github.com/numtide/multigres-operator/pkg/resolver"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
 )
 
 // ============================================================================
@@ -173,8 +174,24 @@ func (v *TemplateValidator) ValidateDelete(
 	templateName := metaObj.GetName()
 	namespace := metaObj.GetNamespace()
 
+	// Pre-filter clusters by tracking label to narrow the search space.
+	kindLabel := ""
+	switch v.Kind {
+	case "CoreTemplate":
+		kindLabel = metadata.LabelUsesCoreTemplate
+	case "CellTemplate":
+		kindLabel = metadata.LabelUsesCellTemplate
+	case "ShardTemplate":
+		kindLabel = metadata.LabelUsesShardTemplate
+	}
+
+	listOpts := []client.ListOption{client.InNamespace(namespace)}
+	if kindLabel != "" {
+		listOpts = append(listOpts, client.MatchingLabels{kindLabel: "true"})
+	}
+
 	clusters := &multigresv1alpha1.MultigresClusterList{}
-	if err := v.Client.List(ctx, clusters, client.InNamespace(namespace)); err != nil {
+	if err := v.Client.List(ctx, clusters, listOpts...); err != nil {
 		return nil, fmt.Errorf("failed to list clusters for validation: %w", err)
 	}
 


### PR DESCRIPTION
Three audit findings addressed: missing PoolSpec tolerations, noisy backup events, and inefficient webhook template-in-use lookups.

- Add Tolerations field to PoolSpec in shard_types.go and wire into BuildPoolPod, ComputeSpecHash, and mergePoolSpec in resolver
- Gate BackupStale event on healthy-to-unhealthy transition only in reconcile_data_plane.go to match BackupHealthy symmetry
- Add uses-core/cell/shard-template boolean tracking labels to labels.go and apply via MergeFrom patch in cluster controller
- Pre-filter TemplateValidator.ValidateDelete with MatchingLabels in validator.go for O(1) indexed lookups instead of full scan
- Regenerate CRD manifests for tolerations schema
- Add tests for tolerations, spec hash, and tracking labels

Eliminates backup event noise, enables pod scheduling on tainted nodes, and reduces webhook latency at scale.