### PR TITLE
refactor(webhook): materialize topology defaults in spec

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/integration_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_test.go
@@ -248,6 +248,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						Etcd: &multigresv1alpha1.EtcdSpec{
 							Image:     "etcd:latest",
 							Replicas:  ptr.To(resolver.DefaultEtcdReplicas),
+							RootPath:  resolver.DefaultTopoRootPath,
 							Storage:   multigresv1alpha1.StorageSpec{Size: resolver.DefaultEtcdStorageSize},
 							Resources: resolver.DefaultResourcesEtcd(),
 						},
@@ -542,6 +543,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						Etcd: &multigresv1alpha1.EtcdSpec{
 							Image:     "etcd:default",
 							Replicas:  ptr.To(resolver.DefaultEtcdReplicas),
+							RootPath:  resolver.DefaultTopoRootPath,
 							Storage:   multigresv1alpha1.StorageSpec{Size: resolver.DefaultEtcdStorageSize},
 							Resources: resolver.DefaultResourcesEtcd(),
 						},
@@ -831,6 +833,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						Etcd: &multigresv1alpha1.EtcdSpec{
 							Image:     "etcd:default",
 							Replicas:  ptr.To(resolver.DefaultEtcdReplicas),
+							RootPath:  resolver.DefaultTopoRootPath,
 							Storage:   multigresv1alpha1.StorageSpec{Size: resolver.DefaultEtcdStorageSize},
 							Resources: resolver.DefaultResourcesEtcd(),
 						},

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global.go
@@ -158,17 +158,15 @@ func (r *MultigresClusterReconciler) getGlobalTopoRef(
 		address = string(spec.External.Endpoints[0])
 	}
 
-	rootPath := "/multigres/global"
-	if spec.External != nil && spec.External.RootPath != "" {
-		rootPath = spec.External.RootPath
-	}
-	if spec.Etcd != nil && spec.Etcd.RootPath != "" {
-		rootPath = spec.Etcd.RootPath
-	}
+	rootPath := ""
+	implementation := ""
 
-	implementation := "etcd"
-	if spec.External != nil && spec.External.Implementation != "" {
+	if spec.External != nil {
+		rootPath = spec.External.RootPath
 		implementation = spec.External.Implementation
+	} else if spec.Etcd != nil {
+		rootPath = spec.Etcd.RootPath
+		implementation = "etcd"
 	}
 
 	return multigresv1alpha1.GlobalTopoServerRef{

--- a/pkg/resolver/cell.go
+++ b/pkg/resolver/cell.go
@@ -30,8 +30,14 @@ func (r *Resolver) ResolveCell(
 	defaultStatelessSpec(gateway, DefaultResourcesGateway(), 1)
 
 	// Note: We do NOT default LocalTopo here because it is optional.
-	if localTopo != nil && localTopo.Etcd != nil {
-		defaultEtcdSpec(localTopo.Etcd)
+	if localTopo != nil {
+		defaultRootPath := fmt.Sprintf("/multigres/%s", cellSpec.Name)
+		if localTopo.Etcd != nil {
+			defaultEtcdSpec(localTopo.Etcd, defaultRootPath)
+		}
+		if localTopo.External != nil {
+			defaultExternalTopoSpec(localTopo.External, defaultRootPath)
+		}
 	}
 
 	return gateway, localTopo, nil

--- a/pkg/resolver/cell_test.go
+++ b/pkg/resolver/cell_test.go
@@ -45,6 +45,7 @@ func TestResolver_ResolveCell(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     "local-etcd-default",
 					Replicas:  ptr.To(DefaultEtcdReplicas),
+					RootPath:  "/multigres/",
 					Resources: DefaultResourcesEtcd(),
 					Storage:   multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 				},

--- a/pkg/resolver/cluster.go
+++ b/pkg/resolver/cluster.go
@@ -172,7 +172,10 @@ func (r *Resolver) ResolveGlobalTopo(
 	}
 
 	if finalSpec.Etcd != nil {
-		defaultEtcdSpec(finalSpec.Etcd)
+		defaultEtcdSpec(finalSpec.Etcd, DefaultTopoRootPath)
+	}
+	if finalSpec.External != nil {
+		defaultExternalTopoSpec(finalSpec.External, DefaultTopoRootPath)
 	}
 
 	// Merge GlobalTopoServerSpec-level PVCDeletionPolicy

--- a/pkg/resolver/cluster_test.go
+++ b/pkg/resolver/cluster_test.go
@@ -437,6 +437,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     "inline",
 					Replicas:  ptr.To(DefaultEtcdReplicas),
+					RootPath:  DefaultTopoRootPath,
 					Resources: DefaultResourcesEtcd(),
 					Storage:   multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 				},
@@ -455,6 +456,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     "core-default", // From fixture
 					Replicas:  ptr.To(DefaultEtcdReplicas),
+					RootPath:  DefaultTopoRootPath,
 					Resources: DefaultResourcesEtcd(),
 					Storage:   multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 				},
@@ -508,6 +510,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     "core-default",
 					Replicas:  ptr.To(DefaultEtcdReplicas),
+					RootPath:  DefaultTopoRootPath,
 					Resources: DefaultResourcesEtcd(),
 					Storage:   multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 				},
@@ -520,6 +523,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     DefaultEtcdImage,
 					Replicas:  ptr.To(DefaultEtcdReplicas),
+					RootPath:  DefaultTopoRootPath,
 					Resources: DefaultResourcesEtcd(),
 					Storage:   multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 				},
