### PR TITLE
fix(shard): shorten multipooler service ID to prevent app_name overflow

### DIFF
--- a/config/samples/minimal.yaml
+++ b/config/samples/minimal.yaml
@@ -1,7 +1,7 @@
 apiVersion: multigres.com/v1alpha1
 kind: MultigresCluster
 metadata:
-  name: m
+  name: minimal
   namespace: default
 spec:
   pvcDeletionPolicy:

--- a/config/samples/no-templates.yaml
+++ b/config/samples/no-templates.yaml
@@ -1,7 +1,7 @@
 apiVersion: multigres.com/v1alpha1
 kind: MultigresCluster
 metadata:
-  name: i
+  name: inline
   namespace: default
 spec:
   pvcDeletionPolicy:

--- a/pkg/data-handler/topo/pooler.go
+++ b/pkg/data-handler/topo/pooler.go
@@ -22,11 +22,14 @@ type PoolerStatusResult struct {
 }
 
 // GetPoolerStatus queries the topology for all poolers belonging to a shard
-// and returns a map of hostname to role string.
+// and returns a map of pod name to role string. managedPodNames is the set of
+// Kubernetes pod names currently managed by the shard controller; topology
+// entries are matched to pods via PodMatchesPooler (FQDN-aware).
 func GetPoolerStatus(
 	ctx context.Context,
 	store topoclient.Store,
 	shard *multigresv1alpha1.Shard,
+	managedPodNames []string,
 ) *PoolerStatusResult {
 	result := &PoolerStatusResult{
 		Roles:        make(map[string]string),
@@ -46,19 +49,29 @@ func GetPoolerStatus(
 				case clustermetadatapb.PoolerType_DRAINED:
 					roleName = "DRAINED"
 				}
-				hostname := p.GetHostname()
-				if p.Id != nil && p.Id.Name != "" {
-					hostname = p.Id.Name
-				} else if hostname == "" {
-					hostname = fmt.Sprintf("unknown-pooler-%v", p.Id)
+				// Match the topology entry to an actual managed pod.
+				podName := matchPoolerToPod(p, managedPodNames)
+				if podName == "" {
+					continue // Orphaned entry; pruning handles cleanup.
 				}
-				result.Roles[hostname] = roleName
+				result.Roles[podName] = roleName
 			}
 		} else {
 			result.QuerySuccess = false
 		}
 	}
 	return result
+}
+
+// matchPoolerToPod finds the managed pod name that matches a topology pooler
+// entry, using the FQDN-aware PodMatchesPooler comparison.
+func matchPoolerToPod(p *topoclient.MultiPoolerInfo, podNames []string) string {
+	for _, name := range podNames {
+		if PodMatchesPooler(name, p) {
+			return name
+		}
+	}
+	return ""
 }
 
 // FindPrimaryPooler discovers the PRIMARY multipooler from the given cells

--- a/pkg/data-handler/topo/pooler_test.go
+++ b/pkg/data-handler/topo/pooler_test.go
@@ -507,7 +507,7 @@ func TestGetPoolerStatus(t *testing.T) {
 			},
 		}
 
-		result := topo.GetPoolerStatus(ctx, store, shard)
+		result := topo.GetPoolerStatus(ctx, store, shard, []string{"primary", "replica", "drained"})
 		if !result.QuerySuccess {
 			t.Error("expected QuerySuccess=true")
 		}
@@ -536,7 +536,7 @@ func TestGetPoolerStatus(t *testing.T) {
 			},
 		}
 
-		result := topo.GetPoolerStatus(context.Background(), store, shard)
+		result := topo.GetPoolerStatus(context.Background(), store, shard, nil)
 		if result.QuerySuccess {
 			t.Error("expected QuerySuccess=false when store errors")
 		}
@@ -567,7 +567,7 @@ func TestGetPoolerStatus(t *testing.T) {
 			},
 		}
 
