### PR TITLE
docs(readme): slim down and reorganize

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,17 @@ kubectl get multigrescluster,cell,shard,tablegroup,toposerver -A -w
 make kind-down
 ```
 
-See the [README](README.md#local-development-kind) for additional Kind deployment options (cert-manager, observability stack).
+**All Kind deployment targets:**
+
+| Command | Description |
+| :--- | :--- |
+| `make kind-deploy` | Deploy operator to local Kind cluster using self-signed certs (Default). |
+| `make kind-deploy-certmanager` | Deploy operator to Kind, installing `cert-manager` for certificate handling. |
+| `make kind-deploy-no-webhook` | Deploy operator to Kind with the webhook fully disabled. |
+| `make kind-deploy-observability` | Deploy operator with full observability stack (Prometheus Operator, OTel Collector, Tempo, Grafana). |
+| `make kind-portforward` | Port-forward Grafana (3000), Prometheus (9090), Tempo (3200) to localhost. Re-run if connection drops. |
+
+See the [demo/](demo/) folder for guided walkthroughs of cert-manager and observability deployments.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The **[Multigres](https://github.com/multigres/multigres) Operator** is a Kubern
 - [Backup & Restore](#backup--restore)
 - [Observability](#observability)
 - [Webhook & Certificate Management](#webhook--certificate-management)
-- [Operator Flags](#operator-flags)
 - [Pool Replication & Quorum](#pool-replication--quorum)
 - [Constraints & Limits](#constraints--limits-v1alpha1)
+- [Further Reading](#further-reading)
 
 ## Features
 - **Global Cluster Management**: Single source of truth (`MultigresCluster`) for the entire database topology.
@@ -47,67 +47,21 @@ This deploys the operator into the `multigres-operator` namespace with:
 - The operator Deployment
 - Metrics endpoint
 
-### With cert-manager
-
-If you prefer external certificate management via [cert-manager](https://cert-manager.io/):
-
-```bash
-# 1. Install cert-manager (if not already present)
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
-kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
-
-# 2. Install the operator
-kubectl apply --server-side -f \
-  https://github.com/numtide/multigres-operator/releases/latest/download/install-certmanager.yaml
-```
-
-### With observability stack
-
-Install the operator alongside Prometheus, OpenTelemetry Collector, Tempo, and Grafana for metrics, tracing, and dashboards:
-
-```bash
-# 1. Install the Prometheus Operator (if not already present)
-kubectl apply --server-side -f \
-  https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.80.0/bundle.yaml
-kubectl wait --for=condition=Available deployment/prometheus-operator -n default --timeout=120s
-
-# 2. Install the operator with observability
-kubectl apply --server-side -f \
-  https://github.com/numtide/multigres-operator/releases/latest/download/install-observability.yaml
-```
-
-> [!NOTE]
-> The bundled Prometheus, Tempo, Grafana, and OTel Collector are single-replica deployments with sane defaults intended for **evaluation and development**. They do not include HA, persistent storage, or authentication. For production observability, integrate the operator's metrics and traces with your existing monitoring infrastructure.
-
-### Applying samples
-
 Once the operator is running, try a sample cluster:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/numtide/multigres-operator/main/config/samples/minimal.yaml
 ```
 
-| Sample | Description |
-| :--- | :--- |
-| `config/samples/minimal.yaml` | The simplest possible cluster, relying entirely on system defaults. |
-| `config/samples/templated-cluster.yaml` | A full cluster example using reusable templates. |
-| `config/samples/templates/` | Individual `CoreTemplate`, `CellTemplate`, and `ShardTemplate` examples. |
-| `config/samples/default-templates/` | Namespace-level default templates (named `default`). |
-| `config/samples/overrides.yaml` | Advanced usage showing how to override specific fields on top of templates. |
-| `config/samples/no-templates.yaml` | A verbose example where all configuration is defined inline. |
-| `config/samples/external-etcd.yaml` | Connecting to an existing external Etcd cluster. |
+For more sample configurations, see the [samples directory](config/samples/README.md).
 
-### Local Development (Kind)
+### Deployment Options
 
-For local testing using Kind, we provide several helper commands:
-
-| Command | Description |
-| :--- | :--- |
-| `make kind-deploy` | Deploy operator to local Kind cluster using self-signed certs (Default). |
-| `make kind-deploy-certmanager` | Deploy operator to Kind, installing `cert-manager` for certificate handling. |
-| `make kind-deploy-no-webhook` | Deploy operator to Kind with the webhook fully disabled. |
-| `make kind-deploy-observability` | Deploy operator with full observability stack (Prometheus Operator, OTel Collector, Tempo, Grafana). |
-| `make kind-portforward` | Port-forward Grafana (3000), Prometheus (9090), Tempo (3200) to localhost. Re-run if connection drops. |
+| Option | Description | Guide |
+| :--- | :--- | :--- |
+| **Self-signed certs** (default) | Zero-config TLS — operator generates and rotates its own CA. | *(Installed above)* |
+| **cert-manager** | External certificate management via cert-manager. | [Cert-Manager Demo](demo/cert-manager/) |
+| **Observability stack** | Full metrics, tracing, and dashboards (Prometheus, Tempo, Grafana). | [Observability Demo](demo/observability/) |
 
 ---
 
@@ -216,148 +170,6 @@ spec:
 >
 > This mechanism may change in future versions. See [Template Propagation](docs/development/template-propagation.md) for details on planned improvements.
 
