### PR TITLE
refactor(shard,toposerver): split status updates into owner-scoped SSA patches

### DIFF
--- a/api/v1alpha1/toposerver_types.go
+++ b/api/v1alpha1/toposerver_types.go
@@ -30,6 +30,7 @@ import (
 // +kubebuilder:rbac:groups=multigres.com,resources=toposervers/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get
 
 // ============================================================================
 // TopoServer Spec (Read-only API)

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/testutil"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -645,6 +645,7 @@ func TestReconcile_PostgresSecretError(t *testing.T) {
 	baseClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(shard).
+		WithStatusSubresource(&multigresv1alpha1.Shard{}).
 		Build()
 
 	// Fail on the second Patch (1st=pg_hba ConfigMap, 2nd=postgres-password Secret).

--- a/pkg/resource-handler/controller/shard/status.go
+++ b/pkg/resource-handler/controller/shard/status.go
@@ -73,7 +73,16 @@ func (r *ShardReconciler) updateStatus(
 
 	shard.Status.ObservedGeneration = shard.Generation
 
-	// 1. Construct the Patch Object
+	// Filter conditions for the SSA patch. Each condition type must belong to
+	// exactly one SSA field manager
+	var patchConditions []metav1.Condition
+	for i := range shard.Status.Conditions {
+		if shard.Status.Conditions[i].Type == conditionStorageClassValid {
+			continue
+		}
+		patchConditions = append(patchConditions, shard.Status.Conditions[i])
+	}
+
 	patchObj := &multigresv1alpha1.Shard{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: multigresv1alpha1.GroupVersion.String(),
@@ -83,7 +92,19 @@ func (r *ShardReconciler) updateStatus(
 			Name:      shard.Name,
 			Namespace: shard.Namespace,
 		},
-		Status: shard.Status,
+		Status: multigresv1alpha1.ShardStatus{
+			Phase:              shard.Status.Phase,
+			Message:            shard.Status.Message,
+			ObservedGeneration: shard.Status.ObservedGeneration,
+			PoolsReady:         shard.Status.PoolsReady,
+			OrchReady:          shard.Status.OrchReady,
+			ReadyReplicas:      shard.Status.ReadyReplicas,
+			Cells:              shard.Status.Cells,
+			Conditions:         patchConditions,
+			LastBackupTime:     shard.Status.LastBackupTime,
+			LastBackupType:     shard.Status.LastBackupType,
+			PodRoles:           shard.Status.PodRoles,
+		},
 	}
 
 	// 2. Apply the Patch

--- a/pkg/resource-handler/controller/shard/storage_class_guard.go
+++ b/pkg/resource-handler/controller/shard/storage_class_guard.go
@@ -159,29 +159,75 @@ func (r *ShardReconciler) validatePoolStorageClassDependencies(
 	return r.setStorageClassCondition(ctx, shard, metav1.ConditionTrue, reason, message)
 }
 
+// setStorageClassCondition patches the StorageClassValid condition using SSA.
+// Uses FieldOwner("multigres-resource-handler-guard") to avoid ownership conflicts
+// with updateStatus which uses FieldOwner("multigres-resource-handler").
+//
+// Reads the latest condition from the API server (not the in-memory shard) to
+// avoid false skips when the in-memory object is stale.
+// TODO: This stale-safe condition skip logic is mirrored in the TopoServer
+// guard; extract a shared helper to reduce duplication.
 func (r *ShardReconciler) setStorageClassCondition(
 	ctx context.Context,
 	shard *multigresv1alpha1.Shard,
-	status metav1.ConditionStatus,
+	condStatus metav1.ConditionStatus,
 	reason string,
 	message string,
 ) error {
+	// Read the latest from the API server so the skip-if-unchanged check
+	// compares against the real persisted state, not a potentially stale
+	// in-memory copy.
 	latest := &multigresv1alpha1.Shard{}
-	key := client.ObjectKeyFromObject(shard)
-	if err := r.Get(ctx, key, latest); err != nil {
-		return fmt.Errorf("failed to get Shard for StorageClass condition patch: %w", err)
+	if err := r.Get(ctx, client.ObjectKeyFromObject(shard), latest); err != nil {
+		return fmt.Errorf("failed to get Shard for StorageClass condition check: %w", err)
 	}
 
-	base := latest.DeepCopy()
-	meta.SetStatusCondition(&latest.Status.Conditions, metav1.Condition{
-		Type:               conditionStorageClassValid,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		ObservedGeneration: latest.Generation,
-	})
+	existing := meta.FindStatusCondition(latest.Status.Conditions, conditionStorageClassValid)
+	if existing != nil &&
+		existing.Status == condStatus &&
+		existing.Reason == reason &&
+		existing.Message == message &&
+		existing.ObservedGeneration == latest.Generation {
+		return nil
+	}
 
-	if err := r.Status().Patch(ctx, latest, client.MergeFrom(base)); err != nil {
+	// Preserve LastTransitionTime when the status hasn't transitioned,
+	// matching the behaviour of meta.SetStatusCondition.
+	now := metav1.Now()
+	if existing != nil && existing.Status == condStatus {
+		now = existing.LastTransitionTime
+	}
+
+	patchObj := &multigresv1alpha1.Shard{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: multigresv1alpha1.GroupVersion.String(),
+			Kind:       "Shard",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shard.Name,
+			Namespace: shard.Namespace,
+		},
+		Status: multigresv1alpha1.ShardStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               conditionStorageClassValid,
+					Status:             condStatus,
+					Reason:             reason,
+					Message:            message,
+					ObservedGeneration: latest.Generation,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+
+	if err := r.Status().Patch(
+		ctx,
+		patchObj,
+		client.Apply,
+		client.FieldOwner("multigres-resource-handler-guard"),
+		client.ForceOwnership,
+	); err != nil {
 		return fmt.Errorf("failed to patch Shard StorageClass condition: %w", err)
 	}
 

--- a/pkg/resource-handler/controller/shard/storage_class_guard_test.go
+++ b/pkg/resource-handler/controller/shard/storage_class_guard_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/testutil"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	"k8s.io/client-go/tools/record"
 )
@@ -296,4 +297,179 @@ func findCondition(conditions []metav1.Condition, conditionType string) *metav1.
 		}
 	}
 	return nil
+}
+
+func TestShardReconciler_FieldOwnershipIsolation(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = policyv1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
+
+	t.Run("updateStatus patch contains only Available condition", func(t *testing.T) {
+		t.Parallel()
+
+		shard := &multigresv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-field-owner",
+				Namespace: "default",
+				Labels: map[string]string{
+					metadata.LabelMultigresCluster: "test-cluster",
+				},
+			},
+			Spec: multigresv1alpha1.ShardSpec{
+				DatabaseName:   "testdb",
+				TableGroupName: "default",
+				MultiOrch: multigresv1alpha1.MultiOrchSpec{
+					Cells: []multigresv1alpha1.CellName{"zone1"},
+				},
+				Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+					"primary": {
+						Cells:           []multigresv1alpha1.CellName{"zone1"},
+						Type:            "readWrite",
+						Storage:         multigresv1alpha1.StorageSpec{Size: "10Gi"},
+						ReplicasPerCell: ptr.To(int32(1)),
+					},
+				},
+			},
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      BuildPoolPodName(shard, "primary", "zone1", 0),
+				Namespace: "default",
+				Labels: metadata.GetSelectorLabels(
+					buildPoolLabelsWithCell(shard, "primary", "zone1"),
+				),
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+
+		moName := buildHashedMultiOrchName(shard, "zone1")
+		mo := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: moName, Namespace: "default"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr.To(int32(1))},
+			Status:     appsv1.DeploymentStatus{Replicas: 1, ReadyReplicas: 1},
+		}
+
+		baseClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(shard, pod, mo).
+			WithStatusSubresource(shard, pod, mo).
+			Build()
+
+		var capturedPatchObj client.Object
+		fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
+			OnStatusPatch: func(obj client.Object) error {
+				capturedPatchObj = obj
+				return nil
+			},
+		})
+
+		r := &ShardReconciler{
+			Client:   fakeClient,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(100),
+		}
+
+		if err := r.updateStatus(t.Context(), shard); err != nil {
+			t.Fatalf("updateStatus: %v", err)
+		}
+
+		patchShard, ok := capturedPatchObj.(*multigresv1alpha1.Shard)
+		if !ok {
+			t.Fatalf("expected *Shard patch, got %T", capturedPatchObj)
+		}
+
+		for _, c := range patchShard.Status.Conditions {
+			if c.Type == conditionStorageClassValid {
+				t.Fatalf("updateStatus patch must not contain %s condition", conditionStorageClassValid)
+			}
+		}
+		availCond := findCondition(patchShard.Status.Conditions, "Available")
+		if availCond == nil {
+			t.Fatal("updateStatus patch must contain Available condition")
+		}
+	})
+
+	t.Run("guard patch contains only StorageClassValid condition and no other status fields", func(t *testing.T) {
+		t.Parallel()
+
+		shard := &multigresv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-field-owner-2",
+				Namespace: "default",
+			},
+			Spec: multigresv1alpha1.ShardSpec{
+				Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+					"primary": {
+						Storage: multigresv1alpha1.StorageSpec{
+							Size:  "10Gi",
+							Class: "fast-ssd",
+						},
+					},
+				},
+			},
+		}
+		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}}
+
+		baseClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(shard, sc).
+			WithStatusSubresource(&multigresv1alpha1.Shard{}).
+			Build()
+
+		var capturedPatchObj client.Object
+		fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
+			OnStatusPatch: func(obj client.Object) error {
+				capturedPatchObj = obj
+				return nil
+			},
+		})
+
+		r := &ShardReconciler{Client: fakeClient, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+		if err := r.validatePoolStorageClassDependencies(t.Context(), shard); err != nil {
+			t.Fatalf("guard: %v", err)
+		}
+
+		patchShard, ok := capturedPatchObj.(*multigresv1alpha1.Shard)
+		if !ok {
+			t.Fatalf("expected *Shard patch, got %T", capturedPatchObj)
+		}
+
+		// Exactly one condition: StorageClassValid.
+		if len(patchShard.Status.Conditions) != 1 {
+			t.Fatalf("guard patch must contain exactly 1 condition, got %d: %v",
+				len(patchShard.Status.Conditions), patchShard.Status.Conditions)
+		}
+		scCond := &patchShard.Status.Conditions[0]
+		if scCond.Type != conditionStorageClassValid {
+			t.Fatalf("expected %s condition, got %s", conditionStorageClassValid, scCond.Type)
+		}
+		if scCond.Status != metav1.ConditionTrue || scCond.Reason != storageClassFoundReason {
+			t.Fatalf("unexpected condition: status=%s reason=%s", scCond.Status, scCond.Reason)
+		}
+
+		// No other status fields should be set in the guard patch.
+		if patchShard.Status.Phase != "" {
+			t.Fatalf("guard patch must not set Phase, got %q", patchShard.Status.Phase)
+		}
+		if patchShard.Status.Message != "" {
+			t.Fatalf("guard patch must not set Message, got %q", patchShard.Status.Message)
+		}
+		if patchShard.Status.PodRoles != nil {
+			t.Fatal("guard patch must not set PodRoles")
+		}
+		if patchShard.Status.ReadyReplicas != 0 {
+			t.Fatalf("guard patch must not set ReadyReplicas, got %d", patchShard.Status.ReadyReplicas)
+		}
+	})
 }

