### PR TITLE
fix(toposerver): align etcd readiness with multigres

### DIFF
--- a/pkg/resource-handler/controller/toposerver/container_env.go
+++ b/pkg/resource-handler/controller/toposerver/container_env.go
@@ -82,6 +82,10 @@ func buildEtcdConfigEnv(toposerverName, serviceName, namespace string) []corev1.
 			Value: "http://[::]:2380",
 		},
 		{
+			Name:  "ETCD_LISTEN_METRICS_URLS",
+			Value: "http://[::]:2381",
+		},
+		{
 			Name: "ETCD_ADVERTISE_CLIENT_URLS",
 			Value: fmt.Sprintf(
 				"http://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2379",

--- a/pkg/resource-handler/controller/toposerver/container_env_test.go
+++ b/pkg/resource-handler/controller/toposerver/container_env_test.go
@@ -50,6 +50,7 @@ func TestBuildEtcdConfigEnv(t *testing.T) {
 				{Name: "ETCD_DATA_DIR", Value: "/var/lib/etcd"},
 				{Name: "ETCD_LISTEN_CLIENT_URLS", Value: "http://[::]:2379"},
 				{Name: "ETCD_LISTEN_PEER_URLS", Value: "http://[::]:2380"},
+				{Name: "ETCD_LISTEN_METRICS_URLS", Value: "http://[::]:2381"},
 				{
 					Name:  "ETCD_ADVERTISE_CLIENT_URLS",
 					Value: "http://$(POD_NAME).my-toposerver-headless.$(POD_NAMESPACE).svc.cluster.local:2379",
@@ -71,6 +72,7 @@ func TestBuildEtcdConfigEnv(t *testing.T) {
 				{Name: "ETCD_DATA_DIR", Value: "/var/lib/etcd"},
 				{Name: "ETCD_LISTEN_CLIENT_URLS", Value: "http://[::]:2379"},
 				{Name: "ETCD_LISTEN_PEER_URLS", Value: "http://[::]:2380"},
+				{Name: "ETCD_LISTEN_METRICS_URLS", Value: "http://[::]:2381"},
 				{
 					Name:  "ETCD_ADVERTISE_CLIENT_URLS",
 					Value: "http://$(POD_NAME).test-toposerver-headless.$(POD_NAMESPACE).svc.cluster.local:2379",
@@ -92,6 +94,7 @@ func TestBuildEtcdConfigEnv(t *testing.T) {
 				{Name: "ETCD_DATA_DIR", Value: "/var/lib/etcd"},
 				{Name: "ETCD_LISTEN_CLIENT_URLS", Value: "http://[::]:2379"},
 				{Name: "ETCD_LISTEN_PEER_URLS", Value: "http://[::]:2380"},
+				{Name: "ETCD_LISTEN_METRICS_URLS", Value: "http://[::]:2381"},
 				{
 					Name:  "ETCD_ADVERTISE_CLIENT_URLS",
 					Value: "http://$(POD_NAME).very-long-toposerver-cluster-name-headless.$(POD_NAMESPACE).svc.cluster.local:2379",
@@ -217,6 +220,7 @@ func TestBuildContainerEnv(t *testing.T) {
 				{Name: "ETCD_DATA_DIR", Value: "/var/lib/etcd"},
 				{Name: "ETCD_LISTEN_CLIENT_URLS", Value: "http://[::]:2379"},
 				{Name: "ETCD_LISTEN_PEER_URLS", Value: "http://[::]:2380"},
+				{Name: "ETCD_LISTEN_METRICS_URLS", Value: "http://[::]:2381"},
 				{
 					Name:  "ETCD_ADVERTISE_CLIENT_URLS",
 					Value: "http://$(POD_NAME).my-toposerver-headless.$(POD_NAMESPACE).svc.cluster.local:2379",
@@ -259,6 +263,7 @@ func TestBuildContainerEnv(t *testing.T) {
 				{Name: "ETCD_DATA_DIR", Value: "/var/lib/etcd"},
 				{Name: "ETCD_LISTEN_CLIENT_URLS", Value: "http://[::]:2379"},
 				{Name: "ETCD_LISTEN_PEER_URLS", Value: "http://[::]:2380"},
+				{Name: "ETCD_LISTEN_METRICS_URLS", Value: "http://[::]:2381"},
 				{
 					Name:  "ETCD_ADVERTISE_CLIENT_URLS",
 					Value: "http://$(POD_NAME).test-toposerver-headless.$(POD_NAMESPACE).svc.cluster.local:2379",
@@ -303,6 +308,7 @@ func TestBuildContainerEnv(t *testing.T) {
 				{Name: "ETCD_DATA_DIR", Value: "/var/lib/etcd"},
 				{Name: "ETCD_LISTEN_CLIENT_URLS", Value: "http://[::]:2379"},
 				{Name: "ETCD_LISTEN_PEER_URLS", Value: "http://[::]:2380"},
+				{Name: "ETCD_LISTEN_METRICS_URLS", Value: "http://[::]:2381"},
 				{
 					Name:  "ETCD_ADVERTISE_CLIENT_URLS",
 					Value: "http://$(POD_NAME).empty-toposerver-headless.$(POD_NAMESPACE).svc.cluster.local:2379",

--- a/pkg/resource-handler/controller/toposerver/integration_test.go
+++ b/pkg/resource-handler/controller/toposerver/integration_test.go
@@ -132,6 +132,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 											{Name: "ETCD_DATA_DIR", Value: "/var/lib/etcd"},
 											{Name: "ETCD_LISTEN_CLIENT_URLS", Value: "http://[::]:2379"},
 											{Name: "ETCD_LISTEN_PEER_URLS", Value: "http://[::]:2380"},
+											{Name: "ETCD_LISTEN_METRICS_URLS", Value: "http://[::]:2381"},
 											{Name: "ETCD_ADVERTISE_CLIENT_URLS", Value: "http://$(POD_NAME).test-toposerver-headless.$(POD_NAMESPACE).svc.cluster.local:2379"},
 											{Name: "ETCD_INITIAL_ADVERTISE_PEER_URLS", Value: "http://$(POD_NAME).test-toposerver-headless.$(POD_NAMESPACE).svc.cluster.local:2380"},
 											{Name: "ETCD_INITIAL_CLUSTER_STATE", Value: "new"},
@@ -145,7 +146,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 											ProbeHandler: corev1.ProbeHandler{
 												HTTPGet: &corev1.HTTPGetAction{
 													Path:   "/readyz",
-													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Port:   intstr.FromInt32(toposervercontroller.MetricsPort),
 													Scheme: corev1.URISchemeHTTP,
 												},
 											},
@@ -158,7 +159,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 											ProbeHandler: corev1.ProbeHandler{
 												HTTPGet: &corev1.HTTPGetAction{
 													Path:   "/livez",
-													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Port:   intstr.FromInt32(toposervercontroller.MetricsPort),
 													Scheme: corev1.URISchemeHTTP,
 												},
 											},
@@ -171,7 +172,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 											ProbeHandler: corev1.ProbeHandler{
 												HTTPGet: &corev1.HTTPGetAction{
 													Path:   "/readyz",
-													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Port:   intstr.FromInt32(toposervercontroller.MetricsPort),
 													Scheme: corev1.URISchemeHTTP,
 												},
 											},
@@ -309,6 +310,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 											{Name: "ETCD_DATA_DIR", Value: "/var/lib/etcd"},
 											{Name: "ETCD_LISTEN_CLIENT_URLS", Value: "http://[::]:2379"},
 											{Name: "ETCD_LISTEN_PEER_URLS", Value: "http://[::]:2380"},
+											{Name: "ETCD_LISTEN_METRICS_URLS", Value: "http://[::]:2381"},
 											{Name: "ETCD_ADVERTISE_CLIENT_URLS", Value: "http://$(POD_NAME).delete-policy-topo-headless.$(POD_NAMESPACE).svc.cluster.local:2379"},
 											{Name: "ETCD_INITIAL_ADVERTISE_PEER_URLS", Value: "http://$(POD_NAME).delete-policy-topo-headless.$(POD_NAMESPACE).svc.cluster.local:2380"},
 											{Name: "ETCD_INITIAL_CLUSTER_STATE", Value: "new"},
@@ -322,7 +324,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 											ProbeHandler: corev1.ProbeHandler{
 												HTTPGet: &corev1.HTTPGetAction{
 													Path:   "/readyz",
-													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Port:   intstr.FromInt32(toposervercontroller.MetricsPort),
 													Scheme: corev1.URISchemeHTTP,
 												},
 											},
@@ -335,7 +337,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 											ProbeHandler: corev1.ProbeHandler{
 												HTTPGet: &corev1.HTTPGetAction{
 													Path:   "/livez",
-													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Port:   intstr.FromInt32(toposervercontroller.MetricsPort),
 													Scheme: corev1.URISchemeHTTP,
 												},
 											},
@@ -348,7 +350,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 											ProbeHandler: corev1.ProbeHandler{
 												HTTPGet: &corev1.HTTPGetAction{
 													Path:   "/readyz",
-													Port:   intstr.FromInt32(toposervercontroller.ClientPort),
+													Port:   intstr.FromInt32(toposervercontroller.MetricsPort),
 													Scheme: corev1.URISchemeHTTP,
 												},
 											},

--- a/pkg/resource-handler/controller/toposerver/integration_test.go
+++ b/pkg/resource-handler/controller/toposerver/integration_test.go
@@ -108,6 +108,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 										Ports: []corev1.ContainerPort{
 											tcpPort(t, "client", 2379),
 											tcpPort(t, "peer", 2380),
+											tcpPort(t, "metrics", 2381),
 										},
 										Env: []corev1.EnvVar{
 											{
@@ -286,6 +287,7 @@ func TestTopoServerReconciliation(t *testing.T) {
 										Ports: []corev1.ContainerPort{
 											tcpPort(t, "client", 2379),
 											tcpPort(t, "peer", 2380),
+											tcpPort(t, "metrics", 2381),
 										},
 										Env: []corev1.EnvVar{
 											{

--- a/pkg/resource-handler/controller/toposerver/ports.go
+++ b/pkg/resource-handler/controller/toposerver/ports.go
@@ -13,6 +13,9 @@ const (
 
 	// PeerPort is the default port for etcd peer connections.
 	PeerPort int32 = 2380
+
+	// MetricsPort is the default port for etcd metrics and health endpoints.
+	MetricsPort int32 = 2381
 )
 
 // buildContainerPorts creates the port definitions for the etcd container.
@@ -38,6 +41,11 @@ func buildContainerPorts(toposerver *multigresv1alpha1.TopoServer) []corev1.Cont
 		{
 			Name:          "peer",
 			ContainerPort: peerPort,
+			Protocol:      corev1.ProtocolTCP,
+		},
+		{
+			Name:          "metrics",
+			ContainerPort: MetricsPort,
 			Protocol:      corev1.ProtocolTCP,
 		},
 	}

--- a/pkg/resource-handler/controller/toposerver/ports_test.go
+++ b/pkg/resource-handler/controller/toposerver/ports_test.go
@@ -35,6 +35,11 @@ func TestBuildContainerPorts(t *testing.T) {
 					ContainerPort: 2380,
 					Protocol:      corev1.ProtocolTCP,
 				},
+				{
+					Name:          "metrics",
+					ContainerPort: 2381,
+					Protocol:      corev1.ProtocolTCP,
+				},
 			},
 		},
 	}

--- a/pkg/resource-handler/controller/toposerver/statefulset.go
+++ b/pkg/resource-handler/controller/toposerver/statefulset.go
@@ -105,7 +105,7 @@ func BuildStatefulSet(
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/readyz",
-										Port: intstr.FromInt32(ClientPort),
+										Port: intstr.FromInt32(MetricsPort),
 									},
 								},
 								PeriodSeconds:    5,
@@ -115,7 +115,7 @@ func BuildStatefulSet(
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/livez",
-										Port: intstr.FromInt32(ClientPort),
+										Port: intstr.FromInt32(MetricsPort),
 									},
 								},
 								PeriodSeconds: 10,
@@ -124,7 +124,7 @@ func BuildStatefulSet(
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/readyz",
-										Port: intstr.FromInt32(ClientPort),
+										Port: intstr.FromInt32(MetricsPort),
 									},
 								},
 								PeriodSeconds: 5,

--- a/pkg/resource-handler/controller/toposerver/statefulset_test.go
+++ b/pkg/resource-handler/controller/toposerver/statefulset_test.go
@@ -111,7 +111,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/readyz",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds:    5,
@@ -121,7 +121,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/livez",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds: 10,
@@ -130,7 +130,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/readyz",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds: 5,
@@ -252,7 +252,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/readyz",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds:    5,
@@ -262,7 +262,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/livez",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds: 10,
@@ -271,7 +271,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/readyz",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds: 5,
@@ -395,7 +395,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/readyz",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds:    5,
@@ -405,7 +405,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/livez",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds: 10,
@@ -414,7 +414,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										ProbeHandler: corev1.ProbeHandler{
 											HTTPGet: &corev1.HTTPGetAction{
 												Path: "/readyz",
-												Port: intstr.FromInt32(ClientPort),
+												Port: intstr.FromInt32(MetricsPort),
 											},
 										},
 										PeriodSeconds: 5,


### PR DESCRIPTION
## Description

This pr updates the operator’s etcd setup to match the readiness model now used in multigres.

`multigres` now starts etcd with a dedicated metrics listener and expects `/readyz` and `/livez` to be served from that endpoint. This change brings the operator in line with that behaviour by configuring the metrics listener on the etcd container and pointing the probes at it.

## Changes

- add etcd metrics port support to the toposerver container
- set `ETCD_LISTEN_METRICS_URLS` for operator-managed etcd
- move startup, readiness, and liveness probes to the metrics listener
- update unit and integration tests to match the new etcd readiness path

## Tests

- `go test ./pkg/resource-handler/controller/toposerver/...`

## Related Issues or PRs

- related multigres change: https://github.com/multigres/multigres/pull/775
