### PR TITLE
feat(operator): add cluster-wide multigateway replica-read endpoint

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/builders_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global.go
@@ -15,6 +15,11 @@ import (
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
 
+const (
+	globalMultiGatewayReplicaPort       int32 = 5433
+	globalMultiGatewayReplicaTargetPort       = "postgres-replica"
+)
+
 // BuildGlobalTopoServer constructs the desired TopoServer for the global topology.
 // Note: We do NOT use safe hashing here because GlobalTopo is a singleton resource
 // per cluster with a predictable name pattern that is unlikely to exceed length limits.
@@ -456,6 +461,47 @@ func BuildMultiGatewayGlobalService(
 					Name:       "postgres",
 					Port:       5432,
 					TargetPort: intstr.FromString("postgres"),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	if err := controllerutil.SetControllerReference(cluster, svc, scheme); err != nil {
+		return nil, err
+	}
+
+	return svc, nil
+}
+
+// BuildMultiGatewayGlobalReplicaService constructs a cluster-level Service that
+// selects all multigateway pods across all cells and exposes the replica-read endpoint.
+func BuildMultiGatewayGlobalReplicaService(
+	cluster *multigresv1alpha1.MultigresCluster,
+	scheme *runtime.Scheme,
+) (*corev1.Service, error) {
+	labels := metadata.BuildStandardLabels(cluster.Name, metadata.ComponentMultiGateway)
+	metadata.AddClusterLabel(labels, cluster.Name)
+
+	selector := map[string]string{
+		metadata.LabelAppComponent: metadata.ComponentMultiGateway,
+		metadata.LabelAppInstance:  cluster.Name,
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-multigateway-replica", cluster.Name),
+			Namespace: cluster.Namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: selector,
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "postgres-replica",
+					Port:       globalMultiGatewayReplicaPort,
+					TargetPort: intstr.FromString(globalMultiGatewayReplicaTargetPort),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},

--- a/pkg/cluster-handler/controller/multigrescluster/builders_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	globalMultiGatewayReplicaPort       int32 = 5433
-	globalMultiGatewayReplicaTargetPort       = "postgres-replica"
+	globalMultiGatewayReplicaTargetPort       = "pg-replica"
 )
 
 // BuildGlobalTopoServer constructs the desired TopoServer for the global topology.
@@ -499,7 +499,7 @@ func BuildMultiGatewayGlobalReplicaService(
 			Type:     corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "postgres-replica",
+					Name:       "pg-replica",
 					Port:       globalMultiGatewayReplicaPort,
 					TargetPort: intstr.FromString(globalMultiGatewayReplicaTargetPort),
 					Protocol:   corev1.ProtocolTCP,

--- a/pkg/cluster-handler/controller/multigrescluster/builders_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global_test.go
@@ -668,9 +668,9 @@ func TestBuildMultiGatewayGlobalReplicaService(t *testing.T) {
 
 	require.Len(t, got.Spec.Ports, 1)
 	assert.Equal(t, corev1.ServicePort{
-		Name:       "postgres-replica",
+		Name:       "pg-replica",
 		Port:       5433,
-		TargetPort: intstr.FromString("postgres-replica"),
+		TargetPort: intstr.FromString("pg-replica"),
 		Protocol:   corev1.ProtocolTCP,
 	}, got.Spec.Ports[0])
 

--- a/pkg/cluster-handler/controller/multigrescluster/builders_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global_test.go
@@ -645,3 +645,46 @@ func TestBuildMultiGatewayGlobalService(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestBuildMultiGatewayGlobalReplicaService(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "default",
+			UID:       "cluster-uid",
+		},
+	}
+
+	got, err := BuildMultiGatewayGlobalReplicaService(cluster, scheme)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-cluster-multigateway-replica", got.Name)
+	assert.Equal(t, "default", got.Namespace)
+	assert.Equal(t, corev1.ServiceTypeClusterIP, got.Spec.Type)
+
+	require.Len(t, got.Spec.Ports, 1)
+	assert.Equal(t, corev1.ServicePort{
+		Name:       "postgres-replica",
+		Port:       5433,
+		TargetPort: intstr.FromString("postgres-replica"),
+		Protocol:   corev1.ProtocolTCP,
+	}, got.Spec.Ports[0])
+
+	assert.Equal(t, map[string]string{
+		"app.kubernetes.io/component": "multigateway",
+		"app.kubernetes.io/instance":  "my-cluster",
+	}, got.Spec.Selector)
+
+	require.Len(t, got.OwnerReferences, 1)
+	assert.Equal(t, "my-cluster", got.OwnerReferences[0].Name)
+
+	t.Run("ControllerRefError", func(t *testing.T) {
+		emptyScheme := runtime.NewScheme()
+		_, err := BuildMultiGatewayGlobalReplicaService(cluster, emptyScheme)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/cluster-handler/controller/multigrescluster/integration_gateway_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_gateway_test.go
@@ -97,8 +97,34 @@ func TestExternalGateway_EnableDisableLifecycle(t *testing.T) {
 		},
 	}
 
+	expectedReplicaGwSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            clusterName + "-multigateway-replica",
+			Namespace:       testNamespace,
+			Labels:          gwLabels,
+			OwnerReferences: clusterOwnerRefs(t, clusterName),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				metadata.LabelAppComponent: metadata.ComponentMultiGateway,
+				metadata.LabelAppInstance:  clusterName,
+			},
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "postgres-replica",
+					Port:       5433,
+					TargetPort: intstr.FromString("postgres-replica"),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
 	require.NoError(t, watcher.WaitForMatch(expectedGwSvc),
 		"global multigateway Service should be ClusterIP with externalIPs and annotations")
+	require.NoError(t, watcher.WaitForMatch(expectedReplicaGwSvc),
+		"global multigateway replica Service should be ClusterIP")
 
 	// Step 3: Verify initial condition is NoReadyGateways (endpoint assigned via externalIP, 0 ready gateways).
 	assert.Eventually(t, func() bool {
@@ -184,8 +210,34 @@ func TestExternalGateway_EnableDisableLifecycle(t *testing.T) {
 		},
 	}
 
+	expectedReplicaClusterIPSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            clusterName + "-multigateway-replica",
+			Namespace:       testNamespace,
+			Labels:          gwLabels,
+			OwnerReferences: clusterOwnerRefs(t, clusterName),
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				metadata.LabelAppComponent: metadata.ComponentMultiGateway,
+				metadata.LabelAppInstance:  clusterName,
+			},
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "postgres-replica",
+					Port:       5433,
+					TargetPort: intstr.FromString("postgres-replica"),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
 	require.NoError(t, watcher.WaitForMatch(expectedClusterIPSvc),
 		"global multigateway Service should revert to ClusterIP after disabling")
+	require.NoError(t, watcher.WaitForMatch(expectedReplicaClusterIPSvc),
+		"global multigateway replica Service should remain ClusterIP")
 
 	// Step 8: Verify gateway status is nil and condition is removed.
 	assert.Eventually(t, func() bool {

--- a/pkg/cluster-handler/controller/multigrescluster/integration_gateway_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_gateway_test.go
@@ -112,9 +112,9 @@ func TestExternalGateway_EnableDisableLifecycle(t *testing.T) {
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "postgres-replica",
+					Name:       "pg-replica",
 					Port:       5433,
-					TargetPort: intstr.FromString("postgres-replica"),
+					TargetPort: intstr.FromString("pg-replica"),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},
@@ -225,9 +225,9 @@ func TestExternalGateway_EnableDisableLifecycle(t *testing.T) {
 			Type: corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "postgres-replica",
+					Name:       "pg-replica",
 					Port:       5433,
-					TargetPort: intstr.FromString("postgres-replica"),
+					TargetPort: intstr.FromString("pg-replica"),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global.go
@@ -16,10 +16,11 @@ import (
 
 // Builder function variables to allow mocking in tests
 var (
-	buildMultiAdminService         = BuildMultiAdminService
-	buildMultiAdminWebDeployment   = BuildMultiAdminWebDeployment
-	buildMultiAdminWebService      = BuildMultiAdminWebService
-	buildMultiGatewayGlobalService = BuildMultiGatewayGlobalService
+	buildMultiAdminService                = BuildMultiAdminService
+	buildMultiAdminWebDeployment          = BuildMultiAdminWebDeployment
+	buildMultiAdminWebService             = BuildMultiAdminWebService
+	buildMultiGatewayGlobalService        = BuildMultiGatewayGlobalService
+	buildMultiGatewayGlobalReplicaService = BuildMultiGatewayGlobalReplicaService
 )
 
 func (r *MultigresClusterReconciler) reconcileGlobalComponents(
@@ -267,6 +268,23 @@ func (r *MultigresClusterReconciler) reconcileMultiAdminWeb(
 		client.FieldOwner("multigres-operator"),
 	); err != nil {
 		return fmt.Errorf("failed to apply global multigateway service: %w", err)
+	}
+
+	// 4. Reconcile global replica-read multigateway Service
+	desiredReplicaGwSvc, err := buildMultiGatewayGlobalReplicaService(cluster, r.Scheme)
+	if err != nil {
+		return fmt.Errorf("failed to build global replica multigateway service: %w", err)
+	}
+
+	desiredReplicaGwSvc.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	if err := r.Patch(
+		ctx,
+		desiredReplicaGwSvc,
+		client.Apply,
+		client.ForceOwnership,
+		client.FieldOwner("multigres-operator"),
+	); err != nil {
+		return fmt.Errorf("failed to apply global replica multigateway service: %w", err)
 	}
 
 	return nil

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -422,6 +423,38 @@ func TestReconcileGlobal_ErrorPaths(t *testing.T) {
 			t.Errorf("Expected 'gw service patch error', got %v", err)
 		}
 	})
+
+	t.Run("Error: Patch MultiGateway Global Replica Service Failed", func(t *testing.T) {
+		cluster := &multigresv1alpha1.MultigresCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cli client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if svc, ok := obj.(*corev1.Service); ok &&
+					svc.Name == "test-multigateway-replica" {
+					return errors.New("gw replica service patch error")
+				}
+				return cli.Patch(ctx, obj, patch, opts...)
+			},
+		}).WithObjects(cluster).Build()
+
+		r := &MultigresClusterReconciler{
+			Client:   c,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(10),
+		}
+
+		err := r.reconcileMultiAdminWeb(
+			context.Background(),
+			cluster,
+			resolver.NewResolver(c, "default"),
+		)
+		if err == nil ||
+			err.Error() != "failed to apply global replica multigateway service: gw replica service patch error" {
+			t.Errorf("Expected 'gw replica service patch error', got %v", err)
+		}
+	})
 }
 
 func TestReconcile_Global(t *testing.T) {
@@ -515,6 +548,21 @@ func TestReconcile_Global(t *testing.T) {
 						"Global multigateway Service selector component = %v, want multigateway",
 						gwSvc.Spec.Selector["app.kubernetes.io/component"],
 					)
+				}
+
+				// Verify global replica multigateway Service exists
+				gwReplicaSvc := &corev1.Service{}
+				if err := c.Get(
+					ctx,
+					types.NamespacedName{Name: clusterName + "-multigateway-replica", Namespace: namespace},
+					gwReplicaSvc,
+				); err != nil {
+					t.Fatalf("Expected global multigateway replica Service to exist: %v", err)
+				}
+				if len(gwReplicaSvc.Spec.Ports) != 1 ||
+					gwReplicaSvc.Spec.Ports[0].Port != 5433 ||
+					gwReplicaSvc.Spec.Ports[0].TargetPort != intstr.FromString("postgres-replica") {
+					t.Errorf("Global multigateway replica Service ports mismatch: %+v", gwReplicaSvc.Spec.Ports)
 				}
 			},
 		},