--- a/pkg/resource-handler/controller/shard/storage_class_guard_test.go
+++ b/pkg/resource-handler/controller/shard/storage_class_guard_test.go
@@ -15,10 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"k8s.io/client-go/tools/record"
+
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/testutil"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
-	"k8s.io/client-go/tools/record"
 )
 
 func TestValidateBackupStorageClassDependency(t *testing.T) {
@@ -390,7 +391,10 @@ func TestShardReconciler_FieldOwnershipIsolation(t *testing.T) {
 
 		for _, c := range patchShard.Status.Conditions {
 			if c.Type == conditionStorageClassValid {
-				t.Fatalf("updateStatus patch must not contain %s condition", conditionStorageClassValid)
+				t.Fatalf(
+					"updateStatus patch must not contain %s condition",
+					conditionStorageClassValid,
+				)
 			}
 		}
 		availCond := findCondition(patchShard.Status.Conditions, "Available")
@@ -399,77 +403,87 @@ func TestShardReconciler_FieldOwnershipIsolation(t *testing.T) {
 		}
 	})
 
-	t.Run("guard patch contains only StorageClassValid condition and no other status fields", func(t *testing.T) {
-		t.Parallel()
+	t.Run(
+		"guard patch contains only StorageClassValid condition and no other status fields",
+		func(t *testing.T) {
+			t.Parallel()
 
-		shard := &multigresv1alpha1.Shard{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-field-owner-2",
-				Namespace: "default",
-			},
-			Spec: multigresv1alpha1.ShardSpec{
-				Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
-					"primary": {
-						Storage: multigresv1alpha1.StorageSpec{
-							Size:  "10Gi",
-							Class: "fast-ssd",
+			shard := &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-field-owner-2",
+					Namespace: "default",
+				},
+				Spec: multigresv1alpha1.ShardSpec{
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"primary": {
+							Storage: multigresv1alpha1.StorageSpec{
+								Size:  "10Gi",
+								Class: "fast-ssd",
+							},
 						},
 					},
 				},
-			},
-		}
-		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}}
+			}
+			sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}}
 
