### PR TITLE
  feat(defaults): materialize all cluster settings

### DIFF
--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -157,6 +157,11 @@ type ShardSpec struct {
 	// +optional
 	Backup *BackupConfig `json:"backup,omitempty"`
 
+	// TopologyPruning controls whether stale topology entries are pruned.
+	// Inherited from MultigresCluster.
+	// +optional
+	TopologyPruning *TopologyPruningConfig `json:"topologyPruning,omitempty"`
+
 	// CellTopologyLabels maps cell names to their topology nodeSelector labels.
 	// Each entry is a map like {"topology.kubernetes.io/zone": "us-east-1a"}.
 	// Propagated from the cluster's cell configs so the shard controller

--- a/api/v1alpha1/tablegroup_types.go
+++ b/api/v1alpha1/tablegroup_types.go
@@ -82,6 +82,11 @@ type TableGroupSpec struct {
 	// Propagated from the cluster's cell configs.
 	// +optional
 	CellTopologyLabels map[CellName]map[string]string `json:"cellTopologyLabels,omitempty"`
+
+	// TopologyPruning controls whether stale topology entries are pruned.
+	// Inherited from MultigresCluster.
+	// +optional
+	TopologyPruning *TopologyPruningConfig `json:"topologyPruning,omitempty"`
 }
 
 // ShardResolvedSpec represents the fully calculated spec for a shard,

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1245,6 +1245,11 @@ func (in *ShardSpec) DeepCopyInto(out *ShardSpec) {
 		*out = new(BackupConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TopologyPruning != nil {
+		in, out := &in.TopologyPruning, &out.TopologyPruning
+		*out = new(TopologyPruningConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.CellTopologyLabels != nil {
 		in, out := &in.CellTopologyLabels, &out.CellTopologyLabels
 		*out = make(map[CellName]map[string]string, len(*in))
@@ -1603,6 +1608,11 @@ func (in *TableGroupSpec) DeepCopyInto(out *TableGroupSpec) {
 			}
 			(*out)[key] = outVal
 		}
+	}
+	if in.TopologyPruning != nil {
+		in, out := &in.TopologyPruning, &out.TopologyPruning
+		*out = new(TopologyPruningConfig)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -2599,6 +2599,18 @@ spec:
                 maxLength: 25
                 minLength: 1
                 type: string
+              topologyPruning:
+                description: |-
+                  TopologyPruning controls whether stale topology entries are pruned.
+                  Inherited from MultigresCluster.
+                properties:
+                  enabled:
+                    description: |-
+                      Enabled controls whether the operator prunes stale topology entries.
+                      When false, the operator still registers entries but never removes them.
+                      Default: true (nil or empty means enabled).
+                    type: boolean
+                type: object
             required:
             - databaseName
             - globalTopoServer

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -2761,6 +2761,18 @@ spec:
                 maxLength: 25
                 minLength: 1
                 type: string
+              topologyPruning:
+                description: |-
+                  TopologyPruning controls whether stale topology entries are pruned.
+                  Inherited from MultigresCluster.
+                properties:
+                  enabled:
+                    description: |-
+                      Enabled controls whether the operator prunes stale topology entries.
+                      When false, the operator still registers entries but never removes them.
+                      Default: true (nil or empty means enabled).
+                    type: boolean
+                type: object
             required:
             - databaseName
             - globalTopoServer

--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
@@ -46,7 +46,7 @@ func BuildCell(
 			TopoServer:       localTopoSpec,
 			TopologyReconciliation: multigresv1alpha1.TopologyReconciliation{
 				RegisterCell: true,
-				PrunePoolers: true,
+				PrunePoolers: isPruningEnabled(cluster),
 			},
 			Observability: cluster.Spec.Observability,
 		},

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
@@ -62,6 +62,7 @@ func BuildTableGroup(
 			),
 			Observability:      cluster.Spec.Observability,
 			CellTopologyLabels: buildCellTopologyLabels(cluster),
+			TopologyPruning:    cluster.Spec.TopologyPruning,
 		},
 	}
 

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
@@ -94,7 +94,7 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 	}
 
 	// Prune stale topology entries unless disabled.
-	if r.isPruningEnabled(cluster) {
+	if isPruningEnabled(cluster) {
 		specDBNames := make([]string, 0, len(cluster.Spec.Databases))
 		for _, db := range cluster.Spec.Databases {
 			specDBNames = append(specDBNames, string(db.Name))
@@ -136,9 +136,9 @@ func (r *MultigresClusterReconciler) openTopoStore(
 
 // isPruningEnabled returns true if topology pruning is enabled for the cluster.
 // Pruning is enabled by default (nil or empty config means enabled).
-func (r *MultigresClusterReconciler) isPruningEnabled(
-	cluster *multigresv1alpha1.MultigresCluster,
-) bool {
+// This is a package-level function so it can be shared by reconcileTopology
+// and BuildCell (which propagates the flag to the Cell's PrunePoolers field).
+func isPruningEnabled(cluster *multigresv1alpha1.MultigresCluster) bool {
 	if cluster.Spec.TopologyPruning == nil ||
 		cluster.Spec.TopologyPruning.Enabled == nil {
 		return true

--- a/pkg/cluster-handler/controller/tablegroup/builders.go
+++ b/pkg/cluster-handler/controller/tablegroup/builders.go
@@ -56,6 +56,7 @@ func BuildShard(
 			),
 			Observability:      tg.Spec.Observability,
 			Backup:             shardSpec.Backup,
+			TopologyPruning:    tg.Spec.TopologyPruning,
 			CellTopologyLabels: tg.Spec.CellTopologyLabels,
 		},
 	}

--- a/pkg/resolver/cluster.go
+++ b/pkg/resolver/cluster.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 )
@@ -37,6 +38,31 @@ func (r *Resolver) PopulateClusterDefaults(
 	}
 	if cluster.Spec.Images.ImagePullPolicy == "" {
 		cluster.Spec.Images.ImagePullPolicy = DefaultImagePullPolicy
+	}
+
+	if cluster.Spec.TopologyPruning == nil {
+		cluster.Spec.TopologyPruning = &multigresv1alpha1.TopologyPruningConfig{
+			Enabled: ptr.To(true),
+		}
+	}
+
+	if cluster.Spec.PVCDeletionPolicy == nil {
+		cluster.Spec.PVCDeletionPolicy = &multigresv1alpha1.PVCDeletionPolicy{
+			WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+			WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+		}
+	}
+
+	if cluster.Spec.Backup == nil {
+		cluster.Spec.Backup = &multigresv1alpha1.BackupConfig{
+			Type: multigresv1alpha1.BackupTypeFilesystem,
+			Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+				Path: DefaultBackupPath,
+				Storage: multigresv1alpha1.StorageSpec{
+					Size: DefaultBackupStorageSize,
+				},
+			},
+		}
 	}
 
 	// 2. Smart Defaulting: System Catalog

--- a/pkg/resolver/cluster_test.go
+++ b/pkg/resolver/cluster_test.go
@@ -57,6 +57,20 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CellTemplate:  "",
 						ShardTemplate: "",
 					},
+					TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+						Enabled: ptr.To(true),
+					},
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+					},
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Path:    DefaultBackupPath,
+							Storage: multigresv1alpha1.StorageSpec{Size: DefaultBackupStorageSize},
+						},
+					},
 					Databases: []multigresv1alpha1.DatabaseConfig{
 						{
 							Name:    DefaultSystemDatabaseName,
@@ -100,6 +114,20 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CoreTemplate:  "",
 						CellTemplate:  "",
 						ShardTemplate: "",
+					},
+					TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+						Enabled: ptr.To(true),
+					},
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+					},
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Path:    DefaultBackupPath,
+							Storage: multigresv1alpha1.StorageSpec{Size: DefaultBackupStorageSize},
+						},
 					},
 					Databases: []multigresv1alpha1.DatabaseConfig{
 						{
@@ -152,6 +180,20 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CoreTemplate:  "",
 						CellTemplate:  "",
 						ShardTemplate: "",
+					},
+					TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+						Enabled: ptr.To(true),
+					},
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+					},
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Path:    DefaultBackupPath,
+							Storage: multigresv1alpha1.StorageSpec{Size: DefaultBackupStorageSize},
+						},
 					},
 					Cells: []multigresv1alpha1.CellConfig{
 						{Name: "zone-a"},
@@ -218,6 +260,20 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CellTemplate:  "",
 						ShardTemplate: "",
 					},
