### PR TITLE
fix(drain): check primary pod readiness before RPCs

### DIFF
--- a/pkg/data-handler/drain/drain.go
+++ b/pkg/data-handler/drain/drain.go
@@ -154,6 +154,13 @@ func ExecuteDrainStateMachine(
 						pod.Name,
 					)
 					return true, nil
+				} else if IsPrimaryNotReady(ctx, k8sClient, shard, primary) {
+					logger.Info(
+						"Primary pod is not ready, delaying standby removal",
+						"pod",
+						pod.Name,
+					)
+					return true, nil
 				} else {
 					req := &multipoolermanagerdatapb.UpdateSynchronousStandbyListRequest{
 						Operation:    multipoolermanagerdatapb.StandbyUpdateOperation_STANDBY_UPDATE_OPERATION_REMOVE,
@@ -198,6 +205,13 @@ func ExecuteDrainStateMachine(
 				} else if IsPrimaryDraining(ctx, k8sClient, shard, primary) {
 					logger.Info(
 						"Primary pod is being drained, delaying standby removal verification",
+						"pod",
+						pod.Name,
+					)
+					return true, nil
+				} else if IsPrimaryNotReady(ctx, k8sClient, shard, primary) {
+					logger.Info(
+						"Primary pod is not ready, delaying standby removal verification",
 						"pod",
 						pod.Name,
 					)
@@ -305,4 +319,34 @@ func IsPrimaryDraining(
 	}
 	state := primaryPod.Annotations[metadata.AnnotationDrainState]
 	return state != "" && state != metadata.DrainStateReadyForDeletion
+}
+
+// IsPrimaryNotReady checks if the primary pooler's corresponding Kubernetes pod
+// has containers that are not passing readiness probes. This prevents sending
+// RPCs to a pod whose multipooler cannot reach its local postgres.
+func IsPrimaryNotReady(
+	ctx context.Context,
+	k8sClient client.Client,
+	shard *multigresv1alpha1.Shard,
+	primary *clustermetadatapb.MultiPooler,
+) bool {
+	if primary == nil || primary.Id == nil {
+		return true
+	}
+	primaryPod := &corev1.Pod{}
+	key := client.ObjectKey{Namespace: shard.Namespace, Name: primary.Id.Name}
+	if err := k8sClient.Get(ctx, key, primaryPod); err != nil {
+		if errors.IsNotFound(err) {
+			return true
+		}
+		log.FromContext(ctx).
+			Error(err, "Transient error checking primary pod readiness", "pod", key.Name)
+		return true
+	}
+	for _, cond := range primaryPod.Status.Conditions {
+		if cond.Type == corev1.ContainersReady {
+			return cond.Status != corev1.ConditionTrue
+		}
+	}
+	return false
 }

--- a/pkg/data-handler/drain/drain_test.go
+++ b/pkg/data-handler/drain/drain_test.go
@@ -164,3 +164,122 @@ func TestIsPrimaryDraining(t *testing.T) {
 		}
 	})
 }
+
+func TestIsPrimaryNotReady(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-shard",
+			Namespace: "default",
+		},
+	}
+
+	t.Run("returns true for nil primary", func(t *testing.T) {
+		t.Parallel()
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		if !drain.IsPrimaryNotReady(context.Background(), c, shard, nil) {
+			t.Error("expected true for nil primary")
+		}
+	})
+
+	t.Run("returns true for nil primary ID", func(t *testing.T) {
+		t.Parallel()
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		primary := &clustermetadata.MultiPooler{}
+		if !drain.IsPrimaryNotReady(context.Background(), c, shard, primary) {
+			t.Error("expected true for nil primary ID")
+		}
+	})
+
+	t.Run("returns true when primary pod not found", func(t *testing.T) {
+		t.Parallel()
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		primary := &clustermetadata.MultiPooler{
+			Id: &clustermetadata.ID{Cell: "cell1", Name: "missing-pod"},
+		}
+		if !drain.IsPrimaryNotReady(context.Background(), c, shard, primary) {
+			t.Error("expected true when pod not found")
+		}
+	})
+
+	t.Run("returns false when no ContainersReady condition", func(t *testing.T) {
+		t.Parallel()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "primary-pod",
+				Namespace: "default",
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+		primary := &clustermetadata.MultiPooler{
+			Id: &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
+		}
+		if drain.IsPrimaryNotReady(context.Background(), c, shard, primary) {
+			t.Error("expected false when no ContainersReady condition (assume ready)")
+		}
+	})
+
+	t.Run("returns false when ContainersReady is True", func(t *testing.T) {
+		t.Parallel()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "primary-pod",
+				Namespace: "default",
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.ContainersReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+		primary := &clustermetadata.MultiPooler{
+			Id: &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
+		}
+		if drain.IsPrimaryNotReady(context.Background(), c, shard, primary) {
+			t.Error("expected false when ContainersReady is True")
+		}
+	})
+
+	t.Run("returns true when ContainersReady is False", func(t *testing.T) {
+		t.Parallel()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "primary-pod",
+				Namespace: "default",
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.ContainersReady, Status: corev1.ConditionFalse},
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+		primary := &clustermetadata.MultiPooler{
+			Id: &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
+		}
+		if !drain.IsPrimaryNotReady(context.Background(), c, shard, primary) {
+			t.Error("expected true when ContainersReady is False")
+		}
+	})
+
+	t.Run("returns true on transient API error", func(t *testing.T) {
+		t.Parallel()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				return fmt.Errorf("connection refused")
+			},
+		}).Build()
+		primary := &clustermetadata.MultiPooler{
+			Id: &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
+		}
+		if !drain.IsPrimaryNotReady(context.Background(), c, shard, primary) {
+			t.Error("expected true on transient error (fail-safe)")
+		}
+	})
+}


### PR DESCRIPTION
During rolling updates, the primary pod's multipooler can report Ready to Kubernetes while its postgres is still replaying WAL and refusing Unix socket connections. The drain state machine would then retry RPCs against this unreachable primary until the 5-minute timeout expired.

- Add IsPrimaryNotReady guard in both DrainStateRequested and DrainStateDraining phases, checking the ContainersReady condition before attempting UpdateSynchronousStandbyList RPCs
- Add IsPrimaryNotReady function to drain.go following the same pattern as IsPrimaryTerminatingOrMissing and IsPrimaryDraining
- Add 7 unit tests for IsPrimaryNotReady in drain_test.go

Prevents the drain retry loop when the primary's readiness probe reflects actual container health, providing defense-in-depth alongside a pending upstream multipooler readiness probe fix.