### PR TITLE
feat(images): upgrade multigres images from sha-b0a47e1 to sha-4f39f4a

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -3,23 +3,23 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-b0a47e1"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-4f39f4a"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiAdminImage is the default container image for the MultiAdmin component.
-	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-b0a47e1"
+	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-4f39f4a"
 
 	// DefaultMultiAdminWebImage is the default container image for the MultiAdminWeb component.
 	DefaultMultiAdminWebImage = "ghcr.io/multigres/multiadmin-web:sha-b505c90"
 
 	// DefaultMultiOrchImage is the default container image for the MultiOrch component.
-	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-b0a47e1"
+	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-4f39f4a"
 
 	// DefaultMultiPoolerImage is the default container image for the MultiPooler component.
-	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-b0a47e1"
+	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-4f39f4a"
 
 	// DefaultMultiGatewayImage is the default container image for the MultiGateway component.
-	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-b0a47e1"
+	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-4f39f4a"
 )


### PR DESCRIPTION
Upgrade multigres and pgctld container image tags to sha-4f39f4a. multiadmin-web remains at sha-b505c90 (no upstream changes).

Upstream changes between sha-b0a47e1 and sha-4f39f4a (9 commits):
- feat(eventlog): add structured lifecycle event log
- feat(multigateway): implement cross-gateway query cancellation
- feat(multipooler,multigateway): handle SET/RESET locally
- fix(multipooler): return authoritative reserved state
- refactor(multipooler/manager): improve lifecycle management and fix rewind bug
- refactor(repo): move multipooler to go/services/multipooler
- refactor(test): introduce semantic DSN helpers
- build(deps): bump docker/login-action, otel/sdk

No operator code changes required.