-### 4. PVC Deletion Policy
-
-The operator supports fine-grained control over **Persistent Volume Claim (PVC) lifecycle management** for stateful components (TopoServers and Shard Pools). This allows you to decide whether PVCs should be automatically deleted or retained when resources are deleted or scaled down.
-
-#### Policy Options
-
-The `pvcDeletionPolicy` field has two settings:
-
-- **`whenDeleted`**: Controls what happens to PVCs when the entire MultigresCluster (or a component like a TopoServer) is deleted.
-  - `Retain` (default): PVCs are preserved for manual review and potential data recovery
-  - `Delete`: PVCs are automatically deleted along with the cluster
-
-- **`whenScaled`**: Controls what happens to PVCs when reducing the number of replicas (e.g., scaling from 3 pods down to 1 pod).
-  - `Retain` (default): PVCs from scaled-down pods are kept for potential scale-up
-  - `Delete`: PVCs are automatically deleted when pods are removed
-
-#### Safe Defaults
-
-**By default, the operator uses `Retain/Retain`** for maximum data safety. This means:
-- Deleting a cluster will **not** delete your data volumes
-- Scaling down will **not** delete the PVCs from removed pods
-
-This is a deliberate choice to prevent accidental data loss.
-
-#### Where to Set the Policy
-
-The `pvcDeletionPolicy` can be set at multiple levels in the hierarchy, with more specific settings overriding general ones:
-
-```yaml
-apiVersion: multigres.com/v1alpha1
-kind: MultigresCluster
-metadata:
-  name: my-cluster
-spec:
-  # Cluster-level policy (applies to all components unless overridden)
-  pvcDeletionPolicy:
-    whenDeleted: Retain  # Safe: keep data when cluster is deleted
-    whenScaled: Delete   # Aggressive: auto-cleanup when scaling down
-
-  globalTopoServer:
-    # Override for GlobalTopoServer specifically
-    pvcDeletionPolicy:
-      whenDeleted: Delete  # Different policy for topo server
-      whenScaled: Retain
-
-  databases:
-    - name: postgres
-      tableGroups:
-        - name: default
-          # Override for this specific TableGroup
-          pvcDeletionPolicy:
-            whenDeleted: Retain
-            whenScaled: Retain
-          shards:
-            - name: "0-inf"
-              # Override for this specific shard
-              spec:
-                pvcDeletionPolicy:
-                  whenDeleted: Delete
-```
-
-The policy is merged hierarchically:
-1. **Shard-level** policy (most specific)
-2. **TableGroup-level** policy
-3. **Cluster-level** policy
-4. **Template defaults** (CoreTemplate, ShardTemplate)
-5. **Operator defaults** (Retain/Retain)
-
-**Note**: If a child policy specifies only `whenDeleted`, it will inherit `whenScaled` from its parent, and vice versa.
-
-#### Templates and PVC Policy
-
-You can define PVC policies in templates for reuse:
-
-```yaml
-apiVersion: multigres.com/v1alpha1
-kind: ShardTemplate
-metadata:
-  name: production-shard
-spec:
-  pvcDeletionPolicy:
-    whenDeleted: Retain
-    whenScaled: Retain
-  # ... other shard config
----
-apiVersion: multigres.com/v1alpha1
-kind: CoreTemplate
-metadata:
-  name: ephemeral-topo
-spec:
-  globalTopoServer:
-    pvcDeletionPolicy:
-      whenDeleted: Delete
-      whenScaled: Delete
-```
-
-#### Important Caveats
-
-⚠️ **Data Loss Risk**: Setting `whenDeleted: Delete` means **permanent data loss** when the cluster is deleted. Use this only for:
-- Development/testing environments
-- Ephemeral clusters
-- Scenarios where data is backed up externally
-
-⚠️ **Replica Scale-Down Behavior**: Setting `whenScaled: Delete` will **immediately delete PVCs** when the operator removes pods during scale-down. If you scale the replica count back up, new pods will start with **empty volumes** and will need to restore from backup. This is useful for:
-- Reducing storage costs in non-production environments
-- Stateless-like workloads where data is ephemeral
-
-**Note**: This does NOT affect storage size. Changing PVC storage capacity is handled separately by the operator's **PVC Volume Expansion** feature (see below).
-
-✅ **Production Recommendation**: For production clusters, use the default `Retain/Retain` policy and implement proper backup/restore procedures.
-
-### 5. PVC Volume Expansion
-
-The operator supports **in-place PVC volume expansion**. When you increase `storage.size` on a pool (or backup filesystem storage), the operator patches the existing PVC spec and Kubernetes handles the underlying volume expansion.
-
-```yaml
-spec:
-  databases:
-    - name: postgres
-      tableGroups:
-        - name: default
-          shards:
-            - name: "0-inf"
-              spec:
-                pools:
-                  main-app:
-                    storage:
-                      size: "200Gi"  # ← Increase from 100Gi to 200Gi
-```
-
-**Requirements:**
-- The `StorageClass` must have `allowVolumeExpansion: true`
-- Volume expansion is **grow-only** — decreasing `storage.size` is rejected at admission
-
-**Behavior:**
-- Most modern CSI drivers (EBS CSI ≥ v1.5, GCE PD CSI) expand the filesystem **online without pod restart**
-- For drivers that require restart, the operator detects the `FileSystemResizePending` PVC condition and drains the affected pod automatically
-
-> [!IMPORTANT]
-> If your `StorageClass` does not have `allowVolumeExpansion: true`, the Kubernetes API will reject the PVC update and the operator will emit a warning event. Check your StorageClass before changing storage sizes.
-
-
 ---
 
 ## Backup & Restore
@@ -384,7 +196,7 @@ The operator ships with built-in support for **metrics**, **alerting**, **distri
 - **Distributed Tracing** — OpenTelemetry OTLP support, disabled by default, zero overhead when off
 - **Structured Logging** — JSON logging with automatic `trace_id`/`span_id` injection for log-trace correlation
 
