### PR TITLE
feat(observer): add startup grace period for pool pods

### DIFF
--- a/tools/observer/README.md
+++ b/tools/observer/README.md
@@ -1,6 +1,6 @@
 # Multigres Observer
 
-A read-only health validation tool for Multigres clusters. It runs inside the cluster alongside the operator and provides continuous monitoring across 10 check categories. Intended for development and testing — not a production monitoring solution.
+A read-only health validation tool for Multigres clusters. It runs inside the cluster alongside the operator and provides continuous monitoring across 10 check categories. The observer's core purpose is catching issues that are **invisible to both `kubectl` and the operator itself** — silent data-plane failures, replication anomalies, and state mismatches that no single component can detect on its own.
 
 ## Use Cases
 
@@ -13,9 +13,14 @@ The observer exposes a structured `/api/status` endpoint designed for both human
 
 ## Why This Exists
 
-Multigres has many moving parts (gateway, orchestrator, pooler, postgres, etcd) and getting a full picture of cluster health requires checking each component individually. The observer consolidates all of these checks into a single loop and cross-references the results — for example, detecting when Kubernetes thinks a pod is Ready but the observer's own probes show it is broken.
+Multigres has many moving parts (gateway, orchestrator, pooler, postgres, etcd) and getting a full picture of cluster health requires checking each component individually. The observer consolidates all of these checks into a single loop and cross-references the results — for example, detecting when Kubernetes thinks a pod is Ready but the observer's own probes show it is broken, or when the operator reports Healthy but replication is actually degraded.
 
-Some of these checks compensate for gaps in upstream health endpoints (e.g., multipooler returns `/ready=200` while its gRPC server hangs). Those checks may become less necessary as upstream endpoints improve. But the observer's core value is cross-cutting: correlating failures across components, independently verifying what each component self-reports, and providing a single diagnostic snapshot of the entire cluster.
+Neither `kubectl` nor the operator can reliably surface these issues:
+
+- **`kubectl`** only shows pod-level status (Running, Ready, CrashLoopBackOff) — it cannot probe SQL replication, detect async standbys, or verify that gRPC health endpoints are actually serving.
+- **The operator** focuses on driving the desired state and reporting its own phase. It trusts component health endpoints at face value. When those endpoints lie (e.g., multipooler returning `/ready=200` while its gRPC server hangs), the operator cannot detect the failure.
+
+The observer independently verifies what each component self-reports. It is the tool of last resort for finding bugs that hide in the gaps between `kubectl`, the operator, and upstream multigres.
 
 ## Quick Start
 
@@ -110,6 +115,20 @@ The observer catches issues across the full stack:
 - Probe latency exceeding thresholds
 - etcd topology drift vs CRD state
 - Kubernetes Warning events (FailedScheduling, OOM, Unhealthy)