-		result := topo.GetPoolerStatus(ctx, store, shard)
+		result := topo.GetPoolerStatus(ctx, store, shard, []string{"my-pod-0"})
 		if !result.QuerySuccess {
 			t.Error("expected QuerySuccess=true")
 		}

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
-	"github.com/numtide/multigres-operator/pkg/util/name"
+	nameutil "github.com/numtide/multigres-operator/pkg/util/name"
 )
 
 const (
@@ -195,6 +195,16 @@ func buildPgctldContainer(
 	}
 }
 
+// BuildPoolServiceID generates a short, deterministic service ID for a
+// multipooler from its pod name. The pod name is already guaranteed unique
+// (via JoinWithConstraints), so hashing it produces a collision-free short ID.
+//
+// Format: p-{fnv32a_hex} (e.g. "p-a1b2c3d4", always 10 chars).
+// The "p" prefix follows the multigres component naming convention (p=pooler).
+func BuildPoolServiceID(podName string) string {
+	return "p-" + nameutil.Hash([]string{podName})
+}
+
 // buildMultiPoolerSidecar creates the multipooler sidecar container spec.
 // Implemented as native sidecar (init container with restartPolicy: Always) because
 // multipooler must restart with postgres to maintain connection pool consistency.
@@ -203,6 +213,7 @@ func buildMultiPoolerSidecar(
 	pool multigresv1alpha1.PoolSpec,
 	poolName string,
 	cellName string,
+	serviceID string,
 ) corev1.Container {
 	image := multigresv1alpha1.DefaultMultiPoolerImage
 	if shard.Spec.Images.MultiPooler != "" {
@@ -226,7 +237,7 @@ func buildMultiPoolerSidecar(
 		"--database=" + string(shard.Spec.DatabaseName),
 		"--table-group=" + string(shard.Spec.TableGroupName),
 		"--shard=" + string(shard.Spec.ShardName),
-		"--service-id=$(POD_NAME)", // Use pod name as unique service ID
+		"--service-id=" + serviceID,
 		"--pgctld-addr=localhost:15470",
 		"--pg-port=5432",
 		"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)", // Resolved from env var below
@@ -283,14 +294,6 @@ func buildMultiPoolerSidecar(
 	}
 
 	env := []corev1.EnvVar{
-		{
-			Name: "POD_NAME",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "metadata.name",
-				},
-			},
-		},
 		connpoolAdminPasswordEnvVar(shard.Name),
 	}
 	env = append(env, s3EnvVars(shard.Spec.Backup)...)
@@ -418,8 +421,8 @@ func buildSharedBackupVolume(shard *multigresv1alpha1.Shard, cellName string) co
 	if shard.Spec.Backup != nil &&
 		shard.Spec.Backup.Type == multigresv1alpha1.BackupTypeFilesystem {
 		clusterName := shard.Labels["multigres.com/cluster"]
-		claimName := name.JoinWithConstraints(
-			name.ServiceConstraints,
+		claimName := nameutil.JoinWithConstraints(
+			nameutil.ServiceConstraints,
 			"backup-data",
 			clusterName,
 			string(shard.Spec.DatabaseName),

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -1,6 +1,7 @@
 package shard
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -15,10 +16,11 @@ import (
 
 func TestBuildMultiPoolerSidecar(t *testing.T) {
 	tests := map[string]struct {
-		shard    *multigresv1alpha1.Shard
-		poolSpec multigresv1alpha1.PoolSpec
-		cellName string
-		want     corev1.Container
+		shard     *multigresv1alpha1.Shard
+		poolSpec  multigresv1alpha1.PoolSpec
+		cellName  string
+		serviceID string
+		want      corev1.Container
 	}{
 		"default multipooler image with no resources": {
 			shard: &multigresv1alpha1.Shard{
@@ -37,7 +39,8 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 			poolSpec: multigresv1alpha1.PoolSpec{
 				Cells: []multigresv1alpha1.CellName{"zone1"},
 			},
-			cellName: "zone1",
+			cellName:  "zone1",
+			serviceID: "p-test-id",
 			want: corev1.Container{
 				Name:  "multipooler",
 				Image: multigresv1alpha1.DefaultMultiPoolerImage,
@@ -54,7 +57,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					"--database=testdb",
 					"--table-group=default",
 					"--shard=0",
-					"--service-id=$(POD_NAME)",
+					"--service-id=p-test-id",
 					"--pgctld-addr=localhost:15470",
 					"--pg-port=5432",
 					"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
@@ -96,14 +99,6 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					PeriodSeconds: 5,
 				},
 				Env: []corev1.EnvVar{
-					{
-						Name: "POD_NAME",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.name",
-							},
-						},
-					},
 					connpoolAdminPasswordEnvVar("test-shard"),
 				},
 				VolumeMounts: []corev1.VolumeMount{
@@ -142,7 +137,8 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 			poolSpec: multigresv1alpha1.PoolSpec{
 				Cells: []multigresv1alpha1.CellName{"zone2"},
 			},
-			cellName: "zone2",
+			cellName:  "zone2",
+			serviceID: "p-custom-id",
 			want: corev1.Container{
 				Name:  "multipooler",
 				Image: "custom/multipooler:v1.0.0",
@@ -159,7 +155,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					"--database=proddb",
 					"--table-group=orders",
 					"--shard=1",
-					"--service-id=$(POD_NAME)",
+					"--service-id=p-custom-id",
 					"--pgctld-addr=localhost:15470",
 					"--pg-port=5432",
 					"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
@@ -201,14 +197,6 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					PeriodSeconds: 5,
 				},
 				Env: []corev1.EnvVar{
-					{
-						Name: "POD_NAME",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.name",
-							},
-						},
-					},
 					connpoolAdminPasswordEnvVar("custom-shard"),
 				},
 				VolumeMounts: []corev1.VolumeMount{
@@ -256,7 +244,8 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					},
 				},
 			},
-			cellName: "zone1",
+			cellName:  "zone1",
+			serviceID: "p-resource-id",
 			want: corev1.Container{
 				Name:  "multipooler",
 				Image: multigresv1alpha1.DefaultMultiPoolerImage,
@@ -273,7 +262,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					"--database=mydb",
 					"--table-group=default",
 					"--shard=0",
-					"--service-id=$(POD_NAME)",
+					"--service-id=p-resource-id",
 					"--pgctld-addr=localhost:15470",
 					"--pg-port=5432",
 					"--connpool-admin-password=$(CONNPOOL_ADMIN_PASSWORD)",
@@ -324,14 +313,6 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					PeriodSeconds: 5,
 				},
 				Env: []corev1.EnvVar{
-					{
-						Name: "POD_NAME",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.name",
-							},
-						},
-					},
 					connpoolAdminPasswordEnvVar("resource-shard"),
 				},
 				VolumeMounts: []corev1.VolumeMount{
@@ -354,7 +335,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := buildMultiPoolerSidecar(tc.shard, tc.poolSpec, "primary", tc.cellName)
+			got := buildMultiPoolerSidecar(tc.shard, tc.poolSpec, "primary", tc.cellName, tc.serviceID)
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("buildMultiPoolerSidecar() mismatch (-want +got):\n%s", diff)
@@ -714,7 +695,7 @@ func assertContainsFlag(t *testing.T, args []string, want string) {
 }
 
 func TestBuildMultiPoolerSidecar_WithObservability(t *testing.T) {
-	c := buildMultiPoolerSidecar(otelShard(), multigresv1alpha1.PoolSpec{}, "primary", "zone1")
+	c := buildMultiPoolerSidecar(otelShard(), multigresv1alpha1.PoolSpec{}, "primary", "zone1", "p-otel1234")
 	assertContainsOTELEnvVar(t, c.Env, "buildMultiPoolerSidecar")
 }
 
@@ -991,7 +972,7 @@ func TestMultiPoolerSidecar_PgBackRestCertArgs(t *testing.T) {
 			Type: multigresv1alpha1.BackupTypeS3,
 			S3:   &multigresv1alpha1.S3BackupConfig{Bucket: "b", Region: "r"},
 		}
-		c := buildMultiPoolerSidecar(shard, multigresv1alpha1.PoolSpec{}, "primary", "zone1")
+		c := buildMultiPoolerSidecar(shard, multigresv1alpha1.PoolSpec{}, "primary", "zone1", "p-backup123")
 		assertContainsFlag(t, c.Args, "--pgbackrest-cert-file=/certs/pgbackrest/pgbackrest.crt")
 		assertContainsFlag(t, c.Args, "--pgbackrest-key-file=/certs/pgbackrest/pgbackrest.key")
 		assertContainsFlag(t, c.Args, "--pgbackrest-ca-file=/certs/pgbackrest/ca.crt")
@@ -1000,7 +981,7 @@ func TestMultiPoolerSidecar_PgBackRestCertArgs(t *testing.T) {
 
 	t.Run("no cert args when no backup", func(t *testing.T) {
 		shard := baseShard.DeepCopy()
-		c := buildMultiPoolerSidecar(shard, multigresv1alpha1.PoolSpec{}, "primary", "zone1")
+		c := buildMultiPoolerSidecar(shard, multigresv1alpha1.PoolSpec{}, "primary", "zone1", "p-noback123")
 		assertNotContainsFlag(t, c.Args, "--pgbackrest-cert-file")
 		assertNotContainsFlag(t, c.Args, "--pgbackrest-key-file")
 		assertNotContainsFlag(t, c.Args, "--pgbackrest-ca-file")
@@ -1045,6 +1026,43 @@ func TestBuildPoolVolumes_CertVolumePresence(t *testing.T) {
 		for _, v := range volumes {
 			if v.Name == PgBackRestCertVolumeName {
 				t.Error("cert volume should not be present when no backup configured")
+			}
+		}
+	})
+}
+
+func TestBuildPoolServiceID(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		podName := "minimal-postgres-default-0-inf-pool-default-zone-a-a3a0d77b-1"
+		id1 := BuildPoolServiceID(podName)
+		id2 := BuildPoolServiceID(podName)
+		if id1 != id2 {
+			t.Errorf("non-deterministic: %q != %q", id1, id2)
+		}
+	})
+
+	t.Run("format", func(t *testing.T) {
+		id := BuildPoolServiceID("some-pod-name")
+		pattern := regexp.MustCompile(`^p-[0-9a-f]{8}$`)
+		if !pattern.MatchString(id) {
+			t.Errorf("BuildPoolServiceID(%q) = %q, want format p-[0-9a-f]{8}", "some-pod-name", id)
+		}
+	})
+
+	t.Run("different inputs produce different outputs", func(t *testing.T) {
+		id1 := BuildPoolServiceID("pod-a")
+		id2 := BuildPoolServiceID("pod-b")
+		if id1 == id2 {
+			t.Errorf("collision: BuildPoolServiceID(%q) == BuildPoolServiceID(%q) == %q",
+				"pod-a", "pod-b", id1)
+		}
+	})
+
+	t.Run("length is always 10", func(t *testing.T) {
+		for _, name := range []string{"a", "short", "a-very-long-pod-name-that-goes-on-and-on"} {
+			id := BuildPoolServiceID(name)
+			if len(id) != 10 {
+				t.Errorf("BuildPoolServiceID(%q) = %q (len %d), want len 10", name, id, len(id))
 			}
 		}
 	})

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -72,6 +72,8 @@ func BuildPoolPod(
 		},
 	}}, volumes...)
 