-		baseClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(shard, sc).
-			WithStatusSubresource(&multigresv1alpha1.Shard{}).
-			Build()
+			baseClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(shard, sc).
+				WithStatusSubresource(&multigresv1alpha1.Shard{}).
+				Build()
 
-		var capturedPatchObj client.Object
-		fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
-			OnStatusPatch: func(obj client.Object) error {
-				capturedPatchObj = obj
-				return nil
-			},
-		})
+			var capturedPatchObj client.Object
+			fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
+				OnStatusPatch: func(obj client.Object) error {
+					capturedPatchObj = obj
+					return nil
+				},
+			})
 
-		r := &ShardReconciler{Client: fakeClient, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+			r := &ShardReconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
 
-		if err := r.validatePoolStorageClassDependencies(t.Context(), shard); err != nil {
-			t.Fatalf("guard: %v", err)
-		}
+			if err := r.validatePoolStorageClassDependencies(t.Context(), shard); err != nil {
+				t.Fatalf("guard: %v", err)
+			}
 
-		patchShard, ok := capturedPatchObj.(*multigresv1alpha1.Shard)
-		if !ok {
-			t.Fatalf("expected *Shard patch, got %T", capturedPatchObj)
-		}
+			patchShard, ok := capturedPatchObj.(*multigresv1alpha1.Shard)
+			if !ok {
+				t.Fatalf("expected *Shard patch, got %T", capturedPatchObj)
+			}
 
-		// Exactly one condition: StorageClassValid.
-		if len(patchShard.Status.Conditions) != 1 {
-			t.Fatalf("guard patch must contain exactly 1 condition, got %d: %v",
-				len(patchShard.Status.Conditions), patchShard.Status.Conditions)
-		}
-		scCond := &patchShard.Status.Conditions[0]
-		if scCond.Type != conditionStorageClassValid {
-			t.Fatalf("expected %s condition, got %s", conditionStorageClassValid, scCond.Type)
-		}
-		if scCond.Status != metav1.ConditionTrue || scCond.Reason != storageClassFoundReason {
-			t.Fatalf("unexpected condition: status=%s reason=%s", scCond.Status, scCond.Reason)
-		}
+			// Exactly one condition: StorageClassValid.
+			if len(patchShard.Status.Conditions) != 1 {
+				t.Fatalf("guard patch must contain exactly 1 condition, got %d: %v",
+					len(patchShard.Status.Conditions), patchShard.Status.Conditions)
+			}
+			scCond := &patchShard.Status.Conditions[0]
+			if scCond.Type != conditionStorageClassValid {
+				t.Fatalf("expected %s condition, got %s", conditionStorageClassValid, scCond.Type)
+			}
+			if scCond.Status != metav1.ConditionTrue || scCond.Reason != storageClassFoundReason {
+				t.Fatalf("unexpected condition: status=%s reason=%s", scCond.Status, scCond.Reason)
+			}
 
-		// No other status fields should be set in the guard patch.
-		if patchShard.Status.Phase != "" {
-			t.Fatalf("guard patch must not set Phase, got %q", patchShard.Status.Phase)
-		}
-		if patchShard.Status.Message != "" {
-			t.Fatalf("guard patch must not set Message, got %q", patchShard.Status.Message)
-		}
-		if patchShard.Status.PodRoles != nil {
-			t.Fatal("guard patch must not set PodRoles")
-		}
-		if patchShard.Status.ReadyReplicas != 0 {
-			t.Fatalf("guard patch must not set ReadyReplicas, got %d", patchShard.Status.ReadyReplicas)
-		}
-	})
+			// No other status fields should be set in the guard patch.
+			if patchShard.Status.Phase != "" {
+				t.Fatalf("guard patch must not set Phase, got %q", patchShard.Status.Phase)
+			}
+			if patchShard.Status.Message != "" {
+				t.Fatalf("guard patch must not set Message, got %q", patchShard.Status.Message)
+			}
+			if patchShard.Status.PodRoles != nil {
+				t.Fatal("guard patch must not set PodRoles")
+			}
+			if patchShard.Status.ReadyReplicas != 0 {
+				t.Fatalf(
+					"guard patch must not set ReadyReplicas, got %d",
+					patchShard.Status.ReadyReplicas,
+				)
+			}
+		},
+	)
 }

