### PR TITLE
fix: bump image defaults

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -5,25 +5,25 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-cbc77e3"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-d782aa0"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiAdminImage is the default container image for the MultiAdmin component.
-	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-cbc77e3"
+	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-d782aa0"
 
 	// DefaultMultiAdminWebImage is the default container image for the MultiAdminWeb component.
 	DefaultMultiAdminWebImage = "ghcr.io/multigres/multiadmin-web:sha-d7be6e4"
 
 	// DefaultMultiOrchImage is the default container image for the MultiOrch component.
-	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-cbc77e3"
+	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-d782aa0"
 
 	// DefaultMultiPoolerImage is the default container image for the MultiPooler component.
-	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-cbc77e3"
+	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-d782aa0"
 
 	// DefaultMultiGatewayImage is the default container image for the MultiGateway component.
-	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-cbc77e3"
+	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-d782aa0"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
 	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"


### PR DESCRIPTION
Older multigateway doesn't recognize the new flag `--pg-replica-port` introduced in 5ac09a6