### PR TITLE
feat(operator): update multipooler and pgctld health probes

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -3,23 +3,23 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-8bfe693"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-d6c1048"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiAdminImage is the default container image for the MultiAdmin component.
-	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-8bfe693"
+	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-d6c1048"
 
 	// DefaultMultiAdminWebImage is the default container image for the MultiAdminWeb component.
 	DefaultMultiAdminWebImage = "ghcr.io/multigres/multiadmin-web:sha-b505c90"
 
 	// DefaultMultiOrchImage is the default container image for the MultiOrch component.
-	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-8bfe693"
+	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-d6c1048"
 
 	// DefaultMultiPoolerImage is the default container image for the MultiPooler component.
-	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-8bfe693"
+	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-d6c1048"
 
 	// DefaultMultiGatewayImage is the default container image for the MultiGateway component.
-	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-8bfe693"
+	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-d6c1048"
 )

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -128,6 +128,7 @@ func buildPgctldContainer(
 		"--log-level=info",
 		"--grpc-socket-file=" + PoolerDirMountPath + "/pgctld.sock",
 		"--pg-hba-template=" + PgHbaTemplatePath,
+		"--http-port=15400",
 	}
 
 	if shard.Spec.Backup != nil {
@@ -192,6 +193,24 @@ func buildPgctldContainer(
 			RunAsNonRoot: ptr.To(true),
 		},
 		VolumeMounts: volumeMounts,
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/live",
+					Port: intstr.FromInt32(DefaultPgctldHTTPPort),
+				},
+			},
+			PeriodSeconds: 10,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/live",
+					Port: intstr.FromInt32(DefaultPgctldHTTPPort),
+				},
+			},
+			PeriodSeconds: 5,
+		},
 	}
 }
 
@@ -266,7 +285,7 @@ func buildMultiPoolerSidecar(
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/ready",
+					Path: "/live",
 					Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
 				},
 			},
@@ -285,7 +304,7 @@ func buildMultiPoolerSidecar(
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/ready",
+					Path: "/live",
 					Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
 				},
 			},

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -73,7 +73,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				StartupProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/ready",
+							Path: "/live",
 							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
 						},
 					},
@@ -92,7 +92,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/ready",
+							Path: "/live",
 							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
 						},
 					},
@@ -171,7 +171,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				StartupProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/ready",
+							Path: "/live",
 							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
 						},
 					},
@@ -190,7 +190,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/ready",
+							Path: "/live",
 							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
 						},
 					},
@@ -287,7 +287,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				StartupProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/ready",
+							Path: "/live",
 							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
 						},
 					},
@@ -306,7 +306,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
-							Path: "/ready",
+							Path: "/live",
 							Port: intstr.FromInt32(DefaultMultiPoolerHTTPPort),
 						},
 					},
@@ -457,6 +457,13 @@ func TestBuildPgctldContainer(t *testing.T) {
 		}
 		if c.Command[0] != "/usr/local/bin/pgctld" {
 			t.Errorf("Command = %v, want /usr/local/bin/pgctld", c.Command)
+		}
+		assertContainsFlag(t, c.Args, "--http-port=15400")
+		if c.LivenessProbe == nil || c.LivenessProbe.HTTPGet.Path != "/live" {
+			t.Errorf("expected LivenessProbe to hit /live, got %v", c.LivenessProbe)
+		}
+		if c.ReadinessProbe == nil || c.ReadinessProbe.HTTPGet.Path != "/live" {
+			t.Errorf("expected ReadinessProbe to hit /live, got %v", c.ReadinessProbe)
 		}
 	})
 

--- a/pkg/resource-handler/controller/shard/ports.go
+++ b/pkg/resource-handler/controller/shard/ports.go
@@ -15,6 +15,9 @@ const (
 	// DefaultPostgresPort is the default port for PostgreSQL protocol traffic.
 	DefaultPostgresPort int32 = 5432
 
+	// DefaultPgctldHTTPPort is the default port for pgctld HTTP traffic.
+	DefaultPgctldHTTPPort int32 = 15400
+
 	// DefaultMultiOrchHTTPPort is the default port for MultiOrch HTTP traffic.
 	DefaultMultiOrchHTTPPort int32 = 15300
 


### PR DESCRIPTION
- Use /live instead of /ready for multipooler Startup and Readiness probes.
- Provide --http-port=15400 to pgctld and configure Liveness and Readiness probes to /live.
- Update multigres and pgctld container image SHAs to include upstream changes.

Reflects upstream commit 309da86 that added the new endpoint.