--- a/pkg/resource-handler/controller/toposerver/storage_class_guard.go
+++ b/pkg/resource-handler/controller/toposerver/storage_class_guard.go
@@ -1,0 +1,179 @@
+package toposerver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+const (
+	conditionStorageClassValid    = "StorageClassValid"
+	storageClassDependencyRequeue = 10 * time.Second
+
+	storageClassNotFoundReason     = "StorageClassNotFound"
+	storageClassFoundReason        = "StorageClassFound"
+	storageClassNotSpecifiedReason = "StorageClassNotSpecified"
+)
+
+// missingStorageClassDependencyError signals a missing StorageClass (requeue calmly,
+// not exponential backoff).
+type missingStorageClassDependencyError struct {
+	className string
+}
+
+func (e *missingStorageClassDependencyError) Error() string {
+	return fmt.Sprintf("referenced StorageClass %q was not found", e.className)
+}
+
+// isMissingStorageClassDependency checks whether err is a missing StorageClass dependency.
+func isMissingStorageClassDependency(err error) bool {
+	var depErr *missingStorageClassDependencyError
+	return errors.As(err, &depErr)
+}
+
+// validateStorageClassExists checks if the named StorageClass exists.
+func (r *TopoServerReconciler) validateStorageClassExists(
+	ctx context.Context,
+	className string,
+) (bool, error) {
+	sc := &storagev1.StorageClass{}
+	err := r.Get(ctx, client.ObjectKey{Name: className}, sc)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get StorageClass %q: %w", className, err)
+	}
+	return true, nil
+}
+
+// validateEtcdStorageClassDependency runs before StatefulSet apply.
+// Empty class passes through, existing class proceeds, missing class requeues.
+func (r *TopoServerReconciler) validateEtcdStorageClassDependency(
+	ctx context.Context,
+	toposerver *multigresv1alpha1.TopoServer,
+) error {
+	var etcdClass string
+	if toposerver.Spec.Etcd != nil {
+		etcdClass = toposerver.Spec.Etcd.Storage.Class
+	}
+
+	if etcdClass == "" {
+		return r.setStorageClassCondition(
+			ctx,
+			toposerver,
+			metav1.ConditionTrue,
+			storageClassNotSpecifiedReason,
+			"No explicit etcd StorageClass configured; using cluster default",
+		)
+	}
+
+	exists, err := r.validateStorageClassExists(ctx, etcdClass)
+	if err != nil {
+		return fmt.Errorf("failed to validate etcd StorageClass %q: %w", etcdClass, err)
+	}
+	if !exists {
+		msg := fmt.Sprintf("StorageClass %q not found for etcd PVCs", etcdClass)
+		if setErr := r.setStorageClassCondition(
+			ctx,
+			toposerver,
+			metav1.ConditionFalse,
+			storageClassNotFoundReason,
+			msg,
+		); setErr != nil {
+			return setErr
+		}
+		r.Recorder.Eventf(toposerver, "Warning", storageClassNotFoundReason, msg)
+		return &missingStorageClassDependencyError{className: etcdClass}
+	}
+
+	return r.setStorageClassCondition(
+		ctx,
+		toposerver,
+		metav1.ConditionTrue,
+		storageClassFoundReason,
+		fmt.Sprintf("StorageClass %q found for etcd PVCs", etcdClass),
+	)
+}
+
+// setStorageClassCondition patches the StorageClassValid condition using SSA.
+// Uses FieldOwner("multigres-operator-guard") to avoid ownership conflicts with
+// updateStatus which uses FieldOwner("multigres-operator").
+
+// TODO: This stale-safe condition skip logic is mirrored in the Shard guard;
+// extract a shared helper to reduce duplication.
+func (r *TopoServerReconciler) setStorageClassCondition(
+	ctx context.Context,
+	toposerver *multigresv1alpha1.TopoServer,
+	condStatus metav1.ConditionStatus,
+	reason string,
+	message string,
+) error {
+	// Read the latest from the API server so the skip-if-unchanged check
+	// compares against the real persisted state, not a potentially stale
+	// in-memory copy.
+	latest := &multigresv1alpha1.TopoServer{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(toposerver), latest); err != nil {
+		return fmt.Errorf("failed to get TopoServer for StorageClass condition check: %w", err)
+	}
+
+	existing := meta.FindStatusCondition(latest.Status.Conditions, conditionStorageClassValid)
+	if existing != nil &&
+		existing.Status == condStatus &&
+		existing.Reason == reason &&
+		existing.Message == message &&
+		existing.ObservedGeneration == latest.Generation {
+		return nil
+	}
+
+	// Preserve LastTransitionTime when the status hasn't transitioned,
+	// matching the behavior of meta.SetStatusCondition.
+	now := metav1.Now()
+	if existing != nil && existing.Status == condStatus {
+		now = existing.LastTransitionTime
+	}
+
+	patchObj := &multigresv1alpha1.TopoServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: multigresv1alpha1.GroupVersion.String(),
+			Kind:       "TopoServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      toposerver.Name,
+			Namespace: toposerver.Namespace,
+		},
+		Status: multigresv1alpha1.TopoServerStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               conditionStorageClassValid,
+					Status:             condStatus,
+					Reason:             reason,
+					Message:            message,
+					ObservedGeneration: latest.Generation,
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+
+	if err := r.Status().Patch(
+		ctx,
+		patchObj,
+		client.Apply,
+		client.FieldOwner("multigres-operator-guard"),
+		client.ForceOwnership,
+	); err != nil {
+		return fmt.Errorf("failed to patch TopoServer StorageClass condition: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/resource-handler/controller/toposerver/storage_class_guard_test.go
+++ b/pkg/resource-handler/controller/toposerver/storage_class_guard_test.go
@@ -83,38 +83,49 @@ func TestValidateEtcdStorageClassDependency(t *testing.T) {
 		}
 	})
 