+	serviceID := BuildPoolServiceID(podName)
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      podName,
@@ -87,7 +89,7 @@ func BuildPoolPod(
 			},
 			TerminationGracePeriodSeconds: ptr.To(defaultTerminationGracePeriod),
 			InitContainers: []corev1.Container{
-				buildMultiPoolerSidecar(shard, poolSpec, poolName, cellName),
+				buildMultiPoolerSidecar(shard, poolSpec, poolName, cellName, serviceID),
 			},
 			Containers: []corev1.Container{
 				buildPgctldContainer(shard, poolSpec),

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane.go
@@ -114,33 +114,56 @@ func (r *ShardReconciler) reconcileDataPlane(
 }
 
 // reconcilePodRoles queries the topology for pooler status and updates
-// shard.Status.PodRoles.
+// shard.Status.PodRoles. Pod names are resolved by matching topology entries
+// to actual managed Kubernetes pods via PodMatchesPooler.
 func (r *ShardReconciler) reconcilePodRoles(
 	ctx context.Context,
 	store topoclient.Store,
 	shard *multigresv1alpha1.Shard,
 ) {
 	logger := log.FromContext(ctx)
+
+	// List managed pods for this shard (same pattern as reconcilePoolerPrune).
+	lbls := map[string]string{
+		metadata.LabelMultigresCluster:    shard.Labels[metadata.LabelMultigresCluster],
+		metadata.LabelMultigresDatabase:   string(shard.Spec.DatabaseName),
+		metadata.LabelMultigresTableGroup: string(shard.Spec.TableGroupName),
+		metadata.LabelMultigresShard:      string(shard.Spec.ShardName),
+	}
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList,
+		client.InNamespace(shard.Namespace),
+		client.MatchingLabels(lbls),
+	); err != nil {
+		logger.Error(err, "Failed to list pods for role reconciliation")
+		return
+	}
+
+	podNames := make([]string, len(podList.Items))
+	for i := range podList.Items {
+		podNames[i] = podList.Items[i].Name
+	}
+
 	statusBase := shard.DeepCopy()
-	poolerStatus := topo.GetPoolerStatus(ctx, store, shard)
+	poolerStatus := topo.GetPoolerStatus(ctx, store, shard, podNames)
 
 	if shard.Status.PodRoles == nil {
 		shard.Status.PodRoles = make(map[string]string)
 	}
 	rolesChanged := false
 
-	for hostname, role := range poolerStatus.Roles {
-		if shard.Status.PodRoles[hostname] != role {
-			shard.Status.PodRoles[hostname] = role
+	for podName, role := range poolerStatus.Roles {
+		if shard.Status.PodRoles[podName] != role {
+			shard.Status.PodRoles[podName] = role
 			rolesChanged = true
 		}
 	}
 
 	// Prune entries for poolers that no longer exist in the topology.
 	if poolerStatus.QuerySuccess {
-		for hostname := range shard.Status.PodRoles {
-			if _, exists := poolerStatus.Roles[hostname]; !exists {
-				delete(shard.Status.PodRoles, hostname)
+		for podName := range shard.Status.PodRoles {
+			if _, exists := poolerStatus.Roles[podName]; !exists {
+				delete(shard.Status.PodRoles, podName)
 				rolesChanged = true
 			}
 		}

--- a/tools/observer/pkg/observer/topology.go
+++ b/tools/observer/pkg/observer/topology.go
@@ -262,7 +262,7 @@ func (o *Observer) checkPoolerRegistration(
 			continue
 		}
 		// Key format: <prefix><service-id>/Pooler
-		// Service ID format: multipooler-<cell>-<pod-name>
+		// Service ID format: multipooler-<cell>-p-<hash>
 		keyStr := string(key)
 		if strings.HasPrefix(keyStr, prefix) {
 			suffix := strings.TrimPrefix(keyStr, prefix)
@@ -274,22 +274,34 @@ func (o *Observer) checkPoolerRegistration(
 		}
 	}
 
-	// Check running pool pods are registered.
-	// Etcd service IDs use the format "multipooler-<cell>-<pod-name>",
-	// so we match by checking if any registered service ID ends with the pod name.
+	// Build a map of service ID → pod for each pool pod.
+	// The service ID is extracted from the multipooler container's --service-id flag.
+	podByServiceID := make(map[string]*corev1.Pod, len(pods.Items))
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		drainState := pod.Annotations[common.AnnotationDrainState]
+		if sid := extractServiceID(pod); sid != "" {
+			podByServiceID[sid] = pod
+		}
+	}
 
-		registered := false
-		var matchedID string
-		for id := range registeredPoolers {
-			if strings.HasSuffix(id, pod.Name) {
-				registered = true
-				matchedID = id
+	// Match registered pooler service IDs to pods.
+	// Etcd keys contain the full service ID (e.g. "multipooler-z1-p-a1b2c3d4");
+	// pods carry the short service ID (e.g. "p-a1b2c3d4") in --service-id.
+	matchedPods := make(map[string]bool, len(pods.Items))
+	for etcdID := range registeredPoolers {
+		for sid, pod := range podByServiceID {
+			if strings.Contains(etcdID, sid) {
+				matchedPods[pod.Name] = true
+				delete(registeredPoolers, etcdID)
 				break
 			}
 		}
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		drainState := pod.Annotations[common.AnnotationDrainState]
+		registered := matchedPods[pod.Name]
 
 		// Pods in ready-for-deletion should NOT be registered.
 		if drainState == common.DrainStateReadyForDeletion {
@@ -312,16 +324,12 @@ func (o *Observer) checkPoolerRegistration(
 			pod.DeletionTimestamp == nil {
 			if !registered {
 				o.reporter.Report(report.Finding{
-					Severity:  report.SeverityWarn,
+					Severity:  report.SeverityError,
 					Check:     "topology",
 					Component: componentForPod(pod),
 					Message:   fmt.Sprintf("Running pool pod %s not registered in etcd", pod.Name),
 				})
 			}
-		}
-
-		if matchedID != "" {
-			delete(registeredPoolers, matchedID)
 		}
 	}
 
@@ -334,4 +342,23 @@ func (o *Observer) checkPoolerRegistration(
 			Message:   fmt.Sprintf("Pooler %s registered in etcd but no corresponding pod", name),
 		})
 	}
+}
+
+// extractServiceID reads the --service-id flag value from a pod's multipooler
+// container args. Returns empty string if not found.
+func extractServiceID(pod *corev1.Pod) string {
+	const prefix = "--service-id="
+	for _, cs := range [][]corev1.Container{pod.Spec.InitContainers, pod.Spec.Containers} {
+		for i := range cs {
+			if cs[i].Name != "multipooler" {
+				continue
+			}
+			for _, arg := range cs[i].Args {
+				if strings.HasPrefix(arg, prefix) {
+					return strings.TrimPrefix(arg, prefix)
+				}
+			}
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
PostgreSQL silently truncates application_name at 63 chars. When multigres builds it as cell_service-id and the service ID is a 60-char pod name, the combined name overflows, breaking synchronous replication matching.

- Add BuildPoolServiceID in containers.go: FNV-32a hash of pod name with "p-" prefix, producing a fixed 10-char service ID
- Pass computed serviceID to buildMultiPoolerSidecar instead of relying on runtime $(POD_NAME) env var expansion
- Remove POD_NAME env var from multipooler container (no longer needed)
- Rewrite GetPoolerStatus in pooler.go to accept managed pod names and correlate topology entries via PodMatchesPooler, fixing podRoles being keyed by FQDN hostnames instead of short pod names
- Update reconcilePodRoles to list managed pods before querying topology, matching the existing reconcilePoolerPrune pattern
- Fix observer checkPoolerRegistration to extract --service-id from pod args for etcd correlation; bump unregistered-pod severity to ERROR; eliminate dead code and empty-string Contains bug
- Add TestBuildPoolServiceID covering determinism, format, uniqueness, and fixed length

Worst-case application_name drops from 91 to 41 chars, always under 63.