### PR TITLE
fix(ci): handle tags on markdown-only commits

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -28,22 +28,37 @@ jobs:
             exit 1
           fi
 
-      - name: Verify main workflow passed
+      - name: Find latest build for this tag
+        id: find-build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Checking if 'Build main' workflow passed for commit ${{ github.sha }}..."
-          RESULT=$(gh run list \
-            --commit ${{ github.sha }} \
-            --workflow main.yaml \
-            --json conclusion \
-            --jq '.[0].conclusion')
+          echo "Finding the latest successful 'Build main' run that is an ancestor of ${{ github.sha }}..."
 
-          if [ "$RESULT" != "success" ]; then
-            echo "::error::Main workflow has not passed for this commit (status: ${RESULT:-not found})"
+          # Get the 10 most recent successful runs of main.yaml
+          RUNS=$(gh run list \
+            --workflow main.yaml \
+            --status success \
+            --branch main \
+            --limit 10 \
+            --json headSha \
+            --jq '.[].headSha')
+
+          BUILD_SHA=""
+          for SHA in $RUNS; do
+            if git merge-base --is-ancestor "$SHA" "${{ github.sha }}"; then
+              BUILD_SHA="$SHA"
+              break
+            fi
+          done
+
+          if [ -z "$BUILD_SHA" ]; then
+            echo "::error::No successful Build main run found that is an ancestor of ${{ github.sha }}"
             exit 1
           fi
-          echo "Main workflow passed ✅"
+
+          echo "Found build SHA: $BUILD_SHA"
+          echo "build_sha=$BUILD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Log into registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -58,13 +73,13 @@ jobs:
       - name: Retag existing image with version
         run: |
           IMAGE="ghcr.io/${{ github.repository }}"
-          SHA_TAG="${{ github.sha }}"
+          BUILD_SHA="${{ steps.find-build.outputs.build_sha }}"
           VERSION_TAG="${{ github.ref_name }}"
 
-          echo "Retagging $IMAGE:$SHA_TAG → $IMAGE:$VERSION_TAG"
+          echo "Retagging $IMAGE:$BUILD_SHA → $IMAGE:$VERSION_TAG"
           docker buildx imagetools create \
             --tag "$IMAGE:$VERSION_TAG" \
-            "$IMAGE:$SHA_TAG"
+            "$IMAGE:$BUILD_SHA"
 
       - name: Install Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0


### PR DESCRIPTION
The tag release workflow assumed the tagged commit itself had a successful Build main run and a container image. When tags land on markdown-only commits (skipped by main.yaml's paths-ignore), both the workflow check and the image retag fail.

- Replace exact-commit workflow check with ancestor walk that finds the most recent successful Build main run
- Use that run's SHA for the image retag instead of github.sha
- Query up to 10 recent runs and verify ancestry with git merge-base

Tags can now safely point to doc-only commits without breaking the release pipeline.