-	t.Run("missing storage class sets False/NotFound condition and returns dependency error", func(t *testing.T) {
-		t.Parallel()
-		ts := &multigresv1alpha1.TopoServer{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-ts", Namespace: "default"},
-			Spec: multigresv1alpha1.TopoServerSpec{
-				Etcd: &multigresv1alpha1.EtcdSpec{
-					Storage: multigresv1alpha1.StorageSpec{Class: "missing-sc"},
+	t.Run(
+		"missing storage class sets False/NotFound condition and returns dependency error",
+		func(t *testing.T) {
+			t.Parallel()
+			ts := &multigresv1alpha1.TopoServer{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ts", Namespace: "default"},
+				Spec: multigresv1alpha1.TopoServerSpec{
+					Etcd: &multigresv1alpha1.EtcdSpec{
+						Storage: multigresv1alpha1.StorageSpec{Class: "missing-sc"},
+					},
 				},
-			},
-		}
-		c := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(ts).
-			WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
-			Build()
-		r := &TopoServerReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+			}
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(ts).
+				WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+				Build()
+			r := &TopoServerReconciler{
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
 
-		err := r.validateEtcdStorageClassDependency(t.Context(), ts)
-		if err == nil || !isMissingStorageClassDependency(err) {
-			t.Fatalf("expected missing dependency error, got: %v", err)
-		}
+			err := r.validateEtcdStorageClassDependency(t.Context(), ts)
+			if err == nil || !isMissingStorageClassDependency(err) {
+				t.Fatalf("expected missing dependency error, got: %v", err)
+			}
 
-		var updated multigresv1alpha1.TopoServer
-		if getErr := c.Get(t.Context(), client.ObjectKeyFromObject(ts), &updated); getErr != nil {
-			t.Fatalf("failed to read toposerver: %v", getErr)
-		}
-		cond := findCondition(updated.Status.Conditions, conditionStorageClassValid)
-		if cond == nil || cond.Status != metav1.ConditionFalse ||
-			cond.Reason != storageClassNotFoundReason {
-			t.Fatalf("unexpected condition: %#v", cond)
-		}
-	})
+			var updated multigresv1alpha1.TopoServer
+			if getErr := c.Get(
+				t.Context(),
+				client.ObjectKeyFromObject(ts),
+				&updated,
+			); getErr != nil {
+				t.Fatalf("failed to read toposerver: %v", getErr)
+			}
+			cond := findCondition(updated.Status.Conditions, conditionStorageClassValid)
+			if cond == nil || cond.Status != metav1.ConditionFalse ||
+				cond.Reason != storageClassNotFoundReason {
+				t.Fatalf("unexpected condition: %#v", cond)
+			}
+		},
+	)
 
 	t.Run("API error propagates without setting condition", func(t *testing.T) {
 		t.Parallel()
@@ -134,7 +145,11 @@ func TestValidateEtcdStorageClassDependency(t *testing.T) {
 		fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
 			OnGet: testutil.FailOnKeyName("some-sc", testutil.ErrNetworkTimeout),
 		})
-		r := &TopoServerReconciler{Client: fakeClient, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+		r := &TopoServerReconciler{
+			Client:   fakeClient,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(10),
+		}
 
 		err := r.validateEtcdStorageClassDependency(t.Context(), ts)
 		if err == nil {
@@ -145,7 +160,11 @@ func TestValidateEtcdStorageClassDependency(t *testing.T) {
 		}
 
 		var updated multigresv1alpha1.TopoServer
-		if getErr := baseClient.Get(t.Context(), client.ObjectKeyFromObject(ts), &updated); getErr != nil {
+		if getErr := baseClient.Get(
+			t.Context(),
+			client.ObjectKeyFromObject(ts),
+			&updated,
+		); getErr != nil {
 			t.Fatalf("failed to read toposerver: %v", getErr)
 		}
 		cond := findCondition(updated.Status.Conditions, conditionStorageClassValid)

--- a/pkg/resource-handler/controller/toposerver/storage_class_guard_test.go
+++ b/pkg/resource-handler/controller/toposerver/storage_class_guard_test.go
@@ -1,0 +1,178 @@
+package toposerver
+
+import (
+	"errors"
+	"testing"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/testutil"
+)
+
+func TestValidateEtcdStorageClassDependency(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
+
+	t.Run("empty storage class sets True/NotSpecified condition", func(t *testing.T) {
+		t.Parallel()
+		ts := &multigresv1alpha1.TopoServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-ts", Namespace: "default"},
+			Spec:       multigresv1alpha1.TopoServerSpec{},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ts).
+			WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+			Build()
+		r := &TopoServerReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+		if err := r.validateEtcdStorageClassDependency(t.Context(), ts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var updated multigresv1alpha1.TopoServer
+		if err := c.Get(t.Context(), client.ObjectKeyFromObject(ts), &updated); err != nil {
+			t.Fatalf("failed to read toposerver: %v", err)
+		}
+		cond := findCondition(updated.Status.Conditions, conditionStorageClassValid)
+		if cond == nil || cond.Status != metav1.ConditionTrue ||
+			cond.Reason != storageClassNotSpecifiedReason {
+			t.Fatalf("unexpected condition: %#v", cond)
+		}
+	})
+
+	t.Run("existing storage class sets True/Found condition", func(t *testing.T) {
+		t.Parallel()
+		ts := &multigresv1alpha1.TopoServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-ts", Namespace: "default"},
+			Spec: multigresv1alpha1.TopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{
+					Storage: multigresv1alpha1.StorageSpec{Class: "fast-ssd"},
+				},
+			},
+		}
+		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ts, sc).
+			WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+			Build()
+		r := &TopoServerReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+		if err := r.validateEtcdStorageClassDependency(t.Context(), ts); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var updated multigresv1alpha1.TopoServer
+		if err := c.Get(t.Context(), client.ObjectKeyFromObject(ts), &updated); err != nil {
+			t.Fatalf("failed to read toposerver: %v", err)
+		}
+		cond := findCondition(updated.Status.Conditions, conditionStorageClassValid)
+		if cond == nil || cond.Status != metav1.ConditionTrue ||
+			cond.Reason != storageClassFoundReason {
+			t.Fatalf("unexpected condition: %#v", cond)
+		}
+	})
+
+	t.Run("missing storage class sets False/NotFound condition and returns dependency error", func(t *testing.T) {
+		t.Parallel()
+		ts := &multigresv1alpha1.TopoServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-ts", Namespace: "default"},
+			Spec: multigresv1alpha1.TopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{
+					Storage: multigresv1alpha1.StorageSpec{Class: "missing-sc"},
+				},
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ts).
+			WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+			Build()
+		r := &TopoServerReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+		err := r.validateEtcdStorageClassDependency(t.Context(), ts)
+		if err == nil || !isMissingStorageClassDependency(err) {
+			t.Fatalf("expected missing dependency error, got: %v", err)
+		}
+
+		var updated multigresv1alpha1.TopoServer
+		if getErr := c.Get(t.Context(), client.ObjectKeyFromObject(ts), &updated); getErr != nil {
+			t.Fatalf("failed to read toposerver: %v", getErr)
+		}
+		cond := findCondition(updated.Status.Conditions, conditionStorageClassValid)
+		if cond == nil || cond.Status != metav1.ConditionFalse ||
+			cond.Reason != storageClassNotFoundReason {
+			t.Fatalf("unexpected condition: %#v", cond)
+		}
+	})
+
+	t.Run("API error propagates without setting condition", func(t *testing.T) {
+		t.Parallel()
+		ts := &multigresv1alpha1.TopoServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-ts", Namespace: "default"},
+			Spec: multigresv1alpha1.TopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{
+					Storage: multigresv1alpha1.StorageSpec{Class: "some-sc"},
+				},
+			},
+		}
+		baseClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ts).
+			WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+			Build()
+		fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
+			OnGet: testutil.FailOnKeyName("some-sc", testutil.ErrNetworkTimeout),
+		})
+		r := &TopoServerReconciler{Client: fakeClient, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+		err := r.validateEtcdStorageClassDependency(t.Context(), ts)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if isMissingStorageClassDependency(err) {
+			t.Fatal("expected non-dependency error, got dependency error")
+		}
+
+		var updated multigresv1alpha1.TopoServer
+		if getErr := baseClient.Get(t.Context(), client.ObjectKeyFromObject(ts), &updated); getErr != nil {
+			t.Fatalf("failed to read toposerver: %v", getErr)
+		}
+		cond := findCondition(updated.Status.Conditions, conditionStorageClassValid)
+		if cond != nil && cond.Status == metav1.ConditionFalse {
+			t.Fatalf("condition should not be False on API error, got: %#v", cond)
+		}
+	})
+}
+
+func TestIsMissingStorageClassDependencyWrapped(t *testing.T) {
+	err := errors.New("other")
+	if isMissingStorageClassDependency(err) {
+		t.Fatal("expected false for non-dependency error")
+	}
+
+	wrapped := errors.Join(errors.New("outer"), &missingStorageClassDependencyError{className: "x"})
+	if !isMissingStorageClassDependency(wrapped) {
+		t.Fatal("expected true for wrapped missing dependency error")
+	}
+}
+
+// findCondition returns the condition with the given type, or nil if not found.
+func findCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller.go
@@ -335,9 +335,7 @@ func (r *TopoServerReconciler) updateStatus(
 
 	toposerver.Status.ObservedGeneration = toposerver.Generation
 
-	// 1. Construct the Patch Object — include only the fields this owner manages.
-	// The StorageClassValid condition is owned by "multigres-operator-guard" and
-	// must NOT appear here, otherwise SSA would fight over it.
+	// 1. Construct the Patch Object
 	readyCond := meta.FindStatusCondition(toposerver.Status.Conditions, "Ready")
 	var patchConditions []metav1.Condition
 	if readyCond != nil {

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller.go
@@ -75,6 +75,18 @@ func (r *TopoServerReconciler) Reconcile(
 		return ctrl.Result{}, nil
 	}
 
+	// Validate StorageClass dependency before StatefulSet apply
+	if err := r.validateEtcdStorageClassDependency(ctx, toposerver); err != nil {
+		if isMissingStorageClassDependency(err) {
+			logger.Info("StorageClass dependency missing; requeueing",
+				"after", storageClassDependencyRequeue)
+			return ctrl.Result{RequeueAfter: storageClassDependencyRequeue}, nil
+		}
+		monitoring.RecordSpanError(span, err)
+		logger.Error(err, "Failed to validate etcd StorageClass")
+		return ctrl.Result{}, err
+	}
+
 	// Reconcile StatefulSet
 	{
 		ctx, childSpan := monitoring.StartChildSpan(ctx, "TopoServer.ReconcileStatefulSet")
@@ -323,7 +335,15 @@ func (r *TopoServerReconciler) updateStatus(
 
 	toposerver.Status.ObservedGeneration = toposerver.Generation
 
-	// 1. Construct the Patch Object
+	// 1. Construct the Patch Object — include only the fields this owner manages.
+	// The StorageClassValid condition is owned by "multigres-operator-guard" and
+	// must NOT appear here, otherwise SSA would fight over it.
+	readyCond := meta.FindStatusCondition(toposerver.Status.Conditions, "Ready")
+	var patchConditions []metav1.Condition
+	if readyCond != nil {
+		patchConditions = []metav1.Condition{*readyCond}
+	}
+
 	patchObj := &multigresv1alpha1.TopoServer{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: multigresv1alpha1.GroupVersion.String(),
@@ -333,7 +353,14 @@ func (r *TopoServerReconciler) updateStatus(
 			Name:      toposerver.Name,
 			Namespace: toposerver.Namespace,
 		},
-		Status: toposerver.Status,
+		Status: multigresv1alpha1.TopoServerStatus{
+			Phase:              toposerver.Status.Phase,
+			Message:            toposerver.Status.Message,
+			ObservedGeneration: toposerver.Status.ObservedGeneration,
+			ClientService:      toposerver.Status.ClientService,
+			PeerService:        toposerver.Status.PeerService,
+			Conditions:         patchConditions,
+		},
 	}
 
 	// 2. Apply the Patch

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller_test.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,6 +28,7 @@ func TestTopoServerReconciler_Reconcile(t *testing.T) {
 	_ = multigresv1alpha1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
 
 	tests := map[string]struct {
 		toposerver      *multigresv1alpha1.TopoServer
@@ -148,6 +150,62 @@ func TestTopoServerReconciler_Reconcile(t *testing.T) {
 						"StatefulSet image = %s, want quay.io/coreos/etcd:v3.5.15",
 						sts.Spec.Template.Spec.Containers[0].Image,
 					)
+				}
+			},
+		},
+
+		////----------------------------------------
+		///   StorageClass Guard
+		//------------------------------------------
+		"missing StorageClass returns RequeueAfter=10s and no StatefulSet": {
+			toposerver: &multigresv1alpha1.TopoServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-missing-sc",
+					Namespace: "default",
+					Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+				},
+				Spec: multigresv1alpha1.TopoServerSpec{
+					Etcd: &multigresv1alpha1.EtcdSpec{
+						Storage: multigresv1alpha1.StorageSpec{Class: "nonexistent-sc"},
+					},
+				},
+			},
+			existingObjects: []client.Object{},
+			wantRequeue:     true,
+			assertFunc: func(t *testing.T, c client.Client, toposerver *multigresv1alpha1.TopoServer) {
+				// StatefulSet should not have been created.
+				sts := &appsv1.StatefulSet{}
+				err := c.Get(t.Context(),
+					types.NamespacedName{Name: "test-missing-sc", Namespace: "default"},
+					sts)
+				if err == nil {
+					t.Error("StatefulSet should not exist when StorageClass is missing")
+				}
+			},
+		},
+		"existing StorageClass proceeds normally and creates StatefulSet": {
+			toposerver: &multigresv1alpha1.TopoServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-existing-sc",
+					Namespace: "default",
+					Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+				},
+				Spec: multigresv1alpha1.TopoServerSpec{
+					Etcd: &multigresv1alpha1.EtcdSpec{
+						Storage: multigresv1alpha1.StorageSpec{Class: "fast-ssd"},
+					},
+				},
+			},
+			existingObjects: []client.Object{
+				&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}},
+			},
+			wantRequeue: true,
+			assertFunc: func(t *testing.T, c client.Client, toposerver *multigresv1alpha1.TopoServer) {
+				sts := &appsv1.StatefulSet{}
+				if err := c.Get(t.Context(),
+					types.NamespacedName{Name: "test-existing-sc", Namespace: "default"},
+					sts); err != nil {
+					t.Errorf("StatefulSet should exist when StorageClass is present: %v", err)
 				}
 			},
 		},
