### PR TITLE
feat(observability): ship logs from all runtime pods

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 | [README](../README.md) | Installation, configuration, resource hierarchy, and constraints |
 | [Backup & Restore](backup-restore.md) | pgBackRest integration, S3 and filesystem backends, TLS certificates |
 | [Observability](observability.md) | Metrics, alerts, dashboards, distributed tracing, structured logging |
+| [Runtime Log Schema](observability/log-schema.md) | Field definitions for enriched Multigres runtime logs |
 | [Durability Policy](durability-policy.md) | Durability policies, cross-AZ quorum, per-database overrides |
 | [Storage Management](storage.md) | PVC deletion policies and volume expansion |
 | [External Gateway](external-gateway.md) | External multigateway exposure, DNS wiring, GatewayExternalReady condition |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -122,6 +122,15 @@ The endpoint must speak **OTLP** (HTTP or gRPC) — this can be an OpenTelemetry
 
 The operator uses structured JSON logging (`zap` via controller-runtime). When tracing is enabled, every log line within a traced operation automatically includes `trace_id` and `span_id` fields, enabling **log-trace correlation** — click a log line in Grafana Loki to jump directly to the associated trace.
 
+### Runtime Log Shipping References
+
+The operator does not deploy a log collector for you, but it now provides the
+metadata needed for backend-agnostic runtime log shipping. Reference examples:
+
+- [Vector DaemonSet Example](observability/vector-daemonset.yaml)
+- [Log Collector RBAC Example](observability/log-collector-rbac.yaml)
+- [Runtime Log Schema](observability/log-schema.md)
+
 **Log level configuration:** The operator accepts standard controller-runtime zap flags on its command line:
 
 | Flag | Default | Description |

--- a/docs/observability/log-collector-rbac.yaml
+++ b/docs/observability/log-collector-rbac.yaml
@@ -1,0 +1,31 @@
+#
+# Reference example only.
+# This RBAC is NOT managed by the Multigres operator.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: log-collector
+  namespace: observability
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: log-collector-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: log-collector-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: log-collector-reader
+subjects:
+  - kind: ServiceAccount
+    name: log-collector
+    namespace: observability

