### PR TITLE
fix(shard): derive container RunAsUser from pool fsGroup

### DIFF
--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -208,14 +208,14 @@ func buildPgctldContainer(
 	}
 
 	return corev1.Container{
-		Name:      "postgres",
-		Image:     image,
-		Command:   []string{"/usr/local/bin/pgctld"},
-		Args:      args,
-		Resources: pool.Postgres.Resources,
-		Env:       env,
+		Name:            "postgres",
+		Image:           image,
+		Command:         []string{"/usr/local/bin/pgctld"},
+		Args:            args,
+		Resources:       pool.Postgres.Resources,
+		Env:             env,
 		SecurityContext: buildContainerSecurityContext(pool.FSGroup),
-		VolumeMounts: volumeMounts,
+		VolumeMounts:    volumeMounts,
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
@@ -300,13 +300,13 @@ func buildMultiPoolerSidecar(
 	}
 
 	c := corev1.Container{
-		Name:          "multipooler",
-		Image:         image,
-		Args:          args,
-		Ports:         buildMultiPoolerContainerPorts(),
-		Resources:        pool.Multipooler.Resources,
-		RestartPolicy:    &sidecarRestartPolicy,
-		SecurityContext:  buildContainerSecurityContext(pool.FSGroup),
+		Name:            "multipooler",
+		Image:           image,
+		Args:            args,
+		Ports:           buildMultiPoolerContainerPorts(),
+		Resources:       pool.Multipooler.Resources,
+		RestartPolicy:   &sidecarRestartPolicy,
+		SecurityContext: buildContainerSecurityContext(pool.FSGroup),
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
@@ -662,5 +662,3 @@ func s3EnvVars(backup *multigresv1alpha1.BackupConfig) []corev1.EnvVar {
 
 	return envs
 }
-
-

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -5,7 +5,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	nameutil "github.com/multigres/multigres-operator/pkg/util/name"
@@ -215,9 +214,7 @@ func buildPgctldContainer(
 		Args:      args,
 		Resources: pool.Postgres.Resources,
 		Env:       env,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot: ptr.To(true),
-		},
+		SecurityContext: buildContainerSecurityContext(pool.FSGroup),
 		VolumeMounts: volumeMounts,
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -307,11 +304,9 @@ func buildMultiPoolerSidecar(
 		Image:         image,
 		Args:          args,
 		Ports:         buildMultiPoolerContainerPorts(),
-		Resources:     pool.Multipooler.Resources,
-		RestartPolicy: &sidecarRestartPolicy,
-		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot: ptr.To(true),
-		},
+		Resources:        pool.Multipooler.Resources,
+		RestartPolicy:    &sidecarRestartPolicy,
+		SecurityContext:  buildContainerSecurityContext(pool.FSGroup),
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
@@ -667,3 +662,5 @@ func s3EnvVars(backup *multigresv1alpha1.BackupConfig) []corev1.EnvVar {
 
 	return envs
 }
+
+

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -133,6 +133,20 @@ func buildPoolPodSecurityContext(poolSpec multigresv1alpha1.PoolSpec) *corev1.Po
 	}
 }
 
+// buildContainerSecurityContext returns a non-root SecurityContext. When fsGroup
+// is set, RunAsUser and RunAsGroup are pinned to that value so all containers
+// in the pod share the same filesystem identity on shared volumes.
+func buildContainerSecurityContext(fsGroup *int64) *corev1.SecurityContext {
+	sc := &corev1.SecurityContext{
+		RunAsNonRoot: ptr.To(true),
+	}
+	if fsGroup != nil {
+		sc.RunAsUser = fsGroup
+		sc.RunAsGroup = fsGroup
+	}
+	return sc
+}
+
 // buildHeadlessServiceName constructs the headless service name for DNS
 // resolution. Matches the naming used by pool_service.go.
 func buildHeadlessServiceName(shard *multigresv1alpha1.Shard, poolName, cellName string) string {

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -183,6 +184,29 @@ func TestBuildPoolPod_SecurityContextWithFSGroup(t *testing.T) {
 	if pod.Spec.SecurityContext.FSGroup == nil || *pod.Spec.SecurityContext.FSGroup != 1234 {
 		t.Errorf("FSGroup = %v, want 1234", pod.Spec.SecurityContext.FSGroup)
 	}
+}
+
+func TestBuildContainerSecurityContext(t *testing.T) {
+	t.Run("nil fsGroup", func(t *testing.T) {
+		sc := buildContainerSecurityContext(nil)
+		assert.True(t, *sc.RunAsNonRoot)
+		assert.Nil(t, sc.RunAsUser)
+		assert.Nil(t, sc.RunAsGroup)
+	})
+
+	t.Run("with fsGroup", func(t *testing.T) {
+		sc := buildContainerSecurityContext(ptr.To(int64(999)))
+		assert.True(t, *sc.RunAsNonRoot)
+		assert.Equal(t, int64(999), *sc.RunAsUser)
+		assert.Equal(t, int64(999), *sc.RunAsGroup)
+	})
+
+	t.Run("alpine fsGroup", func(t *testing.T) {
+		sc := buildContainerSecurityContext(ptr.To(int64(70)))
+		assert.True(t, *sc.RunAsNonRoot)
+		assert.Equal(t, int64(70), *sc.RunAsUser)
+		assert.Equal(t, int64(70), *sc.RunAsGroup)
+	})
 }
 
 func TestBuildPoolPod_SpecHash(t *testing.T) {


### PR DESCRIPTION
## Description

this pr fixes the regression introduced on #452:  multipooler (multigres image, UID 65532) and pgctld (pgctld image, UID 999) now run as different UIDs and can't share the data volume.

This fix derives `RunAsUser` and `RunAsGroup` from the pool's `fsGroup` value when set, so all containers in the pod share the same filesystem identity. When `fsGroup` is unset, image defaults still apply (preserving the PR #452 goal of no hardcoded UID).

## Changes

- Extracted `buildContainerSecurityContext(fsGroup)` in `pool_pod.go`, used by both `buildMultiPoolerSidecar` and `buildPgctldContainer`.
- When `fsGroup` is set: `RunAsUser` and `RunAsGroup` are pinned to that value.
- When `fsGroup` is nil: only `RunAsNonRoot: true` is set (current behaviour).

## Tests

- Added `TestBuildContainerSecurityContext` covering nil, debian (999), and alpine (70) fsGroup values.
- Existing `TestBuildPoolPod_SecurityContext*` and `TestBuildMultiPoolerSidecar` tests pass unchanged.

## Related 
#452 