@@ -351,6 +409,7 @@ func TestTopoServerReconciler_ReconcileNotFound(t *testing.T) {
 	_ = multigresv1alpha1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -384,6 +443,7 @@ func TestTopoServerReconciler_UpdateStatus(t *testing.T) {
 	_ = multigresv1alpha1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
 
 	t.Run("all_replicas_ready_status", func(t *testing.T) {
 		toposerver := &multigresv1alpha1.TopoServer{
@@ -492,11 +552,160 @@ func TestTopoServerReconciler_UpdateStatus(t *testing.T) {
 	})
 }
 
+func TestTopoServerReconciler_FieldOwnershipIsolation(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
+
+	t.Run("updateStatus patch contains exactly one condition (Ready)", func(t *testing.T) {
+		t.Parallel()
+
+		ts := &multigresv1alpha1.TopoServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-field-owner",
+				Namespace: "default",
+				Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+			},
+			Spec: multigresv1alpha1.TopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{
+					Replicas: ptr.To(int32(3)),
+				},
+			},
+		}
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-field-owner",
+				Namespace: "default",
+				Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+			},
+			Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(3))},
+			Status: appsv1.StatefulSetStatus{
+				Replicas:      3,
+				ReadyReplicas: 3,
+			},
+		}
+
+		baseClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ts, sts).
+			WithStatusSubresource(&multigresv1alpha1.TopoServer{}, sts).
+			Build()
+
+		// Intercept the status patch to inspect the patch object.
+		var capturedPatchObj client.Object
+		fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
+			OnStatusPatch: func(obj client.Object) error {
+				capturedPatchObj = obj
+				return nil
+			},
+		})
+
+		r := &TopoServerReconciler{Client: fakeClient, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+		if err := r.updateStatus(t.Context(), ts); err != nil {
+			t.Fatalf("updateStatus: %v", err)
+		}
+
+		patchTS, ok := capturedPatchObj.(*multigresv1alpha1.TopoServer)
+		if !ok {
+			t.Fatalf("expected *TopoServer patch, got %T", capturedPatchObj)
+		}
+
+		// Exactly one condition: Ready.
+		if len(patchTS.Status.Conditions) != 1 {
+			t.Fatalf("updateStatus patch must contain exactly 1 condition, got %d: %v",
+				len(patchTS.Status.Conditions), patchTS.Status.Conditions)
+		}
+		if patchTS.Status.Conditions[0].Type != "Ready" {
+			t.Fatalf("expected Ready condition, got %s", patchTS.Status.Conditions[0].Type)
+		}
+	})
+
+	t.Run("guard patch contains exactly one condition (StorageClassValid) and no other status fields", func(t *testing.T) {
+		t.Parallel()
+
+		ts := &multigresv1alpha1.TopoServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-field-owner-2",
+				Namespace: "default",
+				Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+			},
+			Spec: multigresv1alpha1.TopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{
+					Storage: multigresv1alpha1.StorageSpec{Class: "fast-ssd"},
+				},
+			},
+		}
+		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}}
+
+		baseClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(ts, sc).
+			WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+			Build()
+
+		// Intercept the status patch to inspect the patch object.
+		var capturedPatchObj client.Object
+		fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
+			OnStatusPatch: func(obj client.Object) error {
+				capturedPatchObj = obj
+				return nil
+			},
+		})
+
+		r := &TopoServerReconciler{Client: fakeClient, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+		if err := r.validateEtcdStorageClassDependency(t.Context(), ts); err != nil {
+			t.Fatalf("guard: %v", err)
+		}
+
+		patchTS, ok := capturedPatchObj.(*multigresv1alpha1.TopoServer)
+		if !ok {
+			t.Fatalf("expected *TopoServer patch, got %T", capturedPatchObj)
+		}
+
+		// Exactly one condition: StorageClassValid.
+		if len(patchTS.Status.Conditions) != 1 {
+			t.Fatalf("guard patch must contain exactly 1 condition, got %d: %v",
+				len(patchTS.Status.Conditions), patchTS.Status.Conditions)
+		}
+		scCond := &patchTS.Status.Conditions[0]
+		if scCond.Type != conditionStorageClassValid {
+			t.Fatalf("expected %s condition, got %s", conditionStorageClassValid, scCond.Type)
+		}
+		if scCond.Status != metav1.ConditionTrue || scCond.Reason != storageClassFoundReason {
+			t.Fatalf("unexpected condition: status=%s reason=%s", scCond.Status, scCond.Reason)
+		}
+
+		// No other status fields should be set in the guard patch.
+		if patchTS.Status.Phase != "" {
+			t.Fatalf("guard patch must not set Phase, got %q", patchTS.Status.Phase)
+		}
+		if patchTS.Status.Message != "" {
+			t.Fatalf("guard patch must not set Message, got %q", patchTS.Status.Message)
+		}
+		if patchTS.Status.ClientService != "" {
+			t.Fatalf("guard patch must not set ClientService, got %q", patchTS.Status.ClientService)
+		}
+		if patchTS.Status.PeerService != "" {
+			t.Fatalf("guard patch must not set PeerService, got %q", patchTS.Status.PeerService)
+		}
+		if patchTS.Status.ObservedGeneration != 0 {
+			t.Fatalf("guard patch must not set ObservedGeneration, got %d", patchTS.Status.ObservedGeneration)
+		}
+	})
+}
+
 func TestTopoServerReconciler_StandaloneMocks(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = multigresv1alpha1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
+	_ = storagev1.AddToScheme(scheme)
 
 	t.Run("ignore_deleted", func(t *testing.T) {
 		toposerver := &multigresv1alpha1.TopoServer{
@@ -620,6 +829,7 @@ func TestTopoServerReconciler_StandaloneMocks(t *testing.T) {
 		baseClient := fake.NewClientBuilder().
 			WithScheme(scheme).
 			WithObjects(toposerver, sts).
+			WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
 			Build()
 		fails := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
 			OnList: func(list client.ObjectList) error { return testutil.ErrNetworkTimeout },

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller_test.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller_test.go
@@ -604,7 +604,11 @@ func TestTopoServerReconciler_FieldOwnershipIsolation(t *testing.T) {
 			},
 		})
 
-		r := &TopoServerReconciler{Client: fakeClient, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+		r := &TopoServerReconciler{
+			Client:   fakeClient,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(10),
+		}
 
 		if err := r.updateStatus(t.Context(), ts); err != nil {
 			t.Fatalf("updateStatus: %v", err)
@@ -625,79 +629,92 @@ func TestTopoServerReconciler_FieldOwnershipIsolation(t *testing.T) {
 		}
 	})
 
-	t.Run("guard patch contains exactly one condition (StorageClassValid) and no other status fields", func(t *testing.T) {
-		t.Parallel()
+	t.Run(
+		"guard patch contains exactly one condition (StorageClassValid) and no other status fields",
+		func(t *testing.T) {
+			t.Parallel()
 
-		ts := &multigresv1alpha1.TopoServer{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-field-owner-2",
-				Namespace: "default",
-				Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
-			},
-			Spec: multigresv1alpha1.TopoServerSpec{
-				Etcd: &multigresv1alpha1.EtcdSpec{
-					Storage: multigresv1alpha1.StorageSpec{Class: "fast-ssd"},
+			ts := &multigresv1alpha1.TopoServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-field-owner-2",
+					Namespace: "default",
+					Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
 				},
-			},
-		}
-		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}}
+				Spec: multigresv1alpha1.TopoServerSpec{
+					Etcd: &multigresv1alpha1.EtcdSpec{
+						Storage: multigresv1alpha1.StorageSpec{Class: "fast-ssd"},
+					},
+				},
+			}
+			sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-ssd"}}
 
-		baseClient := fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(ts, sc).
-			WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
-			Build()
+			baseClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(ts, sc).
+				WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+				Build()
 
-		// Intercept the status patch to inspect the patch object.
-		var capturedPatchObj client.Object
-		fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
-			OnStatusPatch: func(obj client.Object) error {
-				capturedPatchObj = obj
-				return nil
-			},
-		})
+			// Intercept the status patch to inspect the patch object.
+			var capturedPatchObj client.Object
+			fakeClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
+				OnStatusPatch: func(obj client.Object) error {
+					capturedPatchObj = obj
+					return nil
+				},
+			})
 