--- a/docs/observability/log-schema.md
+++ b/docs/observability/log-schema.md
@@ -1,0 +1,67 @@
+# Log Schema
+
+This document describes the expected Multigres runtime log shape after a
+Kubernetes log collector enriches container stdout with pod metadata.
+
+The operator is responsible for making the data available:
+- structured logs to stdout
+- consistent labels for pod discovery
+- `multigres.com/project-ref` annotations for project attribution
+
+The collector is responsible for enrichment and shipping.
+
+## Required Fields
+
+| Field | Type | Description |
+|:---|:---|:---|
+| `timestamp` | ISO-8601 string | Event timestamp emitted by the runtime |
+| `level` | string | Log severity such as `debug`, `info`, `warn`, or `error` |
+| `message` | string | Human-readable log message |
+| `component` | string | Runtime component name |
+| `project` | string | Supabase project ref from `multigres.com/project-ref`, or cluster-name fallback |
+| `cluster` | string | Kubernetes cluster identity from `app.kubernetes.io/instance` |
+| `namespace` | string | Kubernetes namespace containing the pod |
+| `pod_name` | string | Kubernetes pod name |
+| `node_name` | string | Kubernetes node name |
+
+## Component Values
+
+The `component` field should resolve to one of the following values for logs in
+scope for this ticket:
+
+| Runtime | `component` value |
+|:---|:---|
+| Postgres container in pool pods | `postgres` |
+| Multipooler container in pool pods | `multipooler` |
+| MultiOrch pod | `multiorch` |
+| MultiGateway pod | `multigateway` |
+| Postgres exporter sidecar in pool pods | `postgres-exporter` |
+
+For `shard-pool` pods, the collector should use the container name to derive the
+runtime component, since multiple containers share the same pod.
+
+## Project Resolution
+
+Collectors should derive the `project` field using this order:
+
+1. `multigres.com/project-ref` pod annotation
+2. `app.kubernetes.io/instance` pod label
+
+In other words:
+- explicit project ref wins when configured
+- cluster name is the fallback when no explicit project ref is set
+
+## Example Event
+
+```json
+{
+  "timestamp": "2025-01-15T10:30:00.123Z",
+  "level": "info",
+  "message": "checkpoint complete: wrote 42 buffers",
+  "component": "postgres",
+  "project": "proj-abc123",
+  "cluster": "my-cluster",
+  "namespace": "multigres-prod",
+  "pod_name": "my-cluster-postgres-default-0-pool-primary-zone1-0",
+  "node_name": "ip-10-0-1-42.ec2.internal"
+}

--- a/docs/observability/vector-daemonset.yaml
+++ b/docs/observability/vector-daemonset.yaml
@@ -1,0 +1,96 @@
+#
+# Reference example only.
+# This manifest is NOT managed by the Multigres operator.
+#
+# Replace the placeholder image, namespace, and sink configuration to match
+# your environment and log backend.
+#
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector
+  namespace: observability
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vector
+  namespace: observability
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vector
+    spec:
+      serviceAccountName: vector
+      containers:
+        - name: vector
+          image: timberio/vector:0.40.1-alpine
+          args:
+            - --config
+            - /etc/vector/vector.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /etc/vector
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: vector-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-config
+  namespace: observability
+data:
+  vector.yaml: |
+    sources:
+      kubernetes_logs:
+        type: kubernetes_logs
+        extra_label_selector: "app.kubernetes.io/managed-by=multigres-operator"
+        auto_partial_merge: true
+
+    transforms:
+      enrich_logs:
+        type: remap
+        inputs:
+          - kubernetes_logs
+        source: |
+          .project = get(., ["kubernetes", "pod_annotations", "multigres.com/project-ref"]) ??
+                     get(., ["kubernetes", "pod_labels", "app.kubernetes.io/instance"]) ??
+                     "unknown"
+
+          raw_component = get(., ["kubernetes", "pod_labels", "app.kubernetes.io/component"]) ?? "unknown"
+          if raw_component == "shard-pool" {
+            .component = .kubernetes.container_name ?? raw_component
+          } else {
+            .component = raw_component
+          }
+
+          .cluster = get(., ["kubernetes", "pod_labels", "app.kubernetes.io/instance"]) ?? "unknown"
+          .namespace = .kubernetes.pod_namespace
+          .pod_name = .kubernetes.pod_name
+          .node_name = .kubernetes.pod_node_name
+
+          del(.kubernetes)
+          del(.file)
+          del(.source_type)
+
+    sinks:
+      # Replace this console sink with your real backend.
+      # Common choices: Loki, S3, Elasticsearch, or an HTTP endpoint.
+      log_sink:
+        type: console
+        inputs:
+          - enrich_logs
+        encoding:
+          codec: json

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/multigres/multigres v0.0.0-20260410093709-cbc77e3b0997
+	pgregory.net/rapid v1.2.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/multigres/multigres v0.0.0-20260410093709-cbc77e3b0997
-	pgregory.net/rapid v1.2.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,6 @@ k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 h1:HhDfevmPS+OalTjQRKbTHp
 k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20260108192941-914a6e750570 h1:JT4W8lsdrGENg9W+YwwdLJxklIuKWdRm+BC+xt33FOY=
 k8s.io/utils v0.0.0-20260108192941-914a6e750570/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
-pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
-pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=

--- a/go.sum
+++ b/go.sum
@@ -403,6 +403,8 @@ k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 h1:HhDfevmPS+OalTjQRKbTHp
 k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20260108192941-914a6e750570 h1:JT4W8lsdrGENg9W+YwwdLJxklIuKWdRm+BC+xt33FOY=
 k8s.io/utils v0.0.0-20260108192941-914a6e750570/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
+pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
+pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.22.4 h1:GEjV7KV3TY8e+tJ2LCTxUTanW4z/FmNB7l327UfMq9A=

--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
@@ -24,13 +24,20 @@ func BuildCell(
 	labels := metadata.BuildStandardLabels(cluster.Name, metadata.ComponentCell)
 	metadata.AddClusterLabel(labels, cluster.Name)
 	metadata.AddCellLabel(labels, cellCfg.Name)
+	var annotations map[string]string
+	if projectRef := cluster.Annotations[metadata.AnnotationProjectRef]; projectRef != "" {
+		annotations = map[string]string{
+			metadata.AnnotationProjectRef: projectRef,
+		}
+	}
 
 	cellCR := &multigresv1alpha1.Cell{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name.JoinWithConstraints(
 				name.DefaultConstraints, cluster.Name, string(cellCfg.Name)),
-			Namespace: cluster.Namespace,
-			Labels:    labels,
+			Namespace:   cluster.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: multigresv1alpha1.CellSpec{
 			Name:   cellCfg.Name,

--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	"github.com/multigres/multigres-operator/pkg/util/name"
 )
 
@@ -94,6 +95,36 @@ func TestBuildCell(t *testing.T) {
 		)
 		if err == nil {
 			t.Error("Expected error due to missing scheme types, got nil")
+		}
+	})
+
+	t.Run("Propagates explicit project ref annotation", func(t *testing.T) {
+		clusterWithProjectRef := cluster.DeepCopy()
+		clusterWithProjectRef.Annotations = map[string]string{
+			metadata.AnnotationProjectRef: "proj_123",
+		}
+
+		got, err := BuildCell(
+			clusterWithProjectRef,
+			cellCfg,
+			gatewaySpec,
+			noGatewayPlacement,
+			localTopoSpec,
+			globalTopoRef,
+			allCells,
+			scheme,
+		)
+		if err != nil {
+			t.Fatalf("BuildCell() error = %v", err)
+		}
+
+		if got.Annotations[metadata.AnnotationProjectRef] != "proj_123" {
+			t.Fatalf(
+				"annotation %q = %q, want %q",
+				metadata.AnnotationProjectRef,
+				got.Annotations[metadata.AnnotationProjectRef],
+				"proj_123",
+			)
 		}
 	})
 }

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
@@ -30,12 +30,19 @@ func BuildTableGroup(
 	metadata.AddClusterLabel(labels, cluster.Name)
 	metadata.AddDatabaseLabel(labels, dbCfg.Name)
 	metadata.AddTableGroupLabel(labels, tgCfg.Name)
+	var annotations map[string]string
+	if projectRef := cluster.Annotations[metadata.AnnotationProjectRef]; projectRef != "" {
+		annotations = map[string]string{
+			metadata.AnnotationProjectRef: projectRef,
+		}
+	}
 
 	tgCR := &multigresv1alpha1.TableGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      tgNameHash,
-			Namespace: cluster.Namespace,
-			Labels:    labels,
+			Name:        tgNameHash,
+			Namespace:   cluster.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: multigresv1alpha1.TableGroupSpec{
 			DatabaseName:   dbCfg.Name,

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -137,6 +138,36 @@ func TestBuildTableGroup(t *testing.T) {
 		)
 		if err == nil {
 			t.Error("Expected error due to missing scheme types, got nil")
+		}
+	})
+
+	t.Run("Propagates explicit project ref annotation", func(t *testing.T) {
+		clusterWithProjectRef := cluster.DeepCopy()
+		clusterWithProjectRef.Annotations = map[string]string{
+			metadata.AnnotationProjectRef: "proj_123",
+		}
+		tgCfg := &multigresv1alpha1.TableGroupConfig{Name: "tg-with-project-ref"}
+		resolvedShards := []multigresv1alpha1.ShardResolvedSpec{{Name: "shard-0"}}
+
+		got, err := BuildTableGroup(
+			clusterWithProjectRef,
+			dbCfg,
+			tgCfg,
+			resolvedShards,
+			globalTopoRef,
+			scheme,
+		)
+		if err != nil {
+			t.Fatalf("BuildTableGroup() error = %v", err)
+		}
+
+		if got.Annotations[metadata.AnnotationProjectRef] != "proj_123" {
+			t.Fatalf(
+				"annotation %q = %q, want %q",
+				metadata.AnnotationProjectRef,
+				got.Annotations[metadata.AnnotationProjectRef],
+				"proj_123",
+			)
 		}
 	})
 }

--- a/pkg/cluster-handler/controller/tablegroup/builders.go
+++ b/pkg/cluster-handler/controller/tablegroup/builders.go
@@ -33,12 +33,19 @@ func BuildShard(
 	metadata.AddDatabaseLabel(labels, tg.Spec.DatabaseName)
 	metadata.AddTableGroupLabel(labels, tg.Spec.TableGroupName)
 	metadata.AddShardLabel(labels, multigresv1alpha1.ShardName(shardSpec.Name))
+	var annotations map[string]string
+	if projectRef := tg.Annotations[metadata.AnnotationProjectRef]; projectRef != "" {
+		annotations = map[string]string{
+			metadata.AnnotationProjectRef: projectRef,
+		}
+	}
 
 	shardCR := &multigresv1alpha1.Shard{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      shardNameFull,
-			Namespace: tg.Namespace,
-			Labels:    labels,
+			Name:        shardNameFull,
+			Namespace:   tg.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: multigresv1alpha1.ShardSpec{
 			DatabaseName:      tg.Spec.DatabaseName,

--- a/pkg/cluster-handler/controller/tablegroup/builders_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/builders_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	"github.com/multigres/multigres-operator/pkg/util/name"
 )
 
@@ -121,6 +122,27 @@ func TestBuildShard(t *testing.T) {
 		_, err := BuildShard(tg, shardSpec, emptyScheme)
 		if err == nil {
 			t.Error("Expected error due to missing scheme types, got nil")
+		}
+	})
+
+	t.Run("Propagates explicit project ref annotation", func(t *testing.T) {
+		tgWithProjectRef := tg.DeepCopy()
+		tgWithProjectRef.Annotations = map[string]string{
+			metadata.AnnotationProjectRef: "proj_123",
+		}
+
+		got, err := BuildShard(tgWithProjectRef, shardSpec, scheme)
+		if err != nil {
+			t.Fatalf("BuildShard() error = %v", err)
+		}
+
+		if got.Annotations[metadata.AnnotationProjectRef] != "proj_123" {
+			t.Fatalf(
+				"annotation %q = %q, want %q",
+				metadata.AnnotationProjectRef,
+				got.Annotations[metadata.AnnotationProjectRef],
+				"proj_123",
+			)
 		}
 	})
 }

--- a/pkg/resource-handler/controller/cell/integration_test.go
+++ b/pkg/resource-handler/controller/cell/integration_test.go
@@ -113,6 +113,9 @@ func TestCellReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -240,6 +243,9 @@ func TestCellReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -367,6 +373,9 @@ func TestCellReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -511,6 +520,9 @@ func TestCellReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -86,6 +86,9 @@ func BuildMultiGatewayDeployment(
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
+	delete(annotations, metadata.AnnotationPrometheusScrape)
+	delete(annotations, metadata.AnnotationPrometheusPort)
+	delete(annotations, metadata.AnnotationPrometheusPath)
 	annotations[metadata.AnnotationProjectRef] = metadata.ResolveProjectRef(
 		cell.Annotations,
 		clusterName,

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -2,6 +2,7 @@ package cell
 
 import (
 	"fmt"
+	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -81,6 +82,14 @@ func BuildMultiGatewayDeployment(
 	name := BuildMultiGatewayDeploymentName(cell)
 	clusterName := cell.Labels["multigres.com/cluster"]
 	labels := metadata.BuildStandardLabels(clusterName, MultiGatewayComponentName)
+	annotations := maps.Clone(cell.Spec.MultiGateway.PodAnnotations)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[metadata.AnnotationProjectRef] = metadata.ResolveProjectRef(
+		cell.Annotations,
+		clusterName,
+	)
 	metadata.AddCellLabel(labels, cell.Spec.Name)
 	if cell.Spec.Zone != "" {
 		metadata.AddZoneLabel(labels, cell.Spec.Zone)
@@ -103,7 +112,7 @@ func BuildMultiGatewayDeployment(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      metadata.MergeLabels(labels, cell.Spec.MultiGateway.PodLabels),
-					Annotations: cell.Spec.MultiGateway.PodAnnotations,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -802,8 +802,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 							"sidecar-inject": "true",
 						},
 						PodAnnotations: map[string]string{
-							"prometheus.io/scrape": "true",
-							"prometheus.io/port":   "15100",
+							"custom-annotation": "keep-me",
 						},
 					},
 				},
@@ -852,8 +851,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 								"sidecar-inject":               "true",
 							},
 							Annotations: map[string]string{
-								"prometheus.io/scrape": "true",
-								"prometheus.io/port":   "15100",
+								"custom-annotation": "keep-me",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -1483,6 +1481,61 @@ func TestBuildMultiGatewayDeployment_ProjectRefAnnotation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildMultiGatewayDeployment_OmitsPrometheusScrapeAnnotations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	cell := &multigresv1alpha1.Cell{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cell",
+			Namespace: "default",
+			UID:       "test-uid",
+			Labels:    map[string]string{metadata.LabelMultigresCluster: "test-cluster"},
+		},
+		Spec: multigresv1alpha1.CellSpec{
+			Name: "zone1",
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+				Address:        "global-topo:2379",
+				RootPath:       "/multigres/global",
+				Implementation: "etcd",
+			},
+			LogLevels: multigresv1alpha1.ComponentLogLevels{
+				Pgctld:       "info",
+				Multipooler:  "info",
+				Multiorch:    "info",
+				Multiadmin:   "info",
+				Multigateway: "info",
+			},
+			MultiGateway: multigresv1alpha1.StatelessSpec{
+				PodAnnotations: map[string]string{
+					metadata.AnnotationPrometheusScrape: "true",
+					metadata.AnnotationPrometheusPort:   "15100",
+					metadata.AnnotationPrometheusPath:   "/metrics",
+					"custom-annotation":                 "keep-me",
+				},
+			},
+		},
+	}
+
+	deploy, err := BuildMultiGatewayDeployment(cell, scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := deploy.Spec.Template.Annotations[metadata.AnnotationPrometheusScrape]; ok {
+		t.Fatalf("annotation %q should be omitted", metadata.AnnotationPrometheusScrape)
+	}
+	if _, ok := deploy.Spec.Template.Annotations[metadata.AnnotationPrometheusPort]; ok {
+		t.Fatalf("annotation %q should be omitted", metadata.AnnotationPrometheusPort)
+	}
+	if _, ok := deploy.Spec.Template.Annotations[metadata.AnnotationPrometheusPath]; ok {
+		t.Fatalf("annotation %q should be omitted", metadata.AnnotationPrometheusPath)
+	}
+	if got := deploy.Spec.Template.Annotations["custom-annotation"]; got != "keep-me" {
+		t.Fatalf("custom annotation = %q, want %q", got, "keep-me")
 	}
 }
 

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	"github.com/multigres/multigres-operator/pkg/util/name"
 )
 
@@ -1389,6 +1390,13 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 					tc.want.Spec.Template.Labels["app.kubernetes.io/instance"] = tc.cell.Labels["multigres.com/cluster"]
 					tc.want.Spec.Template.Labels["multigres.com/cell"] = string(tc.cell.Spec.Name)
 				}
+				if tc.want.Spec.Template.Annotations == nil {
+					tc.want.Spec.Template.Annotations = map[string]string{}
+				}
+				tc.want.Spec.Template.Annotations[metadata.AnnotationProjectRef] = metadata.ResolveProjectRef(
+					tc.cell.Annotations,
+					tc.cell.Labels[metadata.LabelMultigresCluster],
+				)
 			}
 
 			got, err := BuildMultiGatewayDeployment(tc.cell, tc.scheme)
@@ -1404,6 +1412,75 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("BuildMultiGatewayDeployment() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildMultiGatewayDeployment_ProjectRefAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	tests := map[string]struct {
+		annotations map[string]string
+		want        string
+	}{
+		"falls back to cluster name": {
+			want: "test-cluster",
+		},
+		"uses explicit project ref": {
+			annotations: map[string]string{
+				metadata.AnnotationProjectRef: "proj_123",
+			},
+			want: "proj_123",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cell := &multigresv1alpha1.Cell{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-cell",
+					Namespace:   "default",
+					UID:         "test-uid",
+					Labels:      map[string]string{metadata.LabelMultigresCluster: "test-cluster"},
+					Annotations: tc.annotations,
+				},
+				Spec: multigresv1alpha1.CellSpec{
+					Name: "zone1",
+					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+						Address:        "global-topo:2379",
+						RootPath:       "/multigres/global",
+						Implementation: "etcd",
+					},
+					LogLevels: multigresv1alpha1.ComponentLogLevels{
+						Pgctld:       "info",
+						Multipooler:  "info",
+						Multiorch:    "info",
+						Multiadmin:   "info",
+						Multigateway: "info",
+					},
+				},
+			}
+
+			deploy, err := BuildMultiGatewayDeployment(cell, scheme)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := deploy.Spec.Template.Annotations[metadata.AnnotationProjectRef]; got != tc.want {
+				t.Fatalf("annotation %q = %q, want %q", metadata.AnnotationProjectRef, got, tc.want)
+			}
+
+			assertedLabels := map[string]string{
+				metadata.LabelAppInstance:  "test-cluster",
+				metadata.LabelAppComponent: MultiGatewayComponentName,
+				metadata.LabelAppManagedBy: metadata.ManagedByMultigres,
+			}
+			for key, want := range assertedLabels {
+				if got := deploy.Spec.Template.Labels[key]; got != want {
+					t.Fatalf("label %q = %q, want %q", key, got, want)
+				}
 			}
 		})
 	}

--- a/pkg/resource-handler/controller/shard/integration_test.go
+++ b/pkg/resource-handler/controller/shard/integration_test.go
@@ -131,6 +131,9 @@ func TestShardReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: shardLabels(t, "test-shard-multiorch-zone-a", "multiorch", "zone-a"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -218,6 +221,9 @@ func TestShardReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: shardLabels(t, "test-shard-multiorch-zone-b", "multiorch", "zone-b"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -380,6 +386,9 @@ func TestShardReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: shardLabels(t, "delete-policy-shard-multiorch-zone-a", "multiorch", "zone-a"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -538,6 +547,9 @@ func TestShardReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: shardLabels(t, "multi-cell-shard-multiorch-zone1", "multiorch", "zone1"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{
@@ -625,6 +637,9 @@ func TestShardReconciliation(t *testing.T) {
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: shardLabels(t, "multi-cell-shard-multiorch-zone2", "multiorch", "zone2"),
+								Annotations: map[string]string{
+									"multigres.com/project-ref": "test-cluster",
+								},
 							},
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{

--- a/pkg/resource-handler/controller/shard/multiorch.go
+++ b/pkg/resource-handler/controller/shard/multiorch.go
@@ -2,6 +2,7 @@ package shard
 
 import (
 	"fmt"
+	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,7 +36,16 @@ func BuildMultiOrchDeployment(
 
 	// Use DefaultConstraints (253 chars) for Deployments => Long, Readable Names
 	name := buildMultiOrchNameWithCell(shard, cellName, nameutil.DefaultConstraints)
+	clusterName := shard.Labels["multigres.com/cluster"]
 	labels := buildMultiOrchLabelsWithCell(shard, cellName)
+	annotations := maps.Clone(shard.Spec.MultiOrch.PodAnnotations)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[metadata.AnnotationProjectRef] = metadata.ResolveProjectRef(
+		shard.Annotations,
+		clusterName,
+	)
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -51,7 +61,7 @@ func BuildMultiOrchDeployment(
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      metadata.MergeLabels(labels, shard.Spec.MultiOrch.PodLabels),
-					Annotations: shard.Spec.MultiOrch.PodAnnotations,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/pkg/resource-handler/controller/shard/multiorch.go
+++ b/pkg/resource-handler/controller/shard/multiorch.go
@@ -42,6 +42,9 @@ func BuildMultiOrchDeployment(
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
+	delete(annotations, metadata.AnnotationPrometheusScrape)
+	delete(annotations, metadata.AnnotationPrometheusPort)
+	delete(annotations, metadata.AnnotationPrometheusPath)
 	annotations[metadata.AnnotationProjectRef] = metadata.ResolveProjectRef(
 		shard.Annotations,
 		clusterName,

--- a/pkg/resource-handler/controller/shard/multiorch_test.go
+++ b/pkg/resource-handler/controller/shard/multiorch_test.go
@@ -346,8 +346,7 @@ func TestBuildMultiOrchDeployment(t *testing.T) {
 								"sidecar-inject": "true",
 							},
 							PodAnnotations: map[string]string{
-								"prometheus.io/scrape": "true",
-								"prometheus.io/port":   "8080",
+								"custom-annotation": "keep-me",
 							},
 							Affinity: &corev1.Affinity{
 								PodAntiAffinity: &corev1.PodAntiAffinity{
@@ -433,8 +432,7 @@ func TestBuildMultiOrchDeployment(t *testing.T) {
 								"sidecar-inject":               "true",
 							},
 							Annotations: map[string]string{
-								"prometheus.io/scrape": "true",
-								"prometheus.io/port":   "8080",
+								"custom-annotation": "keep-me",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -699,6 +697,59 @@ func TestBuildMultiOrchDeployment_ProjectRefAnnotation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildMultiOrchDeployment_OmitsPrometheusScrapeAnnotations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labels-shard",
+			Namespace: "default",
+			UID:       "labels-uid",
+			Labels:    map[string]string{metadata.LabelMultigresCluster: "labels-cluster"},
+		},
+		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:   "testdb",
+			TableGroupName: "default",
+			ShardName:      "0",
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+				Address:        "global-topo:2379",
+				RootPath:       "/multigres/global",
+				Implementation: "etcd",
+			},
+			MultiOrch: multigresv1alpha1.MultiOrchSpec{
+				StatelessSpec: multigresv1alpha1.StatelessSpec{
+					PodAnnotations: map[string]string{
+						metadata.AnnotationPrometheusScrape: "true",
+						metadata.AnnotationPrometheusPort:   "8080",
+						metadata.AnnotationPrometheusPath:   "/metrics",
+						"custom-annotation":                 "keep-me",
+					},
+				},
+				Cells: []multigresv1alpha1.CellName{"zone-a"},
+			},
+		},
+	}
+
+	deploy, err := BuildMultiOrchDeployment(shard, "zone-a", scheme)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := deploy.Spec.Template.Annotations[metadata.AnnotationPrometheusScrape]; ok {
+		t.Fatalf("annotation %q should be omitted", metadata.AnnotationPrometheusScrape)
+	}
+	if _, ok := deploy.Spec.Template.Annotations[metadata.AnnotationPrometheusPort]; ok {
+		t.Fatalf("annotation %q should be omitted", metadata.AnnotationPrometheusPort)
+	}
+	if _, ok := deploy.Spec.Template.Annotations[metadata.AnnotationPrometheusPath]; ok {
+		t.Fatalf("annotation %q should be omitted", metadata.AnnotationPrometheusPath)
+	}
+	if got := deploy.Spec.Template.Annotations["custom-annotation"]; got != "keep-me" {
+		t.Fatalf("custom annotation = %q, want %q", got, "keep-me")
 	}
 }
 

--- a/pkg/resource-handler/controller/shard/multiorch_test.go
+++ b/pkg/resource-handler/controller/shard/multiorch_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	nameutil "github.com/multigres/multigres-operator/pkg/util/name"
 )
 
@@ -607,6 +608,13 @@ func TestBuildMultiOrchDeployment(t *testing.T) {
 					nameutil.DefaultConstraints,
 				)
 				tc.want.Name = hashedName
+				if tc.want.Spec.Template.Annotations == nil {
+					tc.want.Spec.Template.Annotations = map[string]string{}
+				}
+				tc.want.Spec.Template.Annotations[metadata.AnnotationProjectRef] = metadata.ResolveProjectRef(
+					tc.shard.Annotations,
+					tc.shard.Labels[metadata.LabelMultigresCluster],
+				)
 			}
 
 			got, err := BuildMultiOrchDeployment(tc.shard, tc.cellName, tc.scheme)
@@ -622,6 +630,73 @@ func TestBuildMultiOrchDeployment(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("BuildMultiOrchDeployment() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildMultiOrchDeployment_ProjectRefAnnotation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	tests := map[string]struct {
+		annotations map[string]string
+		want        string
+	}{
+		"falls back to cluster name": {
+			want: "test-cluster",
+		},
+		"uses explicit project ref": {
+			annotations: map[string]string{
+				metadata.AnnotationProjectRef: "proj_123",
+			},
+			want: "proj_123",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			shard := &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-shard",
+					Namespace:   "default",
+					UID:         "test-uid",
+					Labels:      map[string]string{metadata.LabelMultigresCluster: "test-cluster"},
+					Annotations: tc.annotations,
+				},
+				Spec: multigresv1alpha1.ShardSpec{
+					DatabaseName:   "testdb",
+					TableGroupName: "default",
+					ShardName:      "0",
+					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+						Address:        "global-topo:2379",
+						RootPath:       "/multigres/global",
+						Implementation: "etcd",
+					},
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						Cells: []multigresv1alpha1.CellName{"zone-a"},
+					},
+				},
+			}
+
+			deploy, err := BuildMultiOrchDeployment(shard, "zone-a", scheme)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := deploy.Spec.Template.Annotations[metadata.AnnotationProjectRef]; got != tc.want {
+				t.Fatalf("annotation %q = %q, want %q", metadata.AnnotationProjectRef, got, tc.want)
+			}
+
+			assertedLabels := map[string]string{
+				metadata.LabelAppInstance:  "test-cluster",
+				metadata.LabelAppComponent: MultiOrchComponentName,
+				metadata.LabelAppManagedBy: metadata.ManagedByMultigres,
+			}
+			for key, want := range assertedLabels {
+				if got := deploy.Spec.Template.Labels[key]; got != want {
+					t.Fatalf("label %q = %q, want %q", key, got, want)
+				}
 			}
 		})
 	}

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -58,6 +58,7 @@ func BuildPoolPod(
 	scheme *runtime.Scheme,
 ) (*corev1.Pod, error) {
 	podName := BuildPoolPodName(shard, poolName, cellName, index)
+	clusterName := shard.Labels["multigres.com/cluster"]
 	labels := buildPoolLabelsWithCell(shard, poolName, cellName)
 
 	// Construct volumes: reuse shared volumes and prepend the per-pod data PVC.
@@ -76,6 +77,10 @@ func BuildPoolPod(
 
 	annotations := map[string]string{
 		metadata.AnnotationSpecHash: "", // placeholder, computed below
+		metadata.AnnotationProjectRef: metadata.ResolveProjectRef(
+			shard.Annotations,
+			clusterName,
+		),
 	}
 	if h := shard.Annotations[metadata.AnnotationPostgresConfigHash]; h != "" {
 		annotations[metadata.AnnotationPostgresConfigHash] = h

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -81,6 +81,9 @@ func BuildPoolPod(
 			shard.Annotations,
 			clusterName,
 		),
+		metadata.AnnotationPrometheusScrape: "true",
+		metadata.AnnotationPrometheusPort:   "9187",
+		metadata.AnnotationPrometheusPath:   "/metrics",
 	}
 	if h := shard.Annotations[metadata.AnnotationPostgresConfigHash]; h != "" {
 		annotations[metadata.AnnotationPostgresConfigHash] = h

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -125,6 +125,24 @@ func TestBuildPoolPod_ProjectRefAnnotation(t *testing.T) {
 	}
 }
 
+func TestBuildPoolPod_PrometheusScrapeAnnotations(t *testing.T) {
+	pod, err := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantAnnotations := map[string]string{
+		metadata.AnnotationPrometheusScrape: "true",
+		metadata.AnnotationPrometheusPort:   "9187",
+		metadata.AnnotationPrometheusPath:   "/metrics",
+	}
+	for key, want := range wantAnnotations {
+		if got := pod.Annotations[key]; got != want {
+			t.Fatalf("annotation %q = %q, want %q", key, got, want)
+		}
+	}
+}
+
 func TestBuildPoolPod_Containers(t *testing.T) {
 	pod, err := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
 	if err != nil {

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -71,6 +71,7 @@ func TestBuildPoolPod_BasicStructure(t *testing.T) {
 
 	// Verify labels
 	expectedLabels := map[string]string{
+		"app.kubernetes.io/instance":   "test-cluster",
 		"app.kubernetes.io/component":  PoolComponentName,
 		"app.kubernetes.io/managed-by": "multigres-operator",
 		"multigres.com/cluster":        "test-cluster",
@@ -84,6 +85,43 @@ func TestBuildPoolPod_BasicStructure(t *testing.T) {
 		if got := pod.Labels[k]; got != want {
 			t.Errorf("label %q = %q, want %q", k, got, want)
 		}
+	}
+
+	if got := pod.Annotations[metadata.AnnotationProjectRef]; got != "test-cluster" {
+		t.Errorf("annotation %q = %q, want %q", metadata.AnnotationProjectRef, got, "test-cluster")
+	}
+}
+
+func TestBuildPoolPod_ProjectRefAnnotation(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		want        string
+	}{
+		"falls back to cluster name": {
+			want: "test-cluster",
+		},
+		"uses explicit project ref": {
+			annotations: map[string]string{
+				metadata.AnnotationProjectRef: "proj_123",
+			},
+			want: "proj_123",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			shard := newTestShard()
+			shard.Annotations = tc.annotations
+
+			pod, err := BuildPoolPod(shard, "main", "z1", newTestPoolSpec(), 0, testScheme())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := pod.Annotations[metadata.AnnotationProjectRef]; got != tc.want {
+				t.Fatalf("annotation %q = %q, want %q", metadata.AnnotationProjectRef, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/util/metadata/project_ref.go
+++ b/pkg/util/metadata/project_ref.go
@@ -1,0 +1,16 @@
+package metadata
+
+const (
+	// AnnotationProjectRef carries the downstream-facing project identity used
+	// by observability collectors. When absent, cluster name is the fallback.
+	AnnotationProjectRef = "multigres.com/project-ref"
+)
+
+// ResolveProjectRef returns the explicit project ref when present and
+// non-empty, otherwise it falls back to the cluster name.
+func ResolveProjectRef(annotations map[string]string, clusterName string) string {
+	if ref := annotations[AnnotationProjectRef]; ref != "" {
+		return ref
+	}
+	return clusterName
+}

--- a/pkg/util/metadata/project_ref.go
+++ b/pkg/util/metadata/project_ref.go
@@ -4,6 +4,11 @@ const (
 	// AnnotationProjectRef carries the downstream-facing project identity used
 	// by observability collectors. When absent, cluster name is the fallback.
 	AnnotationProjectRef = "multigres.com/project-ref"
+
+	// Prometheus scrape annotations for autodiscovery of exporter endpoints.
+	AnnotationPrometheusScrape = "prometheus.io/scrape"
+	AnnotationPrometheusPort   = "prometheus.io/port"
+	AnnotationPrometheusPath   = "prometheus.io/path"
 )
 
 // ResolveProjectRef returns the explicit project ref when present and

--- a/pkg/util/metadata/project_ref_test.go
+++ b/pkg/util/metadata/project_ref_test.go
@@ -3,37 +3,46 @@ package metadata_test
 import (
 	"testing"
 
-	"pgregory.net/rapid"
-
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
 
-func TestResolveProjectRef_Property(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		clusterName := rapid.String().Draw(t, "cluster_name")
-		projectRef := rapid.String().Draw(t, "project_ref")
-		hasAnnotation := rapid.Bool().Draw(t, "has_annotation")
-		useNilMap := rapid.Bool().Draw(t, "use_nil_map")
+func TestResolveProjectRef(t *testing.T) {
+	tests := map[string]struct {
+		annotations map[string]string
+		clusterName string
+		want        string
+	}{
+		"uses explicit project ref": {
+			annotations: map[string]string{
+				metadata.AnnotationProjectRef: "proj_123",
+			},
+			clusterName: "cluster-a",
+			want:        "proj_123",
+		},
+		"falls back when annotation missing": {
+			annotations: map[string]string{},
+			clusterName: "cluster-b",
+			want:        "cluster-b",
+		},
+		"falls back when annotations are nil": {
+			clusterName: "cluster-c",
+			want:        "cluster-c",
+		},
+		"falls back when annotation empty": {
+			annotations: map[string]string{
+				metadata.AnnotationProjectRef: "",
+			},
+			clusterName: "cluster-d",
+			want:        "cluster-d",
+		},
+	}
 
-		var annotations map[string]string
-		if !useNilMap {
-			annotations = map[string]string{}
-		}
-		if hasAnnotation {
-			if annotations == nil {
-				annotations = map[string]string{}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := metadata.ResolveProjectRef(tc.annotations, tc.clusterName)
+			if got != tc.want {
+				t.Fatalf("ResolveProjectRef() = %q, want %q", got, tc.want)
 			}
-			annotations[metadata.AnnotationProjectRef] = projectRef
-		}
-
-		want := clusterName
-		if hasAnnotation && projectRef != "" {
-			want = projectRef
-		}
-
-		got := metadata.ResolveProjectRef(annotations, clusterName)
-		if got != want {
-			t.Fatalf("ResolveProjectRef() = %q, want %q", got, want)
-		}
-	})
+		})
+	}
 }

--- a/pkg/util/metadata/project_ref_test.go
+++ b/pkg/util/metadata/project_ref_test.go
@@ -1,0 +1,39 @@
+package metadata_test
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+func TestResolveProjectRef_Property(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		clusterName := rapid.String().Draw(t, "cluster_name")
+		projectRef := rapid.String().Draw(t, "project_ref")
+		hasAnnotation := rapid.Bool().Draw(t, "has_annotation")
+		useNilMap := rapid.Bool().Draw(t, "use_nil_map")
+
+		var annotations map[string]string
+		if !useNilMap {
+			annotations = map[string]string{}
+		}
+		if hasAnnotation {
+			if annotations == nil {
+				annotations = map[string]string{}
+			}
+			annotations[metadata.AnnotationProjectRef] = projectRef
+		}
+
+		want := clusterName
+		if hasAnnotation && projectRef != "" {
+			want = projectRef
+		}
+
+		got := metadata.ResolveProjectRef(annotations, clusterName)
+		if got != want {
+			t.Fatalf("ResolveProjectRef() = %q, want %q", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Description

this pr makes runtime logs from multigres workloads consistently attributable and discoverable.

It propagates `multigres.com/project-ref` from cluster resources down to the actual runtime pods that produce logs, adds Prometheus scrape annotations for the postgres exporter on shard pool pods, and includes reference docs and manifests for backend-agnostic log collection.

## Changes

- Propagated `multigres.com/project-ref` through the resource chain from cluster resources into cells, tablegroups, shards, and runtime pods.
- Added `multigres.com/project-ref` pod-template annotations to shard pool pods, multiorch deployments, and multigateway deployments.
- Added Prometheus scrape annotations to shard pool pods so postgres-exporter can be autodiscovered at `:9187/metrics`.
- Added reference observability docs and manifests for runtime log collection:
  - `docs/observability/vector-daemonset.yaml`
  - `docs/observability/log-collector-rbac.yaml`
  - `docs/observability/log-schema.md`
- Updated observability docs to link the new runtime log shipping references.

## Testing

Updated shard and cell reconciliation expectations to assert the new `multigres.com/project-ref` pod-template annotation on multiorch and multigateway deployments.

Verified shard pool pods advertise postgres-exporter with Prometheus scrape metadata, while multiorch and multigateway pods do not expose misleading scrape annotations.
