### PR TITLE
fix(shard,poolspec): remove hardcoded UID/GID and make pool fsGroup explicit

### DIFF
--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -103,6 +103,12 @@ type PoolSpec struct {
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
+	// FSGroup sets the pod-level fsGroup for shared volume and socket access across
+	// pool containers. When unset, runtime defaults apply.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	FSGroup *int64 `json:"fsGroup,omitempty"`
+
 	// PVCDeletionPolicy controls PVC lifecycle for this pool.
 	// Overrides Shard, TableGroup, and MultigresCluster settings.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1111,6 +1111,11 @@ func (in *PoolSpec) DeepCopyInto(out *PoolSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.FSGroup != nil {
+		in, out := &in.FSGroup, &out.FSGroup
+		*out = new(int64)
+		**out = **in
+	}
 	if in.PVCDeletionPolicy != nil {
 		in, out := &in.PVCDeletionPolicy, &out.PVCDeletionPolicy
 		*out = new(PVCDeletionPolicy)

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -5128,6 +5128,14 @@ spec:
                                             - message: Cells cannot be removed from
                                                 a pool (Append-Only)
                                               rule: oldSelf.all(c, c in self)
+                                          fsGroup:
+                                            description: |-
+                                              FSGroup sets the pod-level fsGroup for shared volume and socket access across
+                                              pool containers. When unset, the operator does not set pod fsGroup and runtime
+                                              defaults apply.
+                                            format: int64
+                                            minimum: 1
+                                            type: integer
                                           multipooler:
                                             description: Multipooler container configuration.
                                             properties:
@@ -7567,6 +7575,14 @@ spec:
                                             - message: Cells cannot be removed from
                                                 a pool (Append-Only)
                                               rule: oldSelf.all(c, c in self)
+                                          fsGroup:
+                                            description: |-
+                                              FSGroup sets the pod-level fsGroup for shared volume and socket access across
+                                              pool containers. When unset, the operator does not set pod fsGroup and runtime
+                                              defaults apply.
+                                            format: int64
+                                            minimum: 1
+                                            type: integer
                                           multipooler:
                                             description: Multipooler container configuration.
                                             properties:

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -2425,6 +2425,14 @@ spec:
                       x-kubernetes-validations:
                       - message: Cells cannot be removed from a pool (Append-Only)
                         rule: oldSelf.all(c, c in self)
+                    fsGroup:
+                      description: |-
+                        FSGroup sets the pod-level fsGroup for shared volume and socket access across
+                        pool containers. When unset, the operator does not set pod fsGroup and runtime
+                        defaults apply.
+                      format: int64
+                      minimum: 1
+                      type: integer
                     multipooler:
                       description: Multipooler container configuration.
                       properties:

--- a/config/crd/bases/multigres.com_shardtemplates.yaml
+++ b/config/crd/bases/multigres.com_shardtemplates.yaml
@@ -2059,6 +2059,14 @@ spec:
                       x-kubernetes-validations:
                       - message: Cells cannot be removed from a pool (Append-Only)
                         rule: oldSelf.all(c, c in self)
+                    fsGroup:
+                      description: |-
+                        FSGroup sets the pod-level fsGroup for shared volume and socket access across
+                        pool containers. When unset, the operator does not set pod fsGroup and runtime
+                        defaults apply.
+                      format: int64
+                      minimum: 1
+                      type: integer
                     multipooler:
                       description: Multipooler container configuration.
                       properties:

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -2589,6 +2589,14 @@ spec:
                             x-kubernetes-validations:
                             - message: Cells cannot be removed from a pool (Append-Only)
                               rule: oldSelf.all(c, c in self)
+                          fsGroup:
+                            description: |-
+                              FSGroup sets the pod-level fsGroup for shared volume and socket access across
+                              pool containers. When unset, the operator does not set pod fsGroup and runtime
+                              defaults apply.
+                            format: int64
+                            minimum: 1
+                            type: integer
                           multipooler:
                             description: Multipooler container configuration.
                             properties:

--- a/pkg/resolver/shard.go
+++ b/pkg/resolver/shard.go
@@ -257,6 +257,9 @@ func mergePoolSpec(
 	if len(override.Tolerations) > 0 {
 		out.Tolerations = append([]corev1.Toleration(nil), override.Tolerations...)
 	}
+	if override.FSGroup != nil {
+		out.FSGroup = override.FSGroup
+	}
 	if override.PVCDeletionPolicy != nil {
 		out.PVCDeletionPolicy = override.PVCDeletionPolicy
 	}

--- a/pkg/resolver/shard_test.go
+++ b/pkg/resolver/shard_test.go
@@ -93,6 +93,39 @@ func TestResolver_ResolveShard(t *testing.T) {
 				},
 			},
 		},