+					TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+						Enabled: ptr.To(true),
+					},
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+					},
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Path:    DefaultBackupPath,
+							Storage: multigresv1alpha1.StorageSpec{Size: DefaultBackupStorageSize},
+						},
+					},
 					Cells: []multigresv1alpha1.CellConfig{{Name: "zone-a"}},
 					Databases: []multigresv1alpha1.DatabaseConfig{
 						{
@@ -278,6 +334,20 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CellTemplate:  "",
 						ShardTemplate: "",
 					},
+					TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+						Enabled: ptr.To(true),
+					},
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+					},
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Path:    DefaultBackupPath,
+							Storage: multigresv1alpha1.StorageSpec{Size: DefaultBackupStorageSize},
+						},
+					},
 					Databases: []multigresv1alpha1.DatabaseConfig{
 						{
 							Name: "custom-db",
@@ -312,6 +382,20 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CellTemplate:  "custom-cell",
 						ShardTemplate: "custom-shard",
 					},
+					TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+						Enabled: ptr.To(false),
+					},
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
+						WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
+					},
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeS3,
+						S3: &multigresv1alpha1.S3BackupConfig{
+							Bucket: "my-bucket",
+							Region: "us-east-1",
+						},
+					},
 					Databases: []multigresv1alpha1.DatabaseConfig{
 						{
 							Name: "custom-db",
@@ -343,6 +427,20 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						CoreTemplate:  "custom-core",
 						CellTemplate:  "custom-cell",
 						ShardTemplate: "custom-shard",
+					},
+					TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+						Enabled: ptr.To(false),
+					},
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
+						WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
+					},
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeS3,
+						S3: &multigresv1alpha1.S3BackupConfig{
+							Bucket: "my-bucket",
+							Region: "us-east-1",
+						},
 					},
 					Databases: []multigresv1alpha1.DatabaseConfig{
 						{

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane.go
@@ -207,13 +207,19 @@ func (r *ShardReconciler) getTopoStore(shard *multigresv1alpha1.Shard) (topoclie
 }
 
 // reconcilePoolerPrune lists active pods for the shard and prunes topology
-// entries for poolers that no longer have a running pod.
+// entries for poolers that no longer have a running pod. Pruning is skipped
+// when the parent cluster has disabled topology pruning (propagated via
+// the Cell's TopologyReconciliation.PrunePoolers field).
 func (r *ShardReconciler) reconcilePoolerPrune(
 	ctx context.Context,
 	store topoclient.Store,
 	shard *multigresv1alpha1.Shard,
 ) {
 	logger := log.FromContext(ctx)
+
+	if !isPoolerPruningEnabled(shard) {
+		return
+	}
 
 	lbls := map[string]string{
 		metadata.LabelMultigresCluster:    shard.Labels[metadata.LabelMultigresCluster],
@@ -245,4 +251,14 @@ func (r *ShardReconciler) reconcilePoolerPrune(
 		r.Recorder.Eventf(shard, "Normal", "PoolersPruned",
 			"Pruned %d stale pooler(s) from topology", pruned)
 	}
+}
+
+// isPoolerPruningEnabled returns true when topology pruning is enabled for
+// the shard. The setting is inherited from MultigresCluster via the
+// TableGroup builder. Defaults to true when unset.
+func isPoolerPruningEnabled(shard *multigresv1alpha1.Shard) bool {
+	if shard.Spec.TopologyPruning == nil || shard.Spec.TopologyPruning.Enabled == nil {
+		return true
+	}
+	return *shard.Spec.TopologyPruning.Enabled
 }

--- a/pkg/webhook/handlers/defaulter_test.go
+++ b/pkg/webhook/handlers/defaulter_test.go
@@ -161,6 +161,22 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 							},
 						},
 					},