-📖 **Full documentation:** [Observability Guide](docs/observability.md) · [Observability Demo](demo/observability/demo.md)
+📖 **Full documentation:** [Observability Guide](docs/observability.md) · [Observability Demo](demo/observability/)
 
 ---
 
@@ -410,35 +222,7 @@ The operator **automatically detects** the certificate management strategy on st
 - If certificates already exist on disk and the operator did not previously manage them (no cert-strategy annotation), it assumes an external provider (e.g. cert-manager) and skips internal rotation.
 - If no certificates exist on disk, or the operator previously annotated the ValidatingWebhookConfiguration, internal certificate rotation is enabled.
 
----
-
-## Operator Flags
-
-You can customize the operator's behavior by passing flags to the binary (or editing the Deployment args).
-
-**Required Environment Variables:**
-
-The operator requires two environment variables to be set on the Deployment (these are pre-configured in the install manifests):
-
-| Variable | Description |
-| :--- | :--- |
-| `POD_NAMESPACE` | Namespace where the operator is deployed. Used for leader election, cert secrets, and cache filtering. |
-| `POD_SERVICE_ACCOUNT` | Service account name of the operator pod. Used for webhook configuration. |
-
-**Flags:**
-
-| Flag | Default | Description |
-| :--- | :--- | :--- |
-| `--webhook-enable` | `true` | Enable the admission webhook server. |
-| `--webhook-port` | `9443` | The port that the webhook server serves at. |
-| `--webhook-cert-dir` | `/var/run/secrets/webhook` | Directory to read/write webhook certificates. |
-| `--webhook-service-name` | `multigres-operator-webhook-service` | Name of the Service pointing to the webhook. |
-| `--webhook-service-namespace`| `$POD_NAMESPACE` | Namespace of the webhook service. |
-| `--webhook-service-account` | `$POD_SERVICE_ACCOUNT` | Service Account name of the operator. |
-| `--metrics-bind-address` | `:8443` | Address for the metrics endpoint. Set to `0` to disable. |
-| `--metrics-secure` | `true` | Serve metrics over HTTPS with authentication and authorization. |
-| `--enable-http2` | `false` | Enable HTTP/2 for metrics and webhook servers. |
-| `--leader-elect` | `false` | Enable leader election (recommended for HA deployments). |
+📖 **Cert-Manager walkthrough:** [Cert-Manager Demo](demo/cert-manager/)
 
 ---
 
@@ -469,3 +253,16 @@ Please be aware of the following constraints in the current version:
     *   **Cluster Name**: Recommended to be under **20 characters** to ensure that even with hashing, suffixes fit comfortably.
 *   **Immutable Fields**: Some fields like `zone` and `region` in Cell definitions are immutable after creation.
 *   **Append-Only Pools and Cells**: Pools and cells cannot be renamed or removed from a cluster. This prevents orphaned pods and stale etcd registrations.
+
+---
+
+## Further Reading
+
+| Resource | Description |
+| :--- | :--- |
+| [Storage Management](docs/storage.md) | PVC deletion policies (Retain/Delete) and volume expansion |
+| [Configuration Reference](docs/configuration.md) | Operator flags, environment variables, and logging |
+| [Demos](demo/) | Guided walkthroughs (webhook, cert-manager, observability) |
+| [Developer Documentation](docs/development/) | Internal architecture, controller patterns, caching strategy |
+| [Contributing](CONTRIBUTING.md) | Development setup, local Kind deployment, code style |
+| [Changelog](CHANGELOG.md) | Release history |

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,11 @@
+# Demos
+
+Guided walkthroughs demonstrating specific user journeys and integration scenarios for the Multigres Operator.
+
+| Demo | Description |
+|:---|:---|
+| [Webhook & Admission Control](webhook/demo.md) | Hybrid admission architecture — mutating/validating webhooks, template resolution, safety gates, and resilient fallback mode. |
+| [Cert-Manager Integration](cert-manager/) | Deploying the operator with cert-manager for external certificate management. |
+| [Observability Stack](observability/) | Full observability setup with Prometheus, Grafana, Tempo, and OpenTelemetry Collector. |
+
+Each demo is self-contained with prerequisites, step-by-step instructions, and expected output.