@@ -797,6 +845,18 @@ func TestReconcile_Global(t *testing.T) {
 			},
 			wantErrMsg: "failed to apply global multigateway service",
 		},
+		"Error: Reconcile Global MultiGateway Replica Service Failed": {
+			failureConfig: &testutil.FailureConfig{
+				OnPatch: func(obj client.Object) error {
+					if obj.GetName() == clusterName+"-multigateway-replica" &&
+						obj.GetObjectKind().GroupVersionKind().Kind == "Service" {
+						return errSimulated
+					}
+					return nil
+				},
+			},
+			wantErrMsg: "failed to apply global replica multigateway service",
+		},
 		"Error: Build MultiAdmin Deployment Failed (Scheme)": {
 			// Bypass Global Topo builder by using External spec
 			preReconcileUpdate: func(t testing.TB, c *multigresv1alpha1.MultigresCluster) {
@@ -985,6 +1045,39 @@ func TestReconcile_Global_BuilderErrors(t *testing.T) {
 			t.Error("Expected error, got nil")
 		} else if !strings.Contains(err.Error(), "failed to build global multigateway service") {
 			t.Errorf("Expected 'failed to build global multigateway service', got: %v", err)
+		}
+	})
+
+	t.Run("Error: Build MultiGateway Global Replica Service Failed (Mock)", func(t *testing.T) {
+		originalBuild := buildMultiGatewayGlobalReplicaService
+		defer func() { buildMultiGatewayGlobalReplicaService = originalBuild }()
+
+		buildMultiGatewayGlobalReplicaService = func(_ *multigresv1alpha1.MultigresCluster, _ *runtime.Scheme) (*corev1.Service, error) {
+			return nil, errors.New("mocked builder error")
+		}
+
+		clientBuilder := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&multigresv1alpha1.MultigresCluster{})
+		c := clientBuilder.Build()
+
+		if err := c.Create(t.Context(), coreTpl.DeepCopy()); err != nil {
+			t.Fatalf("Failed to create CoreTemplate: %v", err)
+		}
+
+		reconciler := &MultigresClusterReconciler{
+			Client:   c,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(10),
+		}
+
+		cluster := baseCluster.DeepCopy()
+		res := resolver.NewResolver(c, baseCluster.Namespace)
+		err := reconciler.reconcileMultiAdminWeb(t.Context(), cluster, res)
+		if err == nil {
+			t.Error("Expected error, got nil")
+		} else if !strings.Contains(err.Error(), "failed to build global replica multigateway service") {
+			t.Errorf("Expected 'failed to build global replica multigateway service', got: %v", err)
 		}
 	})
 }

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
@@ -564,7 +564,7 @@ func TestReconcile_Global(t *testing.T) {
 				}
 				if len(gwReplicaSvc.Spec.Ports) != 1 ||
 					gwReplicaSvc.Spec.Ports[0].Port != 5433 ||