+		"Inline Pool FSGroup": {
+			config: &multigresv1alpha1.ShardConfig{
+				Spec: &multigresv1alpha1.ShardInlineSpec{
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"p": {FSGroup: ptr.To(int64(1234))},
+					},
+				},
+			},
+			wantOrch: &multigresv1alpha1.MultiOrchSpec{
+				StatelessSpec: multigresv1alpha1.StatelessSpec{
+					Replicas:  ptr.To(int32(1)),
+					Resources: DefaultResourcesOrch(),
+				},
+			},
+			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"p": {
+					ReplicasPerCell: ptr.To(int32(3)),
+					FSGroup:         ptr.To(int64(1234)),
+					Storage: multigresv1alpha1.StorageSpec{
+						Size: DefaultEtcdStorageSize,
+					},
+					Postgres: multigresv1alpha1.ContainerConfig{
+						Resources: DefaultResourcesPostgres(),
+					},
+					Multipooler: multigresv1alpha1.ContainerConfig{
+						Resources: DefaultResourcesPooler(),
+					},
+				},
+			},
+		},
 		"Dynamic Cell Injection": {
 			config: &multigresv1alpha1.ShardConfig{
 				Spec: &multigresv1alpha1.ShardInlineSpec{

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -216,8 +216,6 @@ func buildPgctldContainer(
 		Resources: pool.Postgres.Resources,
 		Env:       env,
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:    ptr.To(int64(999)),
-			RunAsGroup:   ptr.To(int64(999)),
 			RunAsNonRoot: ptr.To(true),
 		},
 		VolumeMounts: volumeMounts,
@@ -312,8 +310,6 @@ func buildMultiPoolerSidecar(
 		Resources:     pool.Multipooler.Resources,
 		RestartPolicy: &sidecarRestartPolicy,
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:    ptr.To(int64(999)), // Must match postgres UID to access pg_data directory
-			RunAsGroup:   ptr.To(int64(999)),
 			RunAsNonRoot: ptr.To(true),
 		},
 		StartupProbe: &corev1.Probe{

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -73,8 +73,6 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				Resources:     corev1.ResourceRequirements{},
 				RestartPolicy: &sidecarRestartPolicy,
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:    ptr.To(int64(999)),
-					RunAsGroup:   ptr.To(int64(999)),
 					RunAsNonRoot: ptr.To(true),
 				},
 				StartupProbe: &corev1.Probe{
@@ -178,8 +176,6 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				Resources:     corev1.ResourceRequirements{},
 				RestartPolicy: &sidecarRestartPolicy,
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:    ptr.To(int64(999)),
-					RunAsGroup:   ptr.To(int64(999)),
 					RunAsNonRoot: ptr.To(true),
 				},
 				StartupProbe: &corev1.Probe{
@@ -301,8 +297,6 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 				},
 				RestartPolicy: &sidecarRestartPolicy,
 				SecurityContext: &corev1.SecurityContext{
-					RunAsUser:    ptr.To(int64(999)),
-					RunAsGroup:   ptr.To(int64(999)),
 					RunAsNonRoot: ptr.To(true),
 				},
 				StartupProbe: &corev1.Probe{

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -89,9 +89,7 @@ func BuildPoolPod(
 			Annotations: annotations,
 		},
 		Spec: corev1.PodSpec{
-			SecurityContext: &corev1.PodSecurityContext{
-				FSGroup: ptr.To(int64(999)), // postgres group in postgres:17 image
-			},
+			SecurityContext:               buildPoolPodSecurityContext(poolSpec),
 			TerminationGracePeriodSeconds: ptr.To(defaultTerminationGracePeriod),
 			InitContainers: []corev1.Container{
 				buildMultiPoolerSidecar(shard, poolSpec, poolName, cellName, serviceID),
@@ -122,6 +120,17 @@ func BuildPoolPod(
 	}
 
 	return pod, nil
+}
+
+func buildPoolPodSecurityContext(poolSpec multigresv1alpha1.PoolSpec) *corev1.PodSecurityContext {
+	if poolSpec.FSGroup == nil {
+		return nil
+	}
+
+	fsGroup := *poolSpec.FSGroup
+	return &corev1.PodSecurityContext{
+		FSGroup: &fsGroup,
+	}
 }
 
 // buildHeadlessServiceName constructs the headless service name for DNS
@@ -187,6 +196,12 @@ func ComputeSpecHash(pod *corev1.Pod) string {
 
 	if spec.ServiceAccountName != "" {
 		_, _ = fmt.Fprintf(h, "sa=%s", spec.ServiceAccountName)
+	}
+
+	if spec.SecurityContext != nil {
+		if b, err := json.Marshal(spec.SecurityContext); err == nil {
+			_, _ = fmt.Fprintf(h, "podsc=%s", b)
+		}
 	}
 
 	if v := pod.Annotations[metadata.AnnotationPostgresConfigHash]; v != "" {

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
@@ -151,11 +152,8 @@ func TestBuildPoolPod_SecurityContext(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if pod.Spec.SecurityContext == nil {
-		t.Fatal("pod security context is nil")
-	}
-	if pod.Spec.SecurityContext.FSGroup == nil || *pod.Spec.SecurityContext.FSGroup != 999 {
-		t.Error("FSGroup should be 999 (postgres group)")
+	if pod.Spec.SecurityContext != nil {
+		t.Errorf("pod security context = %v, want nil when fsGroup is not configured", pod.Spec.SecurityContext)
 	}
 
 	if pod.Spec.TerminationGracePeriodSeconds == nil ||
@@ -164,6 +162,23 @@ func TestBuildPoolPod_SecurityContext(t *testing.T) {
 			"terminationGracePeriodSeconds = %v, want 30",
 			pod.Spec.TerminationGracePeriodSeconds,
 		)
+	}
+}
+
+func TestBuildPoolPod_SecurityContextWithFSGroup(t *testing.T) {
+	pool := newTestPoolSpec()
+	pool.FSGroup = ptr.To(int64(1234))
+
+	pod, err := BuildPoolPod(newTestShard(), "main", "z1", pool, 0, testScheme())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if pod.Spec.SecurityContext == nil {
+		t.Fatal("pod security context is nil")
+	}
+	if pod.Spec.SecurityContext.FSGroup == nil || *pod.Spec.SecurityContext.FSGroup != 1234 {
+		t.Errorf("FSGroup = %v, want 1234", pod.Spec.SecurityContext.FSGroup)
 	}
 }
 
@@ -271,6 +286,22 @@ func TestComputeSpecHash_ChangesOnTolerations(t *testing.T) {
 
 	if hash1 == hash2 {
 		t.Error("spec hash should differ when tolerations change")
+	}
+}
+
+func TestComputeSpecHash_ChangesOnFSGroup(t *testing.T) {
+	pool1 := newTestPoolSpec()
+	pod1, _ := BuildPoolPod(newTestShard(), "main", "z1", pool1, 0, testScheme())
+
+	pool2 := newTestPoolSpec()
+	pool2.FSGroup = ptr.To(int64(1234))
+	pod2, _ := BuildPoolPod(newTestShard(), "main", "z1", pool2, 0, testScheme())
+
+	hash1 := ComputeSpecHash(pod1)
+	hash2 := ComputeSpecHash(pod2)
+
+	if hash1 == hash2 {
+		t.Error("spec hash should differ when fsGroup changes")
 	}
 }
 

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -153,7 +153,10 @@ func TestBuildPoolPod_SecurityContext(t *testing.T) {
 	}
 
 	if pod.Spec.SecurityContext != nil {
-		t.Errorf("pod security context = %v, want nil when fsGroup is not configured", pod.Spec.SecurityContext)
+		t.Errorf(
+			"pod security context = %v, want nil when fsGroup is not configured",
+			pod.Spec.SecurityContext,
+		)
 	}
 
 	if pod.Spec.TerminationGracePeriodSeconds == nil ||


### PR DESCRIPTION
## Description

this pr removes hardcoded container UID/GID assumptions from shard pool pods and replaces the remaining permission dependency with explicit, API-level configuration.

The original incompatibility was that postgres and multipooler containers were forced to run as UID/GID `999`, which does not hold for all image variants (e.g. alpine-based postgres images). With this change, container identity is derived from the image runtime user (`USER postgres`) while still enforcing non-root execution.

While implementing this, we found two correctness gaps that became relevant once `fsGroup` stopped being hardcoded in controller code. First, `fsGroup` needed to propagate through resolver merge paths (template/override/inline). Second, pod-level security context was not included in the pool pod spec hash, which could prevent expected rolling updates when security context changes. Both were fixed in this PR.

## Changes

- Removed fixed container UID/GID in shard pool containers and kept non-root enforcement.
- Replaced fixed pod `fsGroup` behavior with explicit per-pool configuration.
- Closed the propagation and rollout-safety gaps discovered during implementation (`fsGroup` merge flow + pod security context hashing).

## Tests

Regenerated the API-generated artifacts (deepcopy and CRD schemas) to keep code and schema in sync with the new pool `fsGroup` field. Also added and updated unit tests to cover the new security-context contract, resolver propagation behaviour, and spec-hash behaviour when `fsGroup` changes. 