--- a/demo/cert-manager/README.md
+++ b/demo/cert-manager/README.md
@@ -1,0 +1,66 @@
+# Cert-Manager Integration Demo
+
+This demo shows how to deploy the Multigres Operator with [cert-manager](https://cert-manager.io/) for external certificate management instead of the operator's built-in self-signed certificates.
+
+## When to Use This
+
+By default, the operator manages its own TLS certificates automatically (see [Webhook & Certificate Management](../../README.md#webhook--certificate-management)). Use cert-manager when:
+
+- Your organization requires centralized certificate management
+- You need certificates signed by a specific CA
+- You want cert-manager to handle certificate rotation
+
+## Prerequisites
+
+- A running Kubernetes cluster (or Kind for local testing)
+- `kubectl` installed
+
+## Steps
+
+### 1. Install cert-manager
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
+```
+
+### 2. Install the operator with the cert-manager overlay
+
+```bash
+kubectl apply --server-side -f \
+  https://github.com/numtide/multigres-operator/releases/latest/download/install-certmanager.yaml
+```
+
+This overlay:
+1. Creates a `Certificate` and `ClusterIssuer` resource for cert-manager to manage.
+2. Mounts the cert-manager-provisioned secret to `/var/run/secrets/webhook` so certificates exist on disk at startup.
+
+### 3. Verify external certificate mode
+
+```bash
+kubectl logs -n multigres-operator deployment/multigres-operator-controller-manager | grep "webhook certificates"
+```
+
+**Expected output:**
+```
+webhook certificates found on disk; using external certificate management
+```
+
+The operator automatically detected that certificates were already present on disk and skipped internal rotation.
+
+### Local Development (Kind)
+
+For local testing with Kind:
+
+```bash
+make kind-deploy-certmanager
+kubectl wait --for=condition=Available deployment/multigres-operator-controller-manager -n multigres-operator --timeout=180s
+```
+
+## How It Works
+
+The operator **automatically detects** the certificate management strategy on startup:
+- If certificates already exist on disk and the operator did not previously manage them (no cert-strategy annotation), it assumes an external provider (e.g. cert-manager) and skips internal rotation.
+- If no certificates exist on disk, or the operator previously annotated the ValidatingWebhookConfiguration, internal certificate rotation is enabled.
+
+No flags or manual configuration are needed — the detection is fully automatic.

--- a/demo/observability/README.md
+++ b/demo/observability/README.md
@@ -1,0 +1,67 @@
+# Observability Stack Demo
+
+This demo deploys the Multigres Operator alongside a full observability stack for metrics, distributed tracing, and dashboards.
+
+## What Gets Deployed
+
+| Component | Purpose |
+|:---|:---|
+| **Prometheus** (via Prometheus Operator) | Scrapes operator metrics, stores time-series data |
+| **OpenTelemetry Collector** | Receives OTLP signals from multigres data-plane, routes traces → Tempo and metrics → Prometheus |
+| **Tempo** | Distributed trace storage and querying |
+| **Grafana** | Pre-provisioned dashboards and datasources (Prometheus + Tempo) |
+
+> [!NOTE]
+> These are single-replica deployments with sane defaults intended for **evaluation and development**. They do not include HA, persistent storage, or authentication. For production observability, integrate the operator's metrics and traces with your existing monitoring infrastructure.
+
+## Prerequisites
+
+- A running Kubernetes cluster (or Kind for local testing)
+- `kubectl` installed
+
+## Steps
+
+### 1. Install the Prometheus Operator
+
+```bash
+kubectl apply --server-side -f \
+  https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.80.0/bundle.yaml
+kubectl wait --for=condition=Available deployment/prometheus-operator -n default --timeout=120s
+```
+
+### 2. Install the operator with the observability overlay
+
+```bash
+kubectl apply --server-side -f \
+  https://github.com/numtide/multigres-operator/releases/latest/download/install-observability.yaml
+```
+
+### 3. Access the dashboards
+
+Port-forward the observability services:
+
+| Service | URL |
+| :--- | :--- |
+| Grafana | [http://localhost:3000](http://localhost:3000) |
+| Prometheus | [http://localhost:9090](http://localhost:9090) |
+| Tempo | [http://localhost:3200](http://localhost:3200) |
+
+### Local Development (Kind)
+
+For local testing with Kind, use the convenience targets:
+
+```bash
+make kind-deploy-observability
+make kind-portforward
+```
+
+This deploys the operator with tracing enabled and opens port-forwards to all services above.
+
+## Hands-on Tutorial
+
+For a detailed walkthrough including Grafana exploration, trace analysis, and alert verification, see the [full observability demo](demo.md).
+
+## Further Reading
+
+- [Observability Guide](../../docs/observability.md) — metrics, tracing, alerts, and logging reference
+- [Configuration Reference](../../docs/configuration.md) — operator flags including `OTEL_EXPORTER_OTLP_ENDPOINT`

--- a/demo/webhook/demo.md
+++ b/demo/webhook/demo.md
@@ -1,0 +1,467 @@
+# Multigres Operator: Hybrid Admission Control Demo
+
+This document demonstrates the **Hybrid Architecture** of the Multigres Operator. It highlights how the operator balances user experience, safety, and operational resiliency through a design that utilizes both a Kubernetes Webhook and an internal logic resolver.
+
+## Overview: Two Modes of Operation
+
+The Multigres Operator implements a **Shared Resolver** pattern. This logic is shared between the API Server (via Webhook) and the Controller (via Reconciliation Loop), providing two distinct modes:
+
+1.  **Robust Mode (Normal Operation)**: A Mutating Webhook intercepts requests to "hydrate" configurations before they are stored in etcd. This ensures users see the full, realized state of their cluster (**"Visible Defaults"**) and protects critical resources via Validating Webhooks. Certificates are auto-generated ("Self-Bootstrap") unless a user provides them.
+2.  **Resilient Mode (No Webhook)**: If the webhook service is unavailable or disabled, the Controller falls back to applying defaults in-memory. This ensures the operator remains functional (**"Invisible Defaults"**) even if admission control is bypassed, though "Fast Fail" validations are lost.
+
+## 🛠️ Prerequisites
+
+The Operator's `Makefile` handles most project-specific dependencies (Kustomize, Controller-Gen), but you must have the base runtime installed on your machine.
+
+**System Requirements:**
+
+1.  **Go (1.23+)**: Required to compile the operator.
+2.  **Docker (or Podman)**: Required to build container images.
+3.  **Kind**: Required to create the local Kubernetes cluster.
+4.  **Kubectl**: Required to interact with the cluster.
+5.  **Make**: Required to run the build scripts.
+
+*Note: The demo commands below will fail immediately if these tools are not found in your `$PATH`.*
+
+** Setup (Go Workspace)**:
+If you have issues building you may need to setup your go workspace:
+
+```bash
+go work init
+go work use -r .
+```
+
+You may also need to need to run this at the root of the project for the `kubectl` commands to work:
+
+```bash
+export KUBECONFIG=$KUBECONFIG:$(pwd)/kubeconfig.yaml
+```
+---
+
+## 🏗️ Scenario 1: Webhook Enabled (Internal Mode)
+
+**Objective:** Demonstrate the "Zero Config" experience where the operator sets up its own secure webhook infrastructure and hydrates configurations.
+
+### 1. Deploy the Operator
+
+We deploy the operator using the standard target. This builds the image, loads it into Kind, and applies the manifests.
+
+```bash
+make kind-deploy
+kubectl wait --for=condition=Available deployment/multigres-operator-controller-manager -n multigres-operator --timeout=120s
+```
+
+### 2. Verify Internal Cert Mode
+
+The operator automatically detects that no certificates were provided and enters **"Self-Bootstrap"** mode.
+
+```bash
+kubectl logs -n multigres-operator deployment/multigres-operator-controller-manager | grep "webhook certificates"
+```
+
+**Output:**
+`webhook certificates not found on disk; enabling internal certificate rotation`
+
+### 3. Inspect the Self-Signed Certificate
+
+Since we are in Internal Mode, the operator generated its own CA and server certificate.
+
+```bash
+kubectl get secret multigres-webhook-certs -n multigres-operator -o yaml
+```
+
+### 4. Apply a Minimal Configuration
+
+We apply a cluster definition consisting of only a single Cell.
+
+```bash
+kubectl apply -f config/samples/minimal.yaml
+```
+
+### 4. Inspect the Result (Visible Defaults)
+
+The Mutating Webhook intercepts the request and uses the Shared Resolver to populate the spec *before* it is persisted.
+
+```bash
+kubectl get multigrescluster minimal -o yaml
+```
+
+**Output:**
+
+```yaml
+spec:
+  cells:
+  - name: zone-a
+    spec:
+      multigateway:
+        replicas: 1
+        resources:         # <--- Fully Materialized Resources
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+    zone: us-east-1a
+  databases:
+  - default: true          # <--- System Catalog Created
+    name: postgres
+    tablegroups:
+    - default: true
+      name: default
+      shards:
+      - name: "0"
+        spec:
+          pools:
+            default:
+              postgres:
+                resources: # <--- Deep Defaults Applied
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+              type: readWrite
+  images:                  # <--- Pinned Versions Injected
+    postgres: postgres:15-alpine
+```
+
+---
+
+## 🚀 Scenario 2: Explicit Templates & Safety Gates
+
+**Objective:** Demonstrate Template Resolution and the **"Fast Fail"** protection provided by the Validating Webhook.
+
+### 1. Install Standard Templates
+
+We install reusable Templates defining a high-availability topology.
+
+```bash
+kubectl apply -f config/samples/templates/
+```
+
+### 2. Apply a Templated Cluster
+
+We apply a cluster that explicitly references these templates.
+
+```bash
+kubectl apply -f config/samples/templated-cluster.yaml
+```
+
+### 3. Verify Resolution
+
+Check that the cluster inherited values from the templates.
+
+```bash
+kubectl get multigrescluster standard-ha-cluster -o yaml
+```
+
+**Output:**
+
+```yaml
+spec:
+  cells:
+  - name: us-east-1a
+    zone: us-east-1a
+  databases:
+  - default: true
+    name: postgres
+    tablegroups:
+    - default: true
+      name: default
+      shards:
+      - name: "0"
+        overrides:
+          pools:
+            main-app:        # <--- Inherited from 'standard-shard' Template
+              cells:
+              - us-east-1a
+              - us-east-1b
+              replicasPerCell: 2 # <--- Overrides default (1)
+  templateDefaults:
+    cellTemplate: standard-cell
+    coreTemplate: standard-core
+    shardTemplate: standard-shard
+```
+
+> Note: The template details are NOT resolved by the webhook, they are only used as a reference for the cluster's configuration. The reason for this is that the webhook is not aware of the templates and cannot resolve them. If it it would create issues too. For example, if a user were to add their own inline spec configuration to the template, it would be difficult to differentiate what's a template and what's a cluster spec.
+
+### 4. Test: Safety Gate (Referential Integrity)
+
+Now that the cluster exists and relies on the templates, we verify that the webhook prevents accidental deletion.
+
+```bash
+kubectl delete celltemplate standard-cell
+```
+
+**Output:**
+The webhook blocks the deletion.
+
+```text
+Error from server (Forbidden): admission webhook "vcelltemplate.kb.io" denied the request:
+cannot delete CellTemplate 'standard-cell' because it is in use by MultigresCluster 'standard-ha-cluster'
+```
+
+---
+
+## 🪄 Scenario 3: Implicit Defaults
+
+**Objective:** Demonstrate the system's "Magic" default resolution. If a user does NOT specify a template, but a template named `default` exists, the system automatically adopts it.
+
+### 1. Install Default Templates
+
+We create templates specifically named `default`.
+
+```bash
+kubectl apply -f config/samples/default-templates
+```
+
+### 2. Apply Minimal Cluster (Again)
+
+We apply the `minimal.yaml` again (or a new one). It has **NO** template references.
+
+```bash
+kubectl apply -f config/samples/minimal.yaml
+```
+
+### 3. Inspect the Magic
+
+```bash
+kubectl get multigrescluster minimal -o yaml
+```
+
+**Output:**
+
+```yaml
+spec:
+  templateDefaults:          # <--- Automatically Populated!
+    cellTemplate: default
+    coreTemplate: default
+    shardTemplate: default
+```
+>NOTE: You will notice that the pools in the cluster did not change. That's because the webhook will not modify any spec that is already defined and populated in the multigrescluster spec. This is for safety and to prevent any unexpected changes to the cluster.
+
+---
+
+## 🔧 Scenario 4: Deep Overrides
+
+**Objective:** Demonstrate how precise overrides can be applied on top of templates.
+
+### 1. Apply Overrides Configuration
+
+We apply a cluster that uses the `standard-ha` templates but overrides specific parameters (e.g., storage size, replicas) for a single shard or pool.
+
+```bash
+kubectl apply -f config/samples/overrides.yaml
+```
+
+### 2. Inspect the Result
+
+```bash
+kubectl get multigrescluster overrides-cluster -o yaml
+```
+
+**Output:**
+
+```yaml
+spec:
+  cells:
+  - name: zone-a
+    overrides:
+      multigateway:
+        replicas: 3          # <--- Specific Override
+    zone: us-east-1a
+  databases:
+  - default: true
+    name: postgres
+    tablegroups:
+    - default: true
+      name: default
+      shards:
+      - name: "0"
+        overrides:
+          pools:
+            analytics:       # <--- Deep Override (Specific Pool)
+              replicasPerCell: 1
+              storage:
+                size: 50Gi   # <--- Override Storage
+              type: readOnly
+            main-app:
+              storage:
+                size: 200Gi  # <--- Override Storage
+```
+
+---
+
+
+## 🏭 Scenario 5: Production Mode (Cert-Manager Integration)
+
+**Objective:** Demonstrate how to use **Cert-Manager** for certificate management.
+
+### 1. Architecture
+
+To switch to External Mode using Cert-Manager, we utilize a Kustomize overlay (`config/deploy-certmanager`). The Operator detects the mounted Secret and automatically disables its internal CA.
+
+### 2. Deploy with Cert-Manager
+
+We use a convenience make target that installs Cert-Manager and deploys the operator with the overlay enabled.
+
+```bash
+make kind-down
+make kind-deploy-certmanager
+kubectl wait --for=condition=Available deployment/multigres-operator-controller-manager -n multigres-operator --timeout=180s
+```
+
+### 3. Verify External Mode
+
+Check the logs to confirm the operator detected the certificates provided by Cert-Manager.
+
+```bash
+kubectl logs -n multigres-operator deployment/multigres-operator-controller-manager | grep "webhook certificates"
+```
+
+**Output:**
+`webhook certificates found on disk; using external certificate management`
+
+### 4. Inspect the Managed Certificate
+
+Cert-Manager has issued a certificate and stored it in a Secret, which the operator is now using.
+
+```bash
+kubectl get secret webhook-server-cert -n multigres-operator -o yaml
+```
+
+---
+
+## 🛡️ Scenario 6: Webhook Disabled (Resilient Fallback)
+
+**Objective:** Demonstrate operational continuity when the Webhook is disabled. Unlike "Strict" operators that fail completely, Multigres falls back to "Invisible Defaults," but loses the "Fast Fail" protections.
+
+> NOTE: running the operator without a webhook may be useful for testing but it is not recommended for production. In fact, given that the webhook has the ability to generate its own certificates seamlessly and we run local tests in kind, we may not even need this at all. The use of the resolver makes it possible to have a fallback to invisible defaults rather seamless.
+
+### 1. Deploy without Webhook
+
+We deploy the operator with the webhook explicitly disabled.
+
+```bash
+make kind-down
+make kind-deploy-no-webhook
+```
+
+### 2. Apply the Minimal Cluster
+
+We apply the exact same minimal YAML from Scenario 1.
+
+```bash
+kubectl apply -f config/samples/minimal.yaml
+```
+
+### 3. Inspect the Object (Invisible Defaults)
+
+Because the webhook is bypassed, the object is stored "as-is" in `etcd`.
+
+```bash
+kubectl get multigrescluster minimal -o yaml
+```
+
+**Output:**
+
+```yaml
+spec:
+  cells:
+  - name: zone-a
+    zone: us-east-1a
+  images: {}                 # <--- Empty! No Defaults Injected
+  templateDefaults: {}
+```
+
+### 4. The Resiliency Payoff
+
+Despite the sparse spec, the **Controller** successfully creates the child resources using in-memory defaults.
+
+```bash
+kubectl get cells,tablegroups -l multigres.com/cluster=minimal
+```
+
+**Output:**
+
+```text
+NAME                                        GATEWAY   READY
+cell.multigres.com/minimal-zone-a   0
+
+NAME                                                        SHARDS
+tablegroup.multigres.com/minimal-postgres-default   0
+```
+
+### 5. Test: Missing Protection
+
+To verify the lack of safety gates, we first set up a scenario where a template is explicitly in use.
+
+```bash
+kubectl apply -f config/samples/templates/
+kubectl apply -f config/samples/templated-cluster.yaml
+```
+
+Now we attempt to delete the template that the cluster relies on.
+
+```bash
+kubectl delete celltemplate standard-cell
+```
+
+**Output:** The deletion **Succeeds**. Without the validating webhook, the safety gate is gone. This is the trade-off for running in Resilient Mode.
+
+---
+
+## 🧠 Internal Architecture
+
+How does the operator achieve this hybrid behavior?
+
+### 1. The Shared Resolver Pattern
+
+Logic is centralized in `pkg/resolver`. Both the Webhook (for mutation) and the Controller (for reconciliation) call this same code.
+
+```go
+// pkg/resolver/resolver.go
+type Resolver struct {
+    Client client.Client
+    // ...
+}
+
+func (r *Resolver) PopulateClusterDefaults(ctx context.Context, cluster *MultigresCluster) error {
+    // 1. apply static defaults (images, etc)
+}
+
+func (r *Resolver) Resolve(ctx context.Context, cluster *MultigresCluster) (*ResolvedCluster, error) {
+    // 1. Load Templates (Core, Cell, Shard)
+    // 2. Initialise Defaults
+    // 3. Apply Overrides (Deep Merge)
+    // 4. Return fully hydrated configuration
+}
+```
+
+### 2. Webhook: The "Visible" Layer
+
+The Webhook (`pkg/webhook/handlers/defaulter.go`) calls `Resolve` and writes the result back to the object.
+
+1.  **Static Defaulting**: Sets images, system catalog.
+2.  **Implicit Promotion**: If `coreTemplate` is empty but `default` exists, it sets `coreTemplate: "default"`.
+3.  **Expansion**: Resolves all deep references logic context.
+
+### 3. Controller: The "Resilient" Layer
+
+The Controller (`pkg/cluster-handler/controller`) is the ultimate source of truth.
+
+```go
+// pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+func (r *MultigresClusterReconciler) Reconcile(...) {
+    // 1. Create Resolver
+    res := resolver.NewResolver(...)
+
+    // 2. Populate Defaults (In-Memory)
+    // Even if Webhook failed or didn't run, we ensure defaults are set here.
+    res.PopulateClusterDefaults(ctx, cluster)
+
+    // 3. Resolve & Reconcile
+    // We proceed to create child resources based on the fully resolved state.
+    // This allows the system to work even if the Spec stored in etcd is "sparse".
+}
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,22 @@
 
 | Document | Description |
 |:---|:---|
-| [README](../README.md) | Installation, configuration, resource hierarchy, PVC policies, and constraints |
+| [README](../README.md) | Installation, configuration, resource hierarchy, and constraints |
 | [Backup & Restore](backup-restore.md) | pgBackRest integration, S3 and filesystem backends, TLS certificates |
 | [Observability](observability.md) | Metrics, alerts, dashboards, distributed tracing, structured logging |
-| [Observability Demo](../demo/observability/demo.md) | Hands-on tutorial for the full observability stack |
+| [Storage Management](storage.md) | PVC deletion policies and volume expansion |
+| [Configuration Reference](configuration.md) | Operator flags, environment variables, and logging |
 | [Sample Configurations](../config/samples/README.md) | YAML examples with override hierarchy walkthrough |
+
+## Demos
+
+Guided walkthroughs for specific user journeys: [demo/](../demo/)
+
+| Demo | Description |
+|:---|:---|
+| [Webhook & Admission Control](../demo/webhook/demo.md) | Hybrid admission architecture, template resolution, safety gates |
+| [Cert-Manager Integration](../demo/cert-manager/) | External certificate management with cert-manager |
+| [Observability Stack](../demo/observability/) | Full metrics, tracing, and dashboards setup |
 
 ## Operations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,47 @@
+# Operator Configuration
+
+## Required Environment Variables
+
+The operator requires two environment variables to be set on the Deployment (these are pre-configured in the install manifests):
+
+| Variable | Description |
+| :--- | :--- |
+| `POD_NAMESPACE` | Namespace where the operator is deployed. Used for leader election, cert secrets, and cache filtering. |
+| `POD_SERVICE_ACCOUNT` | Service account name of the operator pod. Used for webhook configuration. |
+
+## Flags
+
+You can customize the operator's behavior by passing flags to the binary (or editing the Deployment args).
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--webhook-enable` | `true` | Enable the admission webhook server. |
+| `--webhook-port` | `9443` | The port that the webhook server serves at. |
+| `--webhook-cert-dir` | `/var/run/secrets/webhook` | Directory to read/write webhook certificates. |
+| `--webhook-service-name` | `multigres-operator-webhook-service` | Name of the Service pointing to the webhook. |
+| `--webhook-service-namespace`| `$POD_NAMESPACE` | Namespace of the webhook service. |
+| `--webhook-service-account` | `$POD_SERVICE_ACCOUNT` | Service Account name of the operator. |
+| `--metrics-bind-address` | `:8443` | Address for the metrics endpoint. Set to `0` to disable. |
+| `--metrics-secure` | `true` | Serve metrics over HTTPS with authentication and authorization. |
+| `--enable-http2` | `false` | Enable HTTP/2 for metrics and webhook servers. |
+| `--leader-elect` | `false` | Enable leader election (recommended for HA deployments). |
+
+## Logging
+
+The operator uses structured JSON logging (`zap` via controller-runtime). When tracing is enabled, every log line within a traced operation automatically includes `trace_id` and `span_id` fields.
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `--zap-devel` | `true` | Development mode preset (console encoder, debug level, warn stacktraces). |
+| `--zap-log-level` | depends on mode | Log verbosity: `debug`, `info`, `error`, or an integer. |
+| `--zap-encoder` | depends on mode | Log format: `console` or `json`. |
+| `--zap-stacktrace-level` | depends on mode | Minimum level that triggers stacktraces. |
+
+| Setting | `--zap-devel=true` (default) | `--zap-devel=false` (production) |
+| :--- | :--- | :--- |
+| Default log level | `debug` | `info` |
+| Encoder | `console` (human-readable) | `json` |
+| Stacktraces from | `warn` | `error` |
+
+> [!NOTE]
+> For production deployments, set `--zap-devel=false` to switch to JSON encoding and `info`-level logging.

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,144 @@
+# Storage Management
+
+## PVC Deletion Policy
+
+The operator supports fine-grained control over **Persistent Volume Claim (PVC) lifecycle management** for stateful components (TopoServers and Shard Pools). This allows you to decide whether PVCs should be automatically deleted or retained when resources are deleted or scaled down.
+
+### Policy Options
+
+The `pvcDeletionPolicy` field has two settings:
+
+- **`whenDeleted`**: Controls what happens to PVCs when the entire MultigresCluster (or a component like a TopoServer) is deleted.
+  - `Retain` (default): PVCs are preserved for manual review and potential data recovery
+  - `Delete`: PVCs are automatically deleted along with the cluster
+
+- **`whenScaled`**: Controls what happens to PVCs when reducing the number of replicas (e.g., scaling from 3 pods down to 1 pod).
+  - `Retain` (default): PVCs from scaled-down pods are kept for potential scale-up
+  - `Delete`: PVCs are automatically deleted when pods are removed
+
+### Safe Defaults
+
+**By default, the operator uses `Retain/Retain`** for maximum data safety. This means:
+- Deleting a cluster will **not** delete your data volumes
+- Scaling down will **not** delete the PVCs from removed pods
+
+This is a deliberate choice to prevent accidental data loss.
+
+### Where to Set the Policy
+
+The `pvcDeletionPolicy` can be set at multiple levels in the hierarchy, with more specific settings overriding general ones:
+
+```yaml
+apiVersion: multigres.com/v1alpha1
+kind: MultigresCluster
+metadata:
+  name: my-cluster
+spec:
+  # Cluster-level policy (applies to all components unless overridden)
+  pvcDeletionPolicy:
+    whenDeleted: Retain  # Safe: keep data when cluster is deleted
+    whenScaled: Delete   # Aggressive: auto-cleanup when scaling down
+
+  globalTopoServer:
+    # Override for GlobalTopoServer specifically
+    pvcDeletionPolicy:
+      whenDeleted: Delete  # Different policy for topo server
+      whenScaled: Retain
+
+  databases:
+    - name: postgres
+      tableGroups:
+        - name: default
+          # Override for this specific TableGroup
+          pvcDeletionPolicy:
+            whenDeleted: Retain
+            whenScaled: Retain
+          shards:
+            - name: "0-inf"
+              # Override for this specific shard
+              spec:
+                pvcDeletionPolicy:
+                  whenDeleted: Delete
+```
+
+The policy is merged hierarchically:
+1. **Shard-level** policy (most specific)
+2. **TableGroup-level** policy
+3. **Cluster-level** policy
+4. **Template defaults** (CoreTemplate, ShardTemplate)
+5. **Operator defaults** (Retain/Retain)
+
+**Note**: If a child policy specifies only `whenDeleted`, it will inherit `whenScaled` from its parent, and vice versa.
+
+### Templates and PVC Policy
+
+You can define PVC policies in templates for reuse:
+
+```yaml
+apiVersion: multigres.com/v1alpha1
+kind: ShardTemplate
+metadata:
+  name: production-shard
+spec:
+  pvcDeletionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  # ... other shard config
+---
+apiVersion: multigres.com/v1alpha1
+kind: CoreTemplate
+metadata:
+  name: ephemeral-topo
+spec:
+  globalTopoServer:
+    pvcDeletionPolicy:
+      whenDeleted: Delete
+      whenScaled: Delete
+```
+
+### Important Caveats
+
+⚠️ **Data Loss Risk**: Setting `whenDeleted: Delete` means **permanent data loss** when the cluster is deleted. Use this only for:
+- Development/testing environments
+- Ephemeral clusters
+- Scenarios where data is backed up externally
+
+⚠️ **Replica Scale-Down Behavior**: Setting `whenScaled: Delete` will **immediately delete PVCs** when the operator removes pods during scale-down. If you scale the replica count back up, new pods will start with **empty volumes** and will need to restore from backup. This is useful for:
+- Reducing storage costs in non-production environments
+- Stateless-like workloads where data is ephemeral
+
+**Note**: This does NOT affect storage size. Changing PVC storage capacity is handled separately by the **PVC Volume Expansion** feature (see below).
+
+✅ **Production Recommendation**: For production clusters, use the default `Retain/Retain` policy and implement proper backup/restore procedures.
+
+---
+
+## PVC Volume Expansion
+
+The operator supports **in-place PVC volume expansion**. When you increase `storage.size` on a pool (or backup filesystem storage), the operator patches the existing PVC spec and Kubernetes handles the underlying volume expansion.
+
+```yaml
+spec:
+  databases:
+    - name: postgres
+      tableGroups:
+        - name: default
+          shards:
+            - name: "0-inf"
+              spec:
+                pools:
+                  main-app:
+                    storage:
+                      size: "200Gi"  # ← Increase from 100Gi to 200Gi
+```
+
+**Requirements:**
+- The `StorageClass` must have `allowVolumeExpansion: true`
+- Volume expansion is **grow-only** — decreasing `storage.size` is rejected at admission
+
+**Behavior:**
+- Most modern CSI drivers (EBS CSI ≥ v1.5, GCE PD CSI) expand the filesystem **online without pod restart**
+- For drivers that require restart, the operator detects the `FileSystemResizePending` PVC condition and drains the affected pod automatically
+
+> [!IMPORTANT]
+> If your `StorageClass` does not have `allowVolumeExpansion: true`, the Kubernetes API will reject the PVC update and the operator will emit a warning event. Check your StorageClass before changing storage sizes.


### PR DESCRIPTION
The README was 472 lines with detailed operational sections (cert-manager install, observability stack, PVC policies, operator flags, Kind targets) that overwhelmed users trying to get started.

- Reduce README.md from 472 to 268 lines, keeping only core concepts: install, resource hierarchy, config/defaults, templates, webhook/cert management, pool replication, and constraints
- Create docs/storage.md for PVC deletion policy and volume expansion
- Create docs/configuration.md for operator flags, env vars, and logging
- Create demo/README.md as entry point for guided walkthroughs
- Create demo/cert-manager/README.md with cert-manager install steps
- Create demo/observability/README.md with observability stack install steps
- Add demo/webhook/demo.md for hybrid admission control demo
- Merge Kind deployment targets table into CONTRIBUTING.md
- Update docs/README.md hub with links to all new documents

README is now focused on getting started and overall understanding, with detailed operational docs discoverable through a Further Reading section.