+
+## Startup Grace Period
+
+Newly created pool pods go through a brief startup phase where they are not yet serving (Postgres is starting, WAL receiver hasn't connected, standby is initially async). The observer suppresses transient noise from these pods to avoid cluttering findings with expected startup behavior:
+
+| Pod age | Ready? | Behavior |
+|---------|--------|----------|
+| < 60s | any | **Suppressed** — all findings for this pod are skipped |
+| ≥ 60s | no | **Downgraded** — `error`/`fatal` findings become `warn` |
+| ≥ 60s | yes | **Full severity** — this is the high-value signal |
+
+The grace period only applies to pool pods (`component=shard-pool`). Operator, multiorch, multigateway, and toposerver findings are always reported at full severity.
+
+When a pod that Kubernetes marks as Ready is showing errors, that is exactly the kind of issue the observer exists to catch — what `kubectl` and the operator cannot see.
 
 ## Documentation
 

--- a/tools/observer/docs/architecture.md
+++ b/tools/observer/docs/architecture.md
@@ -280,10 +280,15 @@ The observer maintains several tracking maps that persist across cycles but rese
 | `prevDrainState` | `ns/pod` | Detect backward state transitions |
 | `generationDivergeSince` | `kind/ns/name` | Track how long generation hasn't caught up |
 | `primaryViolationSince` | `pool-cell` | Grace period before flagging wrong primary count |
+| `podStartup` | `pod-name` | Pool pod creation time + readiness for startup grace period |
 | `lastLogCheck` | single timestamp | Avoid re-tailing already-checked logs |
 | `lastEventResourceVersion` | single string | Only process new events each cycle |
 
 This state is purely observational — losing it on restart is safe. The observer re-converges within 1-2 cycles.
+
+### Startup Grace Period
+
+The `podStartup` map is populated each cycle by `checkPodHealth` for pool pods and consumed by downstream checks (`connectivity`, `replication`, `logs`). Pods younger than 60 seconds have all findings suppressed; pods older than 60 seconds but not yet Ready have `error`/`fatal` findings downgraded to `warn`. See the [README](../README.md#startup-grace-period) for the full rationale.
 
 ---
 

--- a/tools/observer/pkg/common/constants.go
+++ b/tools/observer/pkg/common/constants.go
@@ -80,6 +80,7 @@ const (
 	ConnectivityLatencyThreshold = 500 * time.Millisecond
 	ReplicationLagWarnSecs       = 10
 	ReplicationLagErrorSecs      = 60
+	PodStartupGracePeriod        = 60 * time.Second
 )
 
 // Operator event reasons to monitor.

--- a/tools/observer/pkg/observer/connectivity.go
+++ b/tools/observer/pkg/observer/connectivity.go
@@ -120,6 +120,9 @@ func (o *Observer) probePoolPodHealth(ctx context.Context) {
 		if pod.Status.PodIP == "" {
 			continue
 		}
+		if o.isPodInGracePeriod(pod.Name) {
+			continue
+		}
 		o.probeHTTP(ctx, pod.Status.PodIP, common.PortMultiPoolerHTTP, "/live", "multipooler-health", pod.Name)
 		o.probeHTTP(ctx, pod.Status.PodIP, common.PortMultiPoolerHTTP, "/ready", "multipooler-readiness", pod.Name)
 		o.probePoolPodGRPC(ctx, pod)
@@ -480,6 +483,9 @@ func (o *Observer) crossCheckReadiness(ctx context.Context) {
 		component, _ := pd["component"].(string)
 
 		if !ready {
+			continue
+		}
+		if o.isPodInGracePeriod(name) {
 			continue
 		}
 

--- a/tools/observer/pkg/observer/logs.go
+++ b/tools/observer/pkg/observer/logs.go
@@ -92,11 +92,20 @@ func (o *Observer) checkDataPlaneLogs(ctx context.Context, sinceSeconds int64) {
 		comp := pod.Labels[common.LabelAppComponent]
 		switch comp {
 		case common.ComponentPool:
+			if o.isPodInGracePeriod(pod.Name) {
+				continue
+			}
 			o.scanPodLogs(ctx, pod, "multipooler", sinceSeconds, dataPlaneErrorPatterns)
 			o.scanPodLogs(ctx, pod, "postgres", sinceSeconds, dataPlaneErrorPatterns)
 		case common.ComponentMultiGateway:
+			if o.hasAnyPodInGracePeriod() {
+				continue
+			}
 			o.scanPodLogs(ctx, pod, "", sinceSeconds, dataPlaneErrorPatterns)
 		case common.ComponentMultiOrch:
+			if o.hasAnyPodInGracePeriod() {
+				continue
+			}
 			o.scanPodLogs(ctx, pod, "", sinceSeconds, dataPlaneErrorPatterns)
 		case common.ComponentGlobalTopo:
 			o.scanPodLogs(ctx, pod, "", sinceSeconds, dataPlaneErrorPatterns)
@@ -177,7 +186,7 @@ func (o *Observer) scanPodLogs(ctx context.Context, pod *corev1.Pod, container s
 			msg = fmt.Sprintf("Pattern %q matched 1 time in %s/%s", pattern, pod.Name, container)
 		}
 		o.reporter.Report(report.Finding{
-			Severity:  m.severity,
+			Severity:  o.effectiveSeverity(pod.Name, m.severity),
 			Check:     m.check,
 			Component: component,
 			Message:   msg,

--- a/tools/observer/pkg/observer/observer.go
+++ b/tools/observer/pkg/observer/observer.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/numtide/multigres-operator/tools/observer/pkg/common"
 	"github.com/numtide/multigres-operator/tools/observer/pkg/report"
 )
 
@@ -18,6 +19,12 @@ var allCheckNames = []string{
 	"pod-health", "resource-validation", "crd-status", "drain-state",
 	"connectivity", "operator-logs", "dataplane-logs", "events",
 	"topology", "replication",
+}
+
+// podInfo tracks per-pod metadata used by the startup grace period logic.
+type podInfo struct {
+	createdAt time.Time
+	ready     bool
 }
 
 // Observer runs continuous health validation checks against a multigres cluster.
@@ -57,6 +64,10 @@ type Observer struct {
 
 	// Event tracking: last event resource version seen.
 	lastEventResourceVersion string
+
+	// Pool pod startup info: populated each cycle by checkPodHealth.
+	// Used by downstream checks to suppress transient findings from newly created pods.
+	podStartup map[string]podInfo
 
 	// Known objects: populated each cycle by earlier checks for event filtering.
 	// Maps pod name → true for all currently-existing multigres-managed pods.
@@ -107,6 +118,7 @@ func New(cfg Config) *Observer {
 		prevDrainState:         make(map[string]string),
 		generationDivergeSince: make(map[string]time.Time),
 		primaryViolationSince:  make(map[string]time.Time),
+		podStartup:             make(map[string]podInfo),
 		knownPodNames:          make(map[string]bool),
 		seenEventCounts:        make(map[types.UID]int32),
 	}
@@ -120,6 +132,48 @@ func (o *Observer) listOpts(extraOpts ...client.ListOption) []client.ListOption 
 		opts = append(opts, client.InNamespace(o.namespace))
 	}
 	return append(opts, extraOpts...)
+}
+
+// isPodInGracePeriod returns true if a pool pod was created less than
+// PodStartupGracePeriod ago. Findings for such pods are suppressed entirely
+// because startup errors (connection refused, no WAL receiver, async standby)
+// are expected and resolve once the pod finishes joining.
+func (o *Observer) isPodInGracePeriod(podName string) bool {
+	info, ok := o.podStartup[podName]
+	if !ok {
+		return false
+	}
+	return time.Since(info.createdAt) < common.PodStartupGracePeriod
+}
+
+// effectiveSeverity downgrades error/fatal findings to warn for pool pods that
+// are past the grace period but still not Ready. Pods that Kubernetes marks as
+// Ready are reported at full severity — those are the high-value findings that
+// reveal issues invisible to kubectl and the operator.
+func (o *Observer) effectiveSeverity(podName string, sev report.Severity) report.Severity {
+	info, ok := o.podStartup[podName]
+	if !ok {
+		return sev
+	}
+	if info.ready {
+		return sev
+	}
+	if sev == report.SeverityError || sev == report.SeverityFatal {
+		return report.SeverityWarn
+	}
+	return sev
+}
+
+// hasAnyPodInGracePeriod returns true if any pool pod is younger than the
+// startup grace period. Used to downgrade findings from non-pool components
+// (e.g., multiorch logging "connection refused" because a pool pod is still starting).
+func (o *Observer) hasAnyPodInGracePeriod() bool {
+	for _, info := range o.podStartup {
+		if time.Since(info.createdAt) < common.PodStartupGracePeriod {
+			return true
+		}
+	}
+	return false
 }
 
 // Run starts the observer loop, running all checks every interval until ctx is cancelled.
@@ -161,6 +215,7 @@ func (o *Observer) runCycle(ctx context.Context) {
 
 	// Reset known objects — populated by checkPodHealth for event filtering.
 	clear(o.knownPodNames)
+	clear(o.podStartup)
 
 	track("pod-health", o.checkPodHealth)
 	track("resource-validation", o.checkResources)

--- a/tools/observer/pkg/observer/pods.go
+++ b/tools/observer/pkg/observer/pods.go
@@ -37,6 +37,13 @@ func (o *Observer) checkPodHealth(ctx context.Context) {
 		activePods[key] = true
 		o.knownPodNames[pod.Name] = true
 
+		if pod.Labels[common.LabelAppComponent] == common.ComponentPool {
+			o.podStartup[pod.Name] = podInfo{
+				createdAt: pod.CreationTimestamp.Time,
+				ready:     isPodReady(pod),
+			}
+		}
+
 		o.checkPodPhase(pod, key)
 		o.checkContainerReadiness(pod, key)
 		o.checkRestarts(pod)
@@ -304,8 +311,12 @@ func (o *Observer) checkPodCounts(ctx context.Context, pods *corev1.PodList) {
 			for _, cellName := range poolSpec.Cells {
 				actual := countPodsForPoolCell(pods, shardLabelValue, string(poolName), string(cellName))
 				if int32(actual) != expectedPerCell {
+					sev := report.SeverityError
+					if o.hasAnyPodInGracePeriod() {
+						sev = report.SeverityWarn
+					}
 					o.reporter.Report(report.Finding{
-						Severity:  report.SeverityError,
+						Severity:  sev,
 						Check:     "pod-health",
 						Component: fmt.Sprintf("shard/%s/%s", shard.Namespace, shard.Name),
 						Message:   fmt.Sprintf("Pool %s cell %s: expected %d pods, found %d", poolName, cellName, expectedPerCell, actual),

--- a/tools/observer/pkg/observer/replication.go
+++ b/tools/observer/pkg/observer/replication.go
@@ -92,6 +92,9 @@ func (o *Observer) checkShardReplication(ctx context.Context, shard *multigresv1
 	for i := range pods.Items {
 		p := &pods.Items[i]
 		if p.Status.PodIP != "" && p.Status.Phase == corev1.PodRunning && p.DeletionTimestamp == nil {
+			if o.isPodInGracePeriod(p.Name) {
+				continue
+			}
 			podIPs[p.Name] = p.Status.PodIP
 		}
 	}
@@ -181,7 +184,7 @@ func (o *Observer) probePrimaryReplication(ctx context.Context, podIP, podName, 
 
 	if len(standbys) == 0 && expectedReplicas > 0 {
 		o.reporter.Report(report.Finding{
-			Severity:  report.SeverityError,
+			Severity:  o.effectiveSeverity(podName, report.SeverityError),
 			Check:     "replication",
 			Component: comp,
 			Message:   fmt.Sprintf("Primary %s has 0 replication connections but %d replicas expected", podName, expectedReplicas),
@@ -263,7 +266,7 @@ func (o *Observer) probeReplicaHealth(ctx context.Context, podIP, podName, comp,
 		})
 	} else if walReceiverCount == 0 {
 		o.reporter.Report(report.Finding{
-			Severity:  report.SeverityError,
+			Severity:  o.effectiveSeverity(podName, report.SeverityError),
 			Check:     "replication",
 			Component: comp,
 			Message:   fmt.Sprintf("Replica %s has no WAL receiver running (not connected to primary)", podName),


### PR DESCRIPTION
Newly created pool pods produce transient errors during startup (connection refused, no WAL receiver, async standby) that clutter observer findings and mask real issues.

- Add 60s PodStartupGracePeriod constant in constants.go
- Track pool pod creation time and readiness in podStartup map
- Suppress all findings for pods younger than 60s
- Downgrade error/fatal to warn for pods past grace but not Ready
- Skip multiorch/multigateway log scanning while any pod is starting
- Downgrade pod count mismatches to warn during grace period
- Skip replication probing and connectivity checks for young pods
- Rewrite README "Why This Exists" to emphasize catching issues invisible to both kubectl and the operator
- Document grace period behavior in README and architecture.md

Pods marked Ready by Kubernetes are always reported at full severity — those are the high-value findings the observer exists to catch.