### PR TITLE
fix(observability): reconcile project-ref annotation updates on existing clusters

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -375,7 +376,9 @@ func (r *MultigresClusterReconciler) SetupWithManager(
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&multigresv1alpha1.MultigresCluster{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&multigresv1alpha1.MultigresCluster{},
+			builder.WithPredicates(projectRefOrGenerationChangedPredicate()),
+		).
 		Owns(&multigresv1alpha1.Cell{}).
 		Owns(&multigresv1alpha1.TableGroup{}).
 		Owns(&multigresv1alpha1.TopoServer{}).
@@ -395,6 +398,36 @@ func (r *MultigresClusterReconciler) SetupWithManager(
 		).
 		WithOptions(controllerOpts).
 		Complete(r)
+}
+
+// projectRefOrGenerationChangedPredicate requeues when desired child state can
+// change due to either spec updates or project-ref annotation updates.
+func projectRefOrGenerationChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+
+			oldAnnotations := e.ObjectOld.GetAnnotations()
+			newAnnotations := e.ObjectNew.GetAnnotations()
+			return oldAnnotations[metadata.AnnotationProjectRef] !=
+				newAnnotations[metadata.AnnotationProjectRef]
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return true
+		},
+	}
 }
 
 // enqueueRequestsFromTemplate returns reconcile requests only for clusters

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -14,11 +14,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/monitoring"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
 
 // TableGroupReconciler reconciles a TableGroup object.
@@ -424,8 +426,40 @@ func (r *TableGroupReconciler) SetupWithManager(
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&multigresv1alpha1.TableGroup{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&multigresv1alpha1.TableGroup{},
+			builder.WithPredicates(projectRefOrGenerationChangedPredicate()),
+		).
 		Owns(&multigresv1alpha1.Shard{}).
 		WithOptions(controllerOpts).
 		Complete(r)
+}
+
+// projectRefOrGenerationChangedPredicate requeues when desired shard state can
+// change due to either spec updates or project-ref annotation updates.
+func projectRefOrGenerationChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+
+			oldAnnotations := e.ObjectOld.GetAnnotations()
+			newAnnotations := e.ObjectNew.GetAnnotations()
+			return oldAnnotations[metadata.AnnotationProjectRef] !=
+				newAnnotations[metadata.AnnotationProjectRef]
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return true
+		},
+	}
 }

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -393,9 +394,41 @@ func (r *CellReconciler) SetupWithManager(mgr ctrl.Manager, opts ...controller.O
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&multigresv1alpha1.Cell{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&multigresv1alpha1.Cell{},
+			builder.WithPredicates(projectRefOrGenerationChangedPredicate()),
+		).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(controllerOpts).
 		Complete(r)
+}
+
+// projectRefOrGenerationChangedPredicate requeues when desired gateway state can
+// change due to either spec updates or project-ref annotation updates.
+func projectRefOrGenerationChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+
+			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+
+			oldAnnotations := e.ObjectOld.GetAnnotations()
+			newAnnotations := e.ObjectNew.GetAnnotations()
+			return oldAnnotations[metadata.AnnotationProjectRef] !=
+				newAnnotations[metadata.AnnotationProjectRef]
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return true
+		},
+	}
 }


### PR DESCRIPTION

## Description

this pr fixes project-ref propagation for existing clusters when `multigres.com/project-ref` is added, changed, or removed after the cluster has already been created.

Create-time propagation already worked, but metadata-only updates on the parent resource did not fan out because the relevant controllers only reconciled on generation changes. As a result, child resources and runtime pods kept the old fallback value until the cluster was recreated.

## Changes

- Updated the `MultigresCluster` controller predicate to reconcile when `multigres.com/project-ref` changes, not just when generation changes.
- Updated the `TableGroup` controller predicate to reconcile when `multigres.com/project-ref` changes, not just when generation changes.
- Updated the `Cell` controller predicate to reconcile when `multigres.com/project-ref` changes, not just when generation changes.
- Kept the predicate scope narrow so unrelated metadata churn does not trigger extra reconciles.
## Testing

Verified locally that the affected controller packages still pass after the predicate change.

Also validated the failure mode in EKS before the fix: creating a cluster with `multigres.com/project-ref` set from the start correctly propagated the explicit value into runtime pods, while adding the annotation after creation did not update existing child resources or pods. This change addresses that update path by treating `multigres.com/project-ref` as reconciliation input for the relevant controllers.