-					gwReplicaSvc.Spec.Ports[0].TargetPort != intstr.FromString("postgres-replica") {
+					gwReplicaSvc.Spec.Ports[0].TargetPort != intstr.FromString("pg-replica") {
 					t.Errorf(
 						"Global multigateway replica Service ports mismatch: %+v",
 						gwReplicaSvc.Spec.Ports,

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_global_test.go
@@ -554,7 +554,10 @@ func TestReconcile_Global(t *testing.T) {
 				gwReplicaSvc := &corev1.Service{}
 				if err := c.Get(
 					ctx,
-					types.NamespacedName{Name: clusterName + "-multigateway-replica", Namespace: namespace},
+					types.NamespacedName{
+						Name:      clusterName + "-multigateway-replica",
+						Namespace: namespace,
+					},
 					gwReplicaSvc,
 				); err != nil {
 					t.Fatalf("Expected global multigateway replica Service to exist: %v", err)
@@ -562,7 +565,10 @@ func TestReconcile_Global(t *testing.T) {
 				if len(gwReplicaSvc.Spec.Ports) != 1 ||
 					gwReplicaSvc.Spec.Ports[0].Port != 5433 ||
 					gwReplicaSvc.Spec.Ports[0].TargetPort != intstr.FromString("postgres-replica") {
-					t.Errorf("Global multigateway replica Service ports mismatch: %+v", gwReplicaSvc.Spec.Ports)
+					t.Errorf(
+						"Global multigateway replica Service ports mismatch: %+v",
+						gwReplicaSvc.Spec.Ports,
+					)
 				}
 			},
 		},

--- a/pkg/resource-handler/controller/cell/integration_test.go
+++ b/pkg/resource-handler/controller/cell/integration_test.go
@@ -134,7 +134,7 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 5432),
-											tcpPort(t, "postgres-replica", 5433),
+											tcpPort(t, "pg-replica", 5433),
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{
@@ -263,7 +263,7 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 5432),
-											tcpPort(t, "postgres-replica", 5433),
+											tcpPort(t, "pg-replica", 5433),
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{
@@ -392,7 +392,7 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 5432),
-											tcpPort(t, "postgres-replica", 5433),
+											tcpPort(t, "pg-replica", 5433),
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{
@@ -538,7 +538,7 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 5432),
-											tcpPort(t, "postgres-replica", 5433),
+											tcpPort(t, "pg-replica", 5433),
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{

--- a/pkg/resource-handler/controller/cell/integration_test.go
+++ b/pkg/resource-handler/controller/cell/integration_test.go
@@ -124,6 +124,7 @@ func TestCellReconciliation(t *testing.T) {
 											"--http-port", "15100",
 											"--grpc-port", "15170",
 											"--pg-port", "5432",
+											"--pg-replica-port", "5433",
 											"--topo-global-server-addresses", "global-topo:2379",
 											"--topo-global-root", "/multigres/global",
 											"--cell", "zone1",
@@ -133,6 +134,7 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 5432),
+											tcpPort(t, "postgres-replica", 5433),
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{
@@ -251,6 +253,7 @@ func TestCellReconciliation(t *testing.T) {
 											"--http-port", "15100",
 											"--grpc-port", "15170",
 											"--pg-port", "5432",
+											"--pg-replica-port", "5433",
 											"--topo-global-server-addresses", "global-topo:2379",
 											"--topo-global-root", "/multigres/global",
 											"--cell", "zone2",
@@ -260,6 +263,7 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 5432),
+											tcpPort(t, "postgres-replica", 5433),
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{
@@ -378,6 +382,7 @@ func TestCellReconciliation(t *testing.T) {
 											"--http-port", "15100",
 											"--grpc-port", "15170",
 											"--pg-port", "5432",
+											"--pg-replica-port", "5433",
 											"--topo-global-server-addresses", "global-topo:2379",
 											"--topo-global-root", "/multigres/global",
 											"--cell", "zone3",
@@ -387,6 +392,7 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 5432),
+											tcpPort(t, "postgres-replica", 5433),
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{
@@ -522,6 +528,7 @@ func TestCellReconciliation(t *testing.T) {
 											"--http-port", "15100",
 											"--grpc-port", "15170",
 											"--pg-port", "5432",
+											"--pg-replica-port", "5433",
 											"--topo-global-server-addresses", "global-topo:2379",
 											"--topo-global-root", "/multigres/global",
 											"--cell", "zone4",
@@ -531,6 +538,7 @@ func TestCellReconciliation(t *testing.T) {
 											tcpPort(t, "http", 15100),
 											tcpPort(t, "grpc", 15170),
 											tcpPort(t, "postgres", 5432),
+											tcpPort(t, "postgres-replica", 5433),
 										},
 										StartupProbe: &corev1.Probe{
 											ProbeHandler: corev1.ProbeHandler{

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -151,7 +151,7 @@ func BuildMultiGatewayDeployment(
 									Protocol:      corev1.ProtocolTCP,
 								},
 								{
-									Name:          "postgres-replica",
+									Name:          "pg-replica",
 									ContainerPort: MultiGatewayPostgresReplicaPort,
 									Protocol:      corev1.ProtocolTCP,
 								},

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -32,6 +32,9 @@ const (
 	// used by both the container and the Kubernetes Service.
 	MultiGatewayPostgresPort int32 = 5432
 
+	// MultiGatewayPostgresReplicaPort is the default port for replica-read database connections.
+	MultiGatewayPostgresReplicaPort int32 = 5433
+
 	// TLS volume/mount constants for the multigateway cert-manager certificate.
 	tlsVolumeName = "tls-certs"
 	tlsMountPath  = "/etc/multigateway/tls"
@@ -118,6 +121,8 @@ func BuildMultiGatewayDeployment(
 								fmt.Sprintf("%d", MultiGatewayGRPCPort),
 								"--pg-port",
 								fmt.Sprintf("%d", MultiGatewayPostgresPort),
+								"--pg-replica-port",
+								fmt.Sprintf("%d", MultiGatewayPostgresReplicaPort),
 								"--topo-global-server-addresses",
 								cell.Spec.GlobalTopoServer.Address,
 								"--topo-global-root",
@@ -143,6 +148,11 @@ func BuildMultiGatewayDeployment(
 								{
 									Name:          "postgres",
 									ContainerPort: MultiGatewayPostgresPort,
+									Protocol:      corev1.ProtocolTCP,
+								},
+								{
+									Name:          "postgres-replica",
+									ContainerPort: MultiGatewayPostgresReplicaPort,
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -125,7 +125,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -267,7 +267,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -409,7 +409,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -577,7 +577,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -762,7 +762,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -919,7 +919,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -1066,7 +1066,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -1208,7 +1208,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
@@ -1353,7 +1353,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 											Protocol:      corev1.ProtocolTCP,
 										},
 										{
-											Name:          "postgres-replica",
+											Name:          "pg-replica",
 											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -101,6 +101,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "zone1",
@@ -121,6 +122,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
@@ -237,6 +243,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "zone2",
@@ -257,6 +264,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
@@ -373,6 +385,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "zone3",
@@ -393,6 +406,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
@@ -535,6 +553,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "zone4",
@@ -555,6 +574,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
@@ -705,6 +729,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "zone5",
@@ -734,6 +759,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
@@ -865,6 +895,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "zone-labels",
@@ -885,6 +916,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
@@ -1006,6 +1042,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "zone-override",
@@ -1026,6 +1063,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
@@ -1142,6 +1184,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "zone-topo",
@@ -1162,6 +1205,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},
@@ -1281,6 +1329,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										"--http-port", "15100",
 										"--grpc-port", "15170",
 										"--pg-port", "5432",
+										"--pg-replica-port", "5433",
 										"--topo-global-server-addresses", "global-topo:2379",
 										"--topo-global-root", "/multigres/global",
 										"--cell", "region-cell",
@@ -1301,6 +1350,11 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 										{
 											Name:          "postgres",
 											ContainerPort: MultiGatewayPostgresPort,
+											Protocol:      corev1.ProtocolTCP,
+										},
+										{
+											Name:          "postgres-replica",
+											ContainerPort: MultiGatewayPostgresReplicaPort,
 											Protocol:      corev1.ProtocolTCP,
 										},
 									},


### PR DESCRIPTION
## Description

this pr adds a cluster-wide replica-read endpoint for multigateway while keeping the existing primary endpoint unchanged.

It enables the replica listener in multigateway pods by default and introduces a dedicated global Service so clients can explicitly target read-only traffic.

## Changes

- Enabled replica listener in cell multigateway deployments with `--pg-replica-port=5433`.
- Added container port `5433` named `postgres-replica` to multigateway pods.
- Added a new global Service builder for `<cluster>-multigateway-replica` as `ClusterIP`, using the same cluster-wide multigateway selector shape and exposing `5433 -> postgres-replica`.
- Updated global reconciliation to apply and own both Services:
  - `<cluster>-multigateway` for primary traffic on `5432`
  - `<cluster>-multigateway-replica` for replica traffic on `5433`

## Testing

Added coverage for the new replica service reconciliation error paths so failures are attributed to the replica endpoint instead of generic service patch ordering.

Updated integration expectations to assert the two-endpoint gateway contract explicitly: primary remains on `<cluster>-multigateway` and replica reads are served via `<cluster>-multigateway-replica`.
