### PR TITLE
fix: reduce default multigateway replicas per cell

### DIFF
--- a/pkg/resolver/validation.go
+++ b/pkg/resolver/validation.go
@@ -453,21 +453,25 @@ func (r *Resolver) ValidateClusterLogic(
 				}
 
 				// ------------------------------------------------------------------
-				// 3. Quorum Warning for pools with insufficient replicas
+				// 3. Quorum Warning for pools with insufficient total replicas
 				// ------------------------------------------------------------------
 				for poolName, pool := range pools {
 					replicas := int32(3) // default
 					if pool.ReplicasPerCell != nil {
 						replicas = *pool.ReplicasPerCell
 					}
-					if replicas < 3 {
+					cellCount := len(pool.Cells)
+					totalReplicas := int(replicas) * cellCount
+					if totalReplicas < 3 {
 						warnings = append(warnings, fmt.Sprintf(
-							"pool '%s' in shard '%s' has replicasPerCell=%d; pools need at least 3 "+
-								"for zero-downtime rolling upgrades (AT_LEAST_2 durability requires 1 primary + 2 standbys "+
-								"to maintain quorum while draining a replica)",
+							"pool '%s' in shard '%s' has replicasPerCell=%d across %d cell(s) (%d total); "+
+								"The HA baseline for AT_LEAST_2 is at least 3 total pods (1 primary + 2 standbys). "+
+								"For zero-downtime rolling upgrades within a single cell, use at least 3 replicas in that cell.",
 							poolName,
 							shard.Name,
 							replicas,
+							cellCount,
+							totalReplicas,
 						))
 					}
 				}

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -224,6 +224,7 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 	tests := map[string]struct {
 		cluster        *multigresv1alpha1.MultigresCluster
 		wantWarnings   []string
+		wantNoWarnings bool
 		wantErr        string
 		customClient   client.Client
 		clientFailures *testutil.FailureConfig
@@ -601,8 +602,36 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 				},
 			},
 			wantWarnings: []string{
-				"replicasPerCell=2; pools need at least 3",
+				"replicasPerCell=2 across 1 cell(s) (2 total)",
 			},
+		},
+		"No Quorum Warning: three cells with 1 replica per cell": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+						{Name: "zone-2"},
+						{Name: "zone-3"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"default": {
+											ReplicasPerCell: ptr.To(int32(1)),
+										},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			wantNoWarnings: true,
 		},
 		"No Quorum Warning: readWrite pool with 3 replicas": {
 			cluster: &multigresv1alpha1.MultigresCluster{
@@ -653,7 +682,7 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 					}},
 				},
 			},
-			wantWarnings: []string{"has replicasPerCell=2"},
+			wantWarnings: []string{"has replicasPerCell=2 across 1 cell(s) (2 total)"},
 		},
 		"Etcd 1 replica warning": {
 			cluster: &multigresv1alpha1.MultigresCluster{
@@ -1254,6 +1283,9 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 						t.Errorf("Expected warning containing '%s', got %v", want, warnings)
 					}
 				}
+			}
+			if tc.wantNoWarnings && len(warnings) > 0 {
+				t.Errorf("Expected no warnings, got %v", warnings)
 			}
 		})
 	}

--- a/pkg/resource-handler/controller/cell/cell_controller_test.go
+++ b/pkg/resource-handler/controller/cell/cell_controller_test.go
@@ -111,11 +111,12 @@ func TestCellReconciler_Reconcile(t *testing.T) {
 				}
 
 				// Verify defaults
-				if *mgDeploy.Spec.Replicas != int32(2) {
+				const wantReplicas int32 = 1
+				if *mgDeploy.Spec.Replicas != wantReplicas {
 					t.Errorf(
 						"MultiGateway Deployment replicas = %d, want %d",
 						*mgDeploy.Spec.Replicas,
-						int32(2),
+						wantReplicas,
 					)
 				}
 			},

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -21,7 +21,7 @@ const (
 	MultiGatewayComponentName = metadata.ComponentMultiGateway
 
 	// DefaultMultiGatewayReplicas is the default number of MultiGateway replicas
-	DefaultMultiGatewayReplicas int32 = 2
+	DefaultMultiGatewayReplicas int32 = 1
 
 	// MultiGatewayHTTPPort is the default port for HTTP connections
 	MultiGatewayHTTPPort int32 = 15100


### PR DESCRIPTION
## Description

this pr fixes the per-cell operator defaults so they match the intended HA baseline for multi-cell clusters.

The previous default created two pods per cell, which meant a three-cell cluster ran six steady-state gateway pods instead of the intended three. That doubled baseline gateway capacity and resource usage for clusters that did not explicitly override the template, even though rollouts can temporarily burst above the steady-state target when needed.

It also fixes the pool replica validation warning so a three-cell cluster with one postgres pod per cell is not warned as under-replicated for HA.

## Changes

- Changed the default multigateway replica count from `2` to `1` per cell.
- Updated the pool replica warning to evaluate total resolved pods across the pool's cells instead of only `replicasPerCell`.
- Reworded the warning to distinguish the `AT_LEAST_2` HA baseline from the extra local capacity needed for zero-downtime rolling upgrades within a single cell.
- Added validation coverage for the three-cell, one-replica-per-cell baseline.

## Testing

Brought up a basic HA cluster on EKS, scaled it down and verified the error message was gone for the previous case.

Ran the focused cell controller and resolver test packages to verify both sides of the change: multigateway reconciliation now creates deployments with the new default replica count, and resolver validation no longer warns for the intended three-cell HA baseline while still warning when total pool pods are below the threshold.

