### PR TITLE
fix: populate QuorumType and RequiredCount in DurabilityPolicy

### DIFF
--- a/pkg/data-handler/topo/database.go
+++ b/pkg/data-handler/topo/database.go
@@ -151,11 +151,26 @@ func GetBackupLocation(shard *multigresv1alpha1.Shard) *clustermetadatapb.Backup
 // GetDurabilityPolicy extracts the durability policy from the shard config.
 // Falls back to "AT_LEAST_2" if not set (the default materialized by the webhook resolver).
 func GetDurabilityPolicy(shard *multigresv1alpha1.Shard) *clustermetadatapb.DurabilityPolicy {
-	name := "AT_LEAST_2"
-	if shard.Spec.DurabilityPolicy != "" {
-		name = shard.Spec.DurabilityPolicy
+	return buildDurabilityPolicy(shard.Spec.DurabilityPolicy)
+}
+
+// buildDurabilityPolicy constructs a fully populated DurabilityPolicy proto from
+// a policy name. Upstream multigres' consensus code routes on QuorumType, so
+// leaving it at the proto3 zero value (QUORUM_TYPE_UNKNOWN) would cause
+// "unsupported quorum type" failures in multiorch's analyzers. Falls back to
+// "AT_LEAST_2" when name is empty.
+func buildDurabilityPolicy(name string) *clustermetadatapb.DurabilityPolicy {
+	if name == "" {
+		name = "AT_LEAST_2"
 	}
-	return &clustermetadatapb.DurabilityPolicy{
-		PolicyName: name,
+	policy := &clustermetadatapb.DurabilityPolicy{PolicyName: name}
+	switch name {
+	case "AT_LEAST_2":
+		policy.QuorumType = clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N
+		policy.RequiredCount = 2
+	case "MULTI_CELL_AT_LEAST_2":
+		policy.QuorumType = clustermetadatapb.QuorumType_QUORUM_TYPE_MULTI_CELL_AT_LEAST_N
+		policy.RequiredCount = 2
 	}
+	return policy
 }

--- a/pkg/data-handler/topo/database.go
+++ b/pkg/data-handler/topo/database.go
@@ -26,10 +26,22 @@ func RegisterDatabase(
 	dbName := string(shard.Spec.DatabaseName)
 	cells := CollectCells(shard)
 
+	durabilityPolicy, err := GetDurabilityPolicy(shard)
+	if err != nil {
+		recorder.Eventf(
+			shard,
+			"Warning",
+			"RegistrationFailed",
+			"Failed to register database in topology: %v",
+			err,
+		)
+		return fmt.Errorf("failed to register database %s in topology: %w", dbName, err)
+	}
+
 	dbMetadata := &clustermetadatapb.Database{
 		Name:                      dbName,
 		BackupLocation:            GetBackupLocation(shard),
-		BootstrapDurabilityPolicy: GetDurabilityPolicy(shard),
+		BootstrapDurabilityPolicy: durabilityPolicy,
 		Cells:                     cells,
 	}
 
@@ -150,7 +162,9 @@ func GetBackupLocation(shard *multigresv1alpha1.Shard) *clustermetadatapb.Backup
 
 // GetDurabilityPolicy extracts the durability policy from the shard config.
 // Falls back to "AT_LEAST_2" if not set (the default materialized by the webhook resolver).
-func GetDurabilityPolicy(shard *multigresv1alpha1.Shard) *clustermetadatapb.DurabilityPolicy {
+func GetDurabilityPolicy(
+	shard *multigresv1alpha1.Shard,
+) (*clustermetadatapb.DurabilityPolicy, error) {
 	return buildDurabilityPolicy(shard.Spec.DurabilityPolicy)
 }
 
@@ -159,7 +173,7 @@ func GetDurabilityPolicy(shard *multigresv1alpha1.Shard) *clustermetadatapb.Dura
 // leaving it at the proto3 zero value (QUORUM_TYPE_UNKNOWN) would cause
 // "unsupported quorum type" failures in multiorch's analyzers. Falls back to
 // "AT_LEAST_2" when name is empty.
-func buildDurabilityPolicy(name string) *clustermetadatapb.DurabilityPolicy {
+func buildDurabilityPolicy(name string) (*clustermetadatapb.DurabilityPolicy, error) {
 	if name == "" {
 		name = "AT_LEAST_2"
 	}
@@ -171,6 +185,11 @@ func buildDurabilityPolicy(name string) *clustermetadatapb.DurabilityPolicy {
 	case "MULTI_CELL_AT_LEAST_2":
 		policy.QuorumType = clustermetadatapb.QuorumType_QUORUM_TYPE_MULTI_CELL_AT_LEAST_N
 		policy.RequiredCount = 2
+	default:
+		return nil, fmt.Errorf(
+			"unsupported durability policy %q (supported: AT_LEAST_2, MULTI_CELL_AT_LEAST_2)",
+			name,
+		)
 	}
-	return policy
+	return policy, nil
 }

--- a/pkg/data-handler/topo/database_test.go
+++ b/pkg/data-handler/topo/database_test.go
@@ -309,6 +309,12 @@ func TestGetDurabilityPolicy(t *testing.T) {
 		if got.GetPolicyName() != "AT_LEAST_2" {
 			t.Errorf("expected AT_LEAST_2, got %s", got.GetPolicyName())
 		}
+		if got.GetQuorumType() != clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N {
+			t.Errorf("expected QUORUM_TYPE_AT_LEAST_N, got %s", got.GetQuorumType())
+		}
+		if got.GetRequiredCount() != 2 {
+			t.Errorf("expected RequiredCount 2, got %d", got.GetRequiredCount())
+		}
 	})
 
 	t.Run("returns explicit AT_LEAST_2", func(t *testing.T) {
@@ -318,6 +324,12 @@ func TestGetDurabilityPolicy(t *testing.T) {
 		got := topo.GetDurabilityPolicy(shard)
 		if got.GetPolicyName() != "AT_LEAST_2" {
 			t.Errorf("expected AT_LEAST_2, got %s", got.GetPolicyName())
+		}
+		if got.GetQuorumType() != clustermetadatapb.QuorumType_QUORUM_TYPE_AT_LEAST_N {
+			t.Errorf("expected QUORUM_TYPE_AT_LEAST_N, got %s", got.GetQuorumType())
+		}
+		if got.GetRequiredCount() != 2 {
+			t.Errorf("expected RequiredCount 2, got %d", got.GetRequiredCount())
 		}
 	})
 
@@ -329,7 +341,32 @@ func TestGetDurabilityPolicy(t *testing.T) {
 		if got.GetPolicyName() != "MULTI_CELL_AT_LEAST_2" {
 			t.Errorf("expected MULTI_CELL_AT_LEAST_2, got %s", got.GetPolicyName())
 		}
+		if got.GetQuorumType() != clustermetadatapb.QuorumType_QUORUM_TYPE_MULTI_CELL_AT_LEAST_N {
+			t.Errorf("expected QUORUM_TYPE_MULTI_CELL_AT_LEAST_N, got %s", got.GetQuorumType())
+		}
+		if got.GetRequiredCount() != 2 {
+			t.Errorf("expected RequiredCount 2, got %d", got.GetRequiredCount())
+		}
 	})
+
+	t.Run(
+		"unknown policy sets PolicyName but leaves QuorumType and RequiredCount at zero",
+		func(t *testing.T) {
+			t.Parallel()
+			shard := newTestShard("test-shard")
+			shard.Spec.DurabilityPolicy = "CUSTOM"
+			got := topo.GetDurabilityPolicy(shard)
+			if got.GetPolicyName() != "CUSTOM" {
+				t.Errorf("expected CUSTOM, got %s", got.GetPolicyName())
+			}
+			if got.GetQuorumType() != 0 {
+				t.Errorf("expected zero QuorumType, got %s", got.GetQuorumType())
+			}
+			if got.GetRequiredCount() != 0 {
+				t.Errorf("expected zero RequiredCount, got %d", got.GetRequiredCount())
+			}
+		},
+	)
 }
 
 func TestGetBackupLocation(t *testing.T) {

--- a/pkg/data-handler/topo/database_test.go
+++ b/pkg/data-handler/topo/database_test.go
@@ -3,6 +3,7 @@ package topo_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -305,7 +306,10 @@ func TestGetDurabilityPolicy(t *testing.T) {
 	t.Run("defaults to AT_LEAST_2 when empty", func(t *testing.T) {
 		t.Parallel()
 		shard := newTestShard("test-shard")
-		got := topo.GetDurabilityPolicy(shard)
+		got, err := topo.GetDurabilityPolicy(shard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if got.GetPolicyName() != "AT_LEAST_2" {
 			t.Errorf("expected AT_LEAST_2, got %s", got.GetPolicyName())
 		}
@@ -321,7 +325,10 @@ func TestGetDurabilityPolicy(t *testing.T) {
 		t.Parallel()
 		shard := newTestShard("test-shard")
 		shard.Spec.DurabilityPolicy = "AT_LEAST_2"
-		got := topo.GetDurabilityPolicy(shard)
+		got, err := topo.GetDurabilityPolicy(shard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if got.GetPolicyName() != "AT_LEAST_2" {
 			t.Errorf("expected AT_LEAST_2, got %s", got.GetPolicyName())
 		}
@@ -337,7 +344,10 @@ func TestGetDurabilityPolicy(t *testing.T) {
 		t.Parallel()
 		shard := newTestShard("test-shard")
 		shard.Spec.DurabilityPolicy = "MULTI_CELL_AT_LEAST_2"
-		got := topo.GetDurabilityPolicy(shard)
+		got, err := topo.GetDurabilityPolicy(shard)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if got.GetPolicyName() != "MULTI_CELL_AT_LEAST_2" {
 			t.Errorf("expected MULTI_CELL_AT_LEAST_2, got %s", got.GetPolicyName())
 		}
@@ -349,24 +359,24 @@ func TestGetDurabilityPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run(
-		"unknown policy sets PolicyName but leaves QuorumType and RequiredCount at zero",
-		func(t *testing.T) {
-			t.Parallel()
-			shard := newTestShard("test-shard")
-			shard.Spec.DurabilityPolicy = "CUSTOM"
-			got := topo.GetDurabilityPolicy(shard)
-			if got.GetPolicyName() != "CUSTOM" {
-				t.Errorf("expected CUSTOM, got %s", got.GetPolicyName())
+	t.Run("unknown policy returns error", func(t *testing.T) {
+		t.Parallel()
+		shard := newTestShard("test-shard")
+		shard.Spec.DurabilityPolicy = "CUSTOM"
+		got, err := topo.GetDurabilityPolicy(shard)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if got != nil {
+			t.Errorf("expected nil policy on error, got %+v", got)
+		}
+		msg := err.Error()
+		for _, want := range []string{"CUSTOM", "AT_LEAST_2", "MULTI_CELL_AT_LEAST_2"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected error message to contain %q, got %q", want, msg)
 			}
-			if got.GetQuorumType() != 0 {
-				t.Errorf("expected zero QuorumType, got %s", got.GetQuorumType())
-			}
-			if got.GetRequiredCount() != 0 {
-				t.Errorf("expected zero RequiredCount, got %d", got.GetRequiredCount())
-			}
-		},
-	)
+		}
+	})
 }
 
 func TestGetBackupLocation(t *testing.T) {

--- a/pkg/data-handler/topo/topology.go
+++ b/pkg/data-handler/topo/topology.go
@@ -36,10 +36,15 @@ func RegisterDatabaseFromSpec(
 		durabilityPolicy = clusterDurabilityPolicy
 	}
 
+	bootstrapDurabilityPolicy, err := buildDurabilityPolicy(durabilityPolicy)
+	if err != nil {
+		return fmt.Errorf("building durability policy for database %s: %w", dbName, err)
+	}
+
 	dbMetadata := &clustermetadatapb.Database{
 		Name:                      dbName,
 		Cells:                     allCellNames,
-		BootstrapDurabilityPolicy: buildDurabilityPolicy(durabilityPolicy),
+		BootstrapDurabilityPolicy: bootstrapDurabilityPolicy,
 	}
 
 	if backup != nil && backup.Type == multigresv1alpha1.BackupTypeS3 && backup.S3 != nil {

--- a/pkg/data-handler/topo/topology.go
+++ b/pkg/data-handler/topo/topology.go
@@ -35,16 +35,11 @@ func RegisterDatabaseFromSpec(
 	if durabilityPolicy == "" {
 		durabilityPolicy = clusterDurabilityPolicy
 	}
-	if durabilityPolicy == "" {
-		durabilityPolicy = "AT_LEAST_2"
-	}
 
 	dbMetadata := &clustermetadatapb.Database{
-		Name:  dbName,
-		Cells: allCellNames,
-		BootstrapDurabilityPolicy: &clustermetadatapb.DurabilityPolicy{
-			PolicyName: durabilityPolicy,
-		},
+		Name:                      dbName,
+		Cells:                     allCellNames,
+		BootstrapDurabilityPolicy: buildDurabilityPolicy(durabilityPolicy),
 	}
 
 	if backup != nil && backup.Type == multigresv1alpha1.BackupTypeS3 && backup.S3 != nil {

--- a/pkg/data-handler/topo/topology_test.go
+++ b/pkg/data-handler/topo/topology_test.go
@@ -245,7 +245,7 @@ func TestRegisterDatabaseFromSpec(t *testing.T) {
 
 		dbConfig := multigresv1alpha1.DatabaseConfig{
 			Name:             "durdb",
-			DurabilityPolicy: "NONE",
+			DurabilityPolicy: "MULTI_CELL_AT_LEAST_2",
 		}
 
 		err := topo.RegisterDatabaseFromSpec(
@@ -260,9 +260,9 @@ func TestRegisterDatabaseFromSpec(t *testing.T) {
 		if err != nil {
 			t.Fatalf("database not found: %v", err)
 		}
-		if db.BootstrapDurabilityPolicy.GetPolicyName() != "NONE" {
+		if db.BootstrapDurabilityPolicy.GetPolicyName() != "MULTI_CELL_AT_LEAST_2" {
 			t.Errorf(
-				"expected database-level policy NONE, got %s",
+				"expected database-level policy MULTI_CELL_AT_LEAST_2, got %s",
 				db.BootstrapDurabilityPolicy.GetPolicyName(),
 			)
 		}


### PR DESCRIPTION
Extract buildDurabilityPolicy helper that sets QuorumType and RequiredCount based on the policy name. Without these fields, multiorch's analyzers fail with "unsupported quorum type" because the proto3 zero value (QUORUM_TYPE_UNKNOWN) is not handled.

Without this fix, when using the `supabase/postgres` image, we get this error from the MultiOrch:

```
{"time":"2026-04-24T08:02:11.875452119Z","level":"ERROR","msg":"analyzer error","analyzer":"ShardNeedsInitialization","shard":{"Database":"postgres","TableGroup":"default","Shard":"0-inf"},"error":"failed to parse bootstrap durability policy: unsupported quorum type: QUORUM_TYPE_UNKNOWN","trace_id":"4c2893eb891408d024e685ba0fb92089","span_id":"f56597b2c0ea8fdf"}
```

We didn't get this error when using `multigres/pgctld` image; according to Claude, this is because:

> The operator writes an incomplete `DurabilityPolicy` protobuf into etcd — it sets `PolicyName: "AT_LEAST_2"` but leaves `QuorumType` and `RequiredCount` at their proto3 zero values (`QUORUM_TYPE_UNKNOWN`, `0`).

> Upstream multigres' `NewPolicyFromProto` routes purely on `QuorumType`, so it rejects the stored record with `unsupported quorum type: QUORUM_TYPE_UNKNOWN`. That error bubbles up from multiorch's `ShardNeedsInitialization` analyzer, which then never emits the problem that would trigger `shard_init_action`, so no primary is ever elected.

> The bug is image-agnostic, but with `multigres/pgctld` the cohort forms fast enough that the analyzer short-circuits before reaching the broken parse; with `supabase/postgres` the slower bootstrap lets the analyzer hit the faulty proto on every tick and bootstrap stalls forever.
