### PR TITLE
fix(cache): filter pods by managed-by label

### DIFF
--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -253,7 +253,7 @@ func main() {
 	// We implement a Split-Brain Caching strategy to balance Scalability vs. Usability.
 	//
 	// 1. GLOBAL FILTER ("The Noise Cancelling"):
-	//    For high-volume resources (Secrets, Services, StatefulSets), we strictly
+	//    For high-volume resources (Secrets, Services, StatefulSets, Pods), we strictly
 	//    filter the cache to ONLY store objects managed by this operator.
 	//    This prevents the "Memory Bomb" where the operator caches 5,000+ Helm
 	//    secrets from other tenants, leading to OOMs.
@@ -316,7 +316,7 @@ func main() {
 					},
 				},
 				// -----------------------------------------------------------
-				// STATEFULSETS & SERVICES: High Volume Resources
+				// STATEFULSETS, SERVICES, PODS: High Volume Resources
 				// -----------------------------------------------------------
 				&appsv1.StatefulSet{}: {
 					Namespaces: map[string]cache.Config{
@@ -325,6 +325,12 @@ func main() {
 					},
 				},
 				&corev1.Service{}: {
+					Namespaces: map[string]cache.Config{
+						defaultNS:           unfilteredConfig,
+						cache.AllNamespaces: filteredConfig,
+					},
+				},
+				&corev1.Pod{}: {
 					Namespaces: map[string]cache.Config{
 						defaultNS:           unfilteredConfig,
 						cache.AllNamespaces: filteredConfig,

--- a/docs/development/caching-strategy.md
+++ b/docs/development/caching-strategy.md
@@ -29,6 +29,7 @@ For high-volume resources in regular user namespaces, we strictly filter the cac
 - `Secret`
 - `Service`
 - `StatefulSet` (still used for TopoServer)
+- `Pod`
 
 **Mechanism:**
 We use `cache.AllNamespaces` with a `LabelSelector`:
@@ -71,7 +72,8 @@ Since ConfigMaps are generally lower volume and lower security risk than Secrets
 | **Service** | Operator NS | **NONE (All)** | Self-discovery. |
 | **StatefulSet** | All Namespaces | `managed-by=multigres` | Noise reduction (still used for TopoServer). |
 | **StatefulSet** | Operator NS | **NONE (All)** | Self-discovery. |
-| **Pod** | All Namespaces | **NONE (All)** | Pool pods are operator-managed; needs full visibility. |
+| **Pod** | All Namespaces | `managed-by=multigres` | OOM prevention; operator only manages its own pool pods. |
+| **Pod** | Operator NS | **NONE (All)** | Self-discovery. |
 | **ConfigMap** | All Namespaces | **NONE (All)** | User Configs (postgresql.conf). |
 
 ## Developer Guide: Reading Secrets


### PR DESCRIPTION
When the operator moved from StatefulSet-based pool management to direct pod management, Pods were not added to the informer cache filter. In multi-tenant clusters, the operator was caching every pod across all namespaces, risking OOM and unnecessary API server load.

- Add corev1.Pod to cache.ByObject in main.go with the same filtered/unfiltered namespace split used for Secrets, Services, and StatefulSets
- Update caching-strategy.md to reflect Pod is now label-filtered globally and unfiltered in the operator NS

Prevents the informer "memory bomb" for Pods in large clusters where thousands of unrelated pods would otherwise be cached.