+					TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+						Enabled: ptr.To(true),
+					},
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+					},
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Path: resolver.DefaultBackupPath,
+							Storage: multigresv1alpha1.StorageSpec{
+								Size: resolver.DefaultBackupStorageSize,
+							},
+						},
+					},
 				}
 				if diff := cmp.Diff(want, &cluster.Spec, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("Cluster mismatch (-want +got):\n%s", diff)
@@ -438,9 +454,25 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 								}},
 							},
 						},
+						TopologyPruning: &multigresv1alpha1.TopologyPruningConfig{
+							Enabled: ptr.To(true),
+						},
+						PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+							WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+							WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+						},
+						Backup: &multigresv1alpha1.BackupConfig{
+							Type: multigresv1alpha1.BackupTypeFilesystem,
+							Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+								Path: resolver.DefaultBackupPath,
+								Storage: multigresv1alpha1.StorageSpec{
+									Size: resolver.DefaultBackupStorageSize,
+								},
+							},
+						},
 					},
 				}
-				if diff := cmp.Diff(want, cluster, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(want, cluster, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("Cluster mismatch (-want +got):\n%s", diff)
 				}
 			},

--- a/tools/observer/deploy/base/kustomization.yaml
+++ b/tools/observer/deploy/base/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - serviceaccount.yaml
   - clusterrole.yaml
   - clusterrolebinding.yaml
+  - service.yaml
   - deployment.yaml

--- a/tools/observer/deploy/base/service.yaml
+++ b/tools/observer/deploy/base/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: multigres-observer
+  namespace: multigres-operator
+  labels:
+    app.kubernetes.io/name: multigres-observer
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  selector:
+    app.kubernetes.io/name: multigres-observer
+  ports:
+    - name: metrics
+      port: 9090
+      targetPort: metrics
+      protocol: TCP


### PR DESCRIPTION
  TopologyPruning, PVCDeletionPolicy, and Backup had hidden defaults
  that affected runtime behavior but stayed nil in kubectl output.
  The observer tool was also missing a Service for port-forwarding.

  - Add TopologyPruning field to TableGroup and Shard specs, propagate via builders (trickle-down pattern)
  - Materialize TopologyPruning (enabled: true), PVCDeletionPolicy (Retain/Retain), and Backup (filesystem, /backups, 10Gi) in PopulateClusterDefaults
  - Wire isPruningEnabled into builders_cell.go and simplify shard controller to read from own spec
  - Add observer Service manifest and update kustomization
  - Update resolver, webhook, and integration tests

  All cluster defaults are now visible in kubectl get mgc -o yaml,
  consistent with the existing pattern for images and databases.