-		r := &TopoServerReconciler{Client: fakeClient, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+			r := &TopoServerReconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
 
-		if err := r.validateEtcdStorageClassDependency(t.Context(), ts); err != nil {
-			t.Fatalf("guard: %v", err)
-		}
+			if err := r.validateEtcdStorageClassDependency(t.Context(), ts); err != nil {
+				t.Fatalf("guard: %v", err)
+			}
 
-		patchTS, ok := capturedPatchObj.(*multigresv1alpha1.TopoServer)
-		if !ok {
-			t.Fatalf("expected *TopoServer patch, got %T", capturedPatchObj)
-		}
+			patchTS, ok := capturedPatchObj.(*multigresv1alpha1.TopoServer)
+			if !ok {
+				t.Fatalf("expected *TopoServer patch, got %T", capturedPatchObj)
+			}
 
-		// Exactly one condition: StorageClassValid.
-		if len(patchTS.Status.Conditions) != 1 {
-			t.Fatalf("guard patch must contain exactly 1 condition, got %d: %v",
-				len(patchTS.Status.Conditions), patchTS.Status.Conditions)
-		}
-		scCond := &patchTS.Status.Conditions[0]
-		if scCond.Type != conditionStorageClassValid {
-			t.Fatalf("expected %s condition, got %s", conditionStorageClassValid, scCond.Type)
-		}
-		if scCond.Status != metav1.ConditionTrue || scCond.Reason != storageClassFoundReason {
-			t.Fatalf("unexpected condition: status=%s reason=%s", scCond.Status, scCond.Reason)
-		}
+			// Exactly one condition: StorageClassValid.
+			if len(patchTS.Status.Conditions) != 1 {
+				t.Fatalf("guard patch must contain exactly 1 condition, got %d: %v",
+					len(patchTS.Status.Conditions), patchTS.Status.Conditions)
+			}
+			scCond := &patchTS.Status.Conditions[0]
+			if scCond.Type != conditionStorageClassValid {
+				t.Fatalf("expected %s condition, got %s", conditionStorageClassValid, scCond.Type)
+			}
+			if scCond.Status != metav1.ConditionTrue || scCond.Reason != storageClassFoundReason {
+				t.Fatalf("unexpected condition: status=%s reason=%s", scCond.Status, scCond.Reason)
+			}
 
-		// No other status fields should be set in the guard patch.
-		if patchTS.Status.Phase != "" {
-			t.Fatalf("guard patch must not set Phase, got %q", patchTS.Status.Phase)
-		}
-		if patchTS.Status.Message != "" {
-			t.Fatalf("guard patch must not set Message, got %q", patchTS.Status.Message)
-		}
-		if patchTS.Status.ClientService != "" {
-			t.Fatalf("guard patch must not set ClientService, got %q", patchTS.Status.ClientService)
-		}
-		if patchTS.Status.PeerService != "" {
-			t.Fatalf("guard patch must not set PeerService, got %q", patchTS.Status.PeerService)
-		}
-		if patchTS.Status.ObservedGeneration != 0 {
-			t.Fatalf("guard patch must not set ObservedGeneration, got %d", patchTS.Status.ObservedGeneration)
-		}
-	})
+			// No other status fields should be set in the guard patch.
+			if patchTS.Status.Phase != "" {
+				t.Fatalf("guard patch must not set Phase, got %q", patchTS.Status.Phase)
+			}
+			if patchTS.Status.Message != "" {
+				t.Fatalf("guard patch must not set Message, got %q", patchTS.Status.Message)
+			}
+			if patchTS.Status.ClientService != "" {
+				t.Fatalf(
+					"guard patch must not set ClientService, got %q",
+					patchTS.Status.ClientService,
+				)
+			}
+			if patchTS.Status.PeerService != "" {
+				t.Fatalf("guard patch must not set PeerService, got %q", patchTS.Status.PeerService)
+			}
+			if patchTS.Status.ObservedGeneration != 0 {
+				t.Fatalf(
+					"guard patch must not set ObservedGeneration, got %d",
+					patchTS.Status.ObservedGeneration,
+				)
+			}
+		},
+	)
 }
 
 func TestTopoServerReconciler_StandaloneMocks(t *testing.T) {


### PR DESCRIPTION
## Description

this PR refactors status writes in Shard and TopoServer to explicit SSA ownership scopes.

Previously, status writes in Shard and TopoServer mixed SSA and `MergeFrom` across reconcile paths, and the same condition area could be updated by more than one path. That combination made final persisted condition state depend on patch ordering and made ownership harder to read from managedFields, because one path was writing with SSA ownership tracking while another path was writing the same condition area with merge patches; the API server then reflected whichever update landed last, but ownership metadata no longer cleanly matched the controller path that logically owned that condition

This change resolves that overlap by assigning each condition path to a single SSA writer. `updateStatus` is now limited to controller-owned status fields plus the primary readiness condition, and StorageClassValid` is handled only by storage-class validation under separate field owners. Validation now checks the latest persisted object before deciding whether to write, so condition updates are based on current API state, while also avoiding stale-object skips during reconciliation. 

## Changes

- Converted `updateStatus` in `status.go` and `toposerver_controller.go` from broad applies to owner-scoped SSA patch payloads.
- Limited main status writes in `status.go` and `toposerver_controller.go` to owned fields plus one readiness condition (**Available** for shard, **Ready** for toposerver).
- Moved StorageClassValid to guard-only SSA writes in `storage_class_guard.go` and `storage_class_guard.go`, with dedicated field owners.
- Updated shard status-subresource test wiring in shard_controller_internal_test.go so Status().Patch() paths are exercised correctly.

## Testing

Added test coverage to check the following:

- Field-ownership isolation for shard and toposerver status patches.
- StorageClass dependency condition behaviour in toposerver (missing/present/not-specified paths).
- Wrapped dependency-error detection for toposerver guard flows.

Also adjusted one existing shard reconcile test setup so status patching paths run with the correct status-subresource behaviour.