### PR TITLE
  fix(operator): handle native sidecar crashes and malformed backup IDs

### DIFF
--- a/pkg/data-handler/backuphealth/backuphealth.go
+++ b/pkg/data-handler/backuphealth/backuphealth.go
@@ -17,6 +17,7 @@ import (
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
 	"github.com/numtide/multigres-operator/pkg/data-handler/topo"
 	"github.com/numtide/multigres-operator/pkg/monitoring"
+	"github.com/numtide/multigres-operator/pkg/util/metadata"
 	"github.com/numtide/multigres-operator/pkg/util/status"
 )
 
@@ -110,11 +111,18 @@ func EvaluateBackups(
 		}
 	}
 
-	now := time.Now()
 	backupTime := ParseBackupTime(latest.BackupId)
+	if backupTime.IsZero() {
+		return &Result{
+			Healthy: false,
+			Message: fmt.Sprintf("Failed to parse backup timestamp from ID %q", latest.BackupId),
+		}
+	}
+
+	now := time.Now()
 	age := now.Sub(backupTime)
 
-	clusterName := shard.Labels["multigres.com/cluster"]
+	clusterName := shard.Labels[metadata.LabelMultigresCluster]
 	monitoring.SetLastBackupAge(clusterName, shard.Name, shard.Namespace, age)
 
 	result := &Result{

--- a/pkg/data-handler/backuphealth/backuphealth_test.go
+++ b/pkg/data-handler/backuphealth/backuphealth_test.go
@@ -250,3 +250,31 @@ func TestParseBackupTime_InvalidFormat(t *testing.T) {
 		t.Errorf("expected zero time for invalid format, got %v", got)
 	}
 }
+
+func TestEvaluateBackups_MalformedBackupID(t *testing.T) {
+	t.Parallel()
+
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-shard",
+			Namespace: "default",
+			Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+		},
+	}
+
+	backups := []*multipoolermanagerdata.BackupMetadata{
+		{
+			BackupId: "not-a-timestamp",
+			Status:   multipoolermanagerdata.BackupMetadata_COMPLETE,
+			Type:     "full",
+		},
+	}
+
+	result := backuphealth.EvaluateBackups(shard, backups)
+	if result.Healthy {
+		t.Error("expected unhealthy for malformed backup ID")
+	}
+	if result.LastBackupTime != nil {
+		t.Errorf("expected nil LastBackupTime, got %v", result.LastBackupTime)
+	}
+}

--- a/pkg/util/status/phase.go
+++ b/pkg/util/status/phase.go
@@ -18,6 +18,7 @@ package status
 
 import (
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -45,19 +46,21 @@ const crashLoopRestartThreshold int32 = 3
 //   - in CrashLoopBackOff, OOMKilled, or ImagePullBackOff waiting state, OR
 //   - terminated with repeated restarts (catches the gap between backoff
 //     restarts when the container is in Completed/Error state).
+//
+// Both regular containers and init containers (native sidecars) are checked.
 func IsCrashLooping(pod *corev1.Pod) bool {
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting != nil {
-			switch cs.State.Waiting.Reason {
-			case "CrashLoopBackOff", "OOMKilled", "ImagePullBackOff":
-				return true
-			}
-		}
-		if cs.State.Terminated != nil && cs.RestartCount >= crashLoopRestartThreshold {
+	return slices.ContainsFunc(pod.Status.ContainerStatuses, isContainerCrashLooping) ||
+		slices.ContainsFunc(pod.Status.InitContainerStatuses, isContainerCrashLooping)
+}
+
+func isContainerCrashLooping(cs corev1.ContainerStatus) bool {
+	if cs.State.Waiting != nil {
+		switch cs.State.Waiting.Reason {
+		case "CrashLoopBackOff", "OOMKilled", "ImagePullBackOff":
 			return true
 		}
 	}
-	return false
+	return cs.State.Terminated != nil && cs.RestartCount >= crashLoopRestartThreshold
 }
 
 // AnyCrashLooping returns true if any non-terminating pod in the slice

--- a/pkg/util/status/phase_test.go
+++ b/pkg/util/status/phase_test.go
@@ -149,6 +149,42 @@ func TestIsCrashLooping(t *testing.T) {
 			}}},
 			want: false,
 		},
+		{
+			name: "InitContainer_CrashLoopBackOff",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+						},
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "InitContainer_TerminatedHighRestarts",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						RestartCount: 5,
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{Reason: "Error"},
+						},
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "InitContainer_Running_NotFlagged",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{InitContainerStatuses: []corev1.ContainerStatus{
+					{State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				}},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/webhook/handlers/defaulter.go
+++ b/pkg/webhook/handlers/defaulter.go
@@ -112,10 +112,6 @@ func (d *MultigresClusterDefaulter) Default(ctx context.Context, obj runtime.Obj
 	{
 		hasInline := cluster.Spec.GlobalTopoServer != nil &&
 			cluster.Spec.GlobalTopoServer.TemplateRef != ""
-			// We also check if the user provided inline CONFIG (External or Etcd spec).
-			// If they provided config but no template, we might still want to merge defaults?
-			// User rule: "When NOT using templates, materialize whatever defaults".
-			// "Using templates" means Inline OR Global OR Implicit exists.
 
 		isUsingTemplate := hasInline || hasGlobalCore || hasImplicitCore
 


### PR DESCRIPTION
  IsCrashLooping only checked ContainerStatuses, missing crash-looping
  native sidecars (init containers with restartPolicy: Always) like
  multipooler. Separately, ParseBackupTime returning zero-time for
  malformed backup IDs caused ~56-year ages in Prometheus metrics and
  misleading BackupStale status conditions.

  - Extract isContainerCrashLooping helper, check both ContainerStatuses and InitContainerStatuses via slices.ContainsFunc
  - Guard EvaluateBackups against zero-time from ParseBackupTime before computing backup age
  - Replace hardcoded "multigres.com/cluster" label string with metadata.LabelMultigresCluster constant
  - Remove stale comments from defaulter.go hasInline check

  Crash-looping native sidecars now correctly surface as Degraded,
  and malformed backup IDs produce clear error messages instead of
  polluting metrics with bogus 492k-hour ages. Tests added for all
  three fixes.