### PR TITLE
feat(toposerver): add health probes to etcd container

### DIFF
--- a/pkg/resource-handler/controller/toposerver/integration_test.go
+++ b/pkg/resource-handler/controller/toposerver/integration_test.go
@@ -139,6 +139,45 @@ func TestTopoServerReconciliation(t *testing.T) {
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: "data", MountPath: "/var/lib/etcd"},
 										},
+										StartupProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/readyz",
+													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+											TimeoutSeconds:   1,
+											PeriodSeconds:    5,
+											SuccessThreshold: 1,
+											FailureThreshold: 30,
+										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/livez",
+													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+											TimeoutSeconds:   1,
+											PeriodSeconds:    10,
+											SuccessThreshold: 1,
+											FailureThreshold: 3,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/readyz",
+													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+											TimeoutSeconds:   1,
+											PeriodSeconds:    5,
+											SuccessThreshold: 1,
+											FailureThreshold: 3,
+										},
 									},
 								},
 							},
@@ -274,6 +313,45 @@ func TestTopoServerReconciliation(t *testing.T) {
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{Name: "data", MountPath: "/var/lib/etcd"},
+										},
+										StartupProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/readyz",
+													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+											TimeoutSeconds:   1,
+											PeriodSeconds:    5,
+											SuccessThreshold: 1,
+											FailureThreshold: 30,
+										},
+										LivenessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/livez",
+													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+											TimeoutSeconds:   1,
+											PeriodSeconds:    10,
+											SuccessThreshold: 1,
+											FailureThreshold: 3,
+										},
+										ReadinessProbe: &corev1.Probe{
+											ProbeHandler: corev1.ProbeHandler{
+												HTTPGet: &corev1.HTTPGetAction{
+													Path:   "/readyz",
+													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Scheme: corev1.URISchemeHTTP,
+												},
+											},
+											TimeoutSeconds:   1,
+											PeriodSeconds:    5,
+											SuccessThreshold: 1,
+											FailureThreshold: 3,
 										},
 									},
 								},

--- a/pkg/resource-handler/controller/toposerver/statefulset.go
+++ b/pkg/resource-handler/controller/toposerver/statefulset.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
@@ -99,6 +100,34 @@ func BuildStatefulSet(
 									Name:      DataVolumeName,
 									MountPath: DataMountPath,
 								},
+							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/readyz",
+										Port: intstr.FromInt32(ClientPort),
+									},
+								},
+								PeriodSeconds:    5,
+								FailureThreshold: 30,
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/livez",
+										Port: intstr.FromInt32(ClientPort),
+									},
+								},
+								PeriodSeconds: 10,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/readyz",
+										Port: intstr.FromInt32(ClientPort),
+									},
+								},
+								PeriodSeconds: 5,
 							},
 						},
 					},

--- a/pkg/resource-handler/controller/toposerver/statefulset_test.go
+++ b/pkg/resource-handler/controller/toposerver/statefulset_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/numtide/multigres-operator/api/v1alpha1"
@@ -105,6 +106,34 @@ func TestBuildStatefulSet(t *testing.T) {
 											Name:      DataVolumeName,
 											MountPath: DataMountPath,
 										},
+									},
+									StartupProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/readyz",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds:    5,
+										FailureThreshold: 30,
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/livez",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds: 10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/readyz",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds: 5,
 									},
 								},
 							},
@@ -218,6 +247,34 @@ func TestBuildStatefulSet(t *testing.T) {
 											Name:      DataVolumeName,
 											MountPath: DataMountPath,
 										},
+									},
+									StartupProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/readyz",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds:    5,
+										FailureThreshold: 30,
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/livez",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds: 10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/readyz",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds: 5,
 									},
 								},
 							},
@@ -333,6 +390,34 @@ func TestBuildStatefulSet(t *testing.T) {
 											Name:      DataVolumeName,
 											MountPath: DataMountPath,
 										},
+									},
+									StartupProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/readyz",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds:    5,
+										FailureThreshold: 30,
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/livez",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds: 10,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/readyz",
+												Port: intstr.FromInt32(ClientPort),
+											},
+										},
+										PeriodSeconds: 5,
 									},
 								},
 							},


### PR DESCRIPTION
The etcd StatefulSet had no health probes, meaning Kubernetes could not detect or recover from unhealthy etcd members automatically.

- Add startup probe on /readyz with 30 failure threshold to accommodate initial cluster bootstrap and WAL replay
- Add liveness probe on /livez to trigger container restart on process-level failures
- Add readiness probe on /readyz to remove unready members from service endpoints
- All probes use HTTP GET on the etcd client port (2379)
- Update unit and integration tests with probe expectations

Kubernetes can now detect and recover from unhealthy etcd members, preventing silent topology store outages.