@@ -548,7 +552,9 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 			},
 			want: &multigresv1alpha1.GlobalTopoServerSpec{
 				External: &multigresv1alpha1.ExternalTopoServerSpec{
-					Endpoints: []multigresv1alpha1.EndpointUrl{"https://1.2.3.4:2379"},
+					Endpoints:      []multigresv1alpha1.EndpointUrl{"https://1.2.3.4:2379"},
+					Implementation: DefaultTopoImplementation,
+					RootPath:       DefaultTopoRootPath,
 				},
 				Etcd: nil, // Explicitly nilled out
 			},
@@ -575,6 +581,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     "core-image",
 					Replicas:  ptr.To(DefaultEtcdReplicas), // Defaults applied
+					RootPath:  DefaultTopoRootPath,
 					Resources: DefaultResourcesEtcd(),
 					Storage:   multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 				},
@@ -610,6 +617,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     "new-etcd",
 					Replicas:  ptr.To(DefaultEtcdReplicas),
+					RootPath:  DefaultTopoRootPath,
 					Resources: DefaultResourcesEtcd(),
 					Storage:   multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 				},
@@ -649,6 +657,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     "template-image",
 					Replicas:  ptr.To(DefaultEtcdReplicas),
+					RootPath:  DefaultTopoRootPath,
 					Resources: DefaultResourcesEtcd(),
 					Storage: multigresv1alpha1.StorageSpec{
 						Size:        "50Gi",
@@ -696,6 +705,7 @@ func TestResolver_ResolveGlobalTopo(t *testing.T) {
 				Etcd: &multigresv1alpha1.EtcdSpec{
 					Image:     "base-image",
 					Replicas:  ptr.To(DefaultEtcdReplicas),
+					RootPath:  DefaultTopoRootPath,
 					Resources: DefaultResourcesEtcd(),
 					Storage: multigresv1alpha1.StorageSpec{
 						Size:        "10Gi",

--- a/pkg/resolver/defaults.go
+++ b/pkg/resolver/defaults.go
@@ -26,6 +26,12 @@ const (
 	// DefaultPoolName is the name used for the default pool when no pools are specified in a ShardTemplate.
 	DefaultPoolName = "default"
 
+	// DefaultTopoRootPath is the default etcd key prefix for the global topology server.
+	DefaultTopoRootPath = "/multigres/global"
+
+	// DefaultTopoImplementation is the default client implementation for external topology servers.
+	DefaultTopoImplementation = "etcd"
+
 	// DefaultSystemDatabaseName is the name of the mandatory system database.
 	DefaultSystemDatabaseName = "postgres"
 

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -84,7 +84,7 @@ func isResourcesZero(res corev1.ResourceRequirements) bool {
 // ============================================================================
 
 // defaultEtcdSpec applies hardcoded safety defaults to an inline Etcd spec.
-func defaultEtcdSpec(spec *multigresv1alpha1.EtcdSpec) {
+func defaultEtcdSpec(spec *multigresv1alpha1.EtcdSpec, defaultRootPath string) {
 	if spec.Image == "" {
 		spec.Image = DefaultEtcdImage
 	}
@@ -95,10 +95,23 @@ func defaultEtcdSpec(spec *multigresv1alpha1.EtcdSpec) {
 		r := DefaultEtcdReplicas
 		spec.Replicas = &r
 	}
+	if spec.RootPath == "" {
+		spec.RootPath = defaultRootPath
+	}
 	// Use isResourcesZero to ensure we respect overrides that only have Claims
 	if isResourcesZero(spec.Resources) {
 		// Safety: DefaultResourcesEtcd() returns a fresh struct, so no DeepCopy needed.
 		spec.Resources = DefaultResourcesEtcd()
+	}
+}
+
+// defaultExternalTopoSpec applies hardcoded safety defaults to an external topo server spec.
+func defaultExternalTopoSpec(spec *multigresv1alpha1.ExternalTopoServerSpec, defaultRootPath string) {
+	if spec.Implementation == "" {
+		spec.Implementation = DefaultTopoImplementation
+	}
+	if spec.RootPath == "" {
+		spec.RootPath = defaultRootPath
 	}
 }
 

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -538,7 +538,7 @@ func TestSharedHelpers(t *testing.T) {
 
 	t.Run("defaultEtcdSpec", func(t *testing.T) {
 		spec := &multigresv1alpha1.EtcdSpec{}
-		defaultEtcdSpec(spec)
+		defaultEtcdSpec(spec, DefaultTopoRootPath)
 
 		if spec.Image != DefaultEtcdImage {
 			t.Errorf("Image: got %q, want %q", spec.Image, DefaultEtcdImage)
@@ -555,7 +555,7 @@ func TestSharedHelpers(t *testing.T) {
 
 		// Test Preservation
 		spec2 := &multigresv1alpha1.EtcdSpec{Image: "custom"}
-		defaultEtcdSpec(spec2)
+		defaultEtcdSpec(spec2, DefaultTopoRootPath)
 		if spec2.Image != "custom" {
 			t.Error("Should preserve existing image")
 		}

--- a/pkg/webhook/handlers/defaulter_test.go
+++ b/pkg/webhook/handlers/defaulter_test.go
@@ -103,6 +103,7 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 						Etcd: &multigresv1alpha1.EtcdSpec{
 							Image:     resolver.DefaultEtcdImage,
 							Replicas:  ptr.To(int32(3)),
+							RootPath:  resolver.DefaultTopoRootPath,
 							Resources: resolver.DefaultResourcesEtcd(),
 							Storage:   multigresv1alpha1.StorageSpec{Size: "1Gi"},
 						},
@@ -362,6 +363,7 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 							Etcd: &multigresv1alpha1.EtcdSpec{
 								Image:    resolver.DefaultEtcdImage,
 								Replicas: ptr.To(int32(3)),
+								RootPath: resolver.DefaultTopoRootPath,
 								Storage: multigresv1alpha1.StorageSpec{
 									Size: resolver.DefaultEtcdStorageSize,
 								},


### PR DESCRIPTION
The mutating webhook was not materializing default values for RootPath and Implementation fields in topology server configurations. This led to "invisible defaults" where the operator used hardcoded fallbacks at runtime that were not reflected in the MultigresCluster CRD, making the system harder to audit and observe.

- Centralized topology constants in pkg/resolver/defaults.go
- Parameterized defaultEtcdSpec to support context-aware root paths
- Implemented defaultExternalTopoSpec to materialize Implementation and RootPath
- Removed redundant hardcoded fallbacks from reconcile_global.go
- Updated resolver and webhook unit tests to ASSERT on materialized defaults

Ensures the MultigresCluster spec is the single, transparent source of truth for all configurations, improving observability for end users and external tools like the chaos observer.