### PR TITLE
⏺ fix(drain): reload pg config after sync standby removal

### DIFF
--- a/pkg/data-handler/drain/drain.go
+++ b/pkg/data-handler/drain/drain.go
@@ -156,8 +156,9 @@ func ExecuteDrainStateMachine(
 					return true, nil
 				} else {
 					req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
-						Operation:  multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
-						StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
+						Operation:    multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
+						StandbyIds:   []*clustermetadatapb.ID{myPooler.Id},
+						ReloadConfig: true,
 					}
 					_, rpcErr := rpcClient.UpdateSynchronousStandbyList(ctx, primary, req)
 					if rpcErr != nil {
@@ -203,8 +204,9 @@ func ExecuteDrainStateMachine(
 					return true, nil
 				} else {
 					req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
-						Operation:  multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
-						StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
+						Operation:    multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
+						StandbyIds:   []*clustermetadatapb.ID{myPooler.Id},
+						ReloadConfig: true,
 					}
 					_, rpcErr := rpcClient.UpdateSynchronousStandbyList(ctx, primary, req)
 					if rpcErr != nil {


### PR DESCRIPTION
  During scale-down, the operator removes draining standbys from
  synchronous_standby_names via UpdateSynchronousStandbyList but
  omits ReloadConfig, so ALTER SYSTEM SET writes to
  postgresql.auto.conf without calling pg_reload_conf(). The
  runtime config stays stale, causing a write stall when all
  standbys disconnect.

  - Set ReloadConfig: true on REMOVE request in drain.go DrainStateRequested path
  - Set ReloadConfig: true on REMOVE request in drain.go DrainStateDraining verification path

  Prevents sync replication write stall during scale-down by
  ensuring runtime config reflects each standby removal.