### PR TITLE
feat: add zone ID support to MultigresCluster cell definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,7 @@ kind-up: ## Create a kind cluster for local development
 	@echo "==> Cluster ready. Use: export KUBECONFIG=$(KIND_KUBECONFIG)"
 
 .PHONY: kind-up-topology
-kind-up-topology: ## Create a multi-node kind cluster with topology zone labels
+kind-up-topology: ## Create a multi-node kind cluster with topology zone ID labels
 	@command -v $(KIND) >/dev/null 2>&1 || { \
 		echo "ERROR: kind is not installed."; \
 		echo "Install it from: https://kind.sigs.k8s.io/docs/user/quick-start/"; \
@@ -397,7 +397,7 @@ kind-up-topology: ## Create a multi-node kind cluster with topology zone labels
 		$(KIND) create cluster --name $(KIND_CLUSTER) --kubeconfig $(KIND_KUBECONFIG) \
 			--config config/kind/kind-config-topology.yaml; \
 	fi
-	@echo "==> Cluster ready (3 workers with zone labels). Use: export KUBECONFIG=$(KIND_KUBECONFIG)"
+	@echo "==> Cluster ready (3 workers with zone ID labels). Use: export KUBECONFIG=$(KIND_KUBECONFIG)"
 
 .PHONY: kind-deploy-topology
 kind-deploy-topology: kind-up-topology manifests kustomize kind-load kind-load-images ## Deploy operator to multi-node kind cluster with topology zones

--- a/api/v1alpha1/cell_types.go
+++ b/api/v1alpha1/cell_types.go
@@ -38,12 +38,20 @@ import (
 // Cell is a child CR managed by MultigresCluster.
 
 // CellSpec defines the desired state of Cell.
-// +kubebuilder:validation:XValidation:rule="!(has(self.zone) && has(self.region))",message="cannot specify both 'zone' and 'region'"
+// +kubebuilder:validation:XValidation:rule="!(has(self.zone) && has(self.zoneId))",message="cannot specify both 'zone' and 'zoneId'"
+// +kubebuilder:validation:XValidation:rule="!(has(self.region) && (has(self.zone) || has(self.zoneId)))",message="cannot specify 'region' with either 'zone' or 'zoneId'"
+// +kubebuilder:validation:XValidation:rule="has(self.zone) || has(self.zoneId) || has(self.region)",message="at least one of 'zone', 'zoneId', or 'region' must be specified"
 type CellSpec struct {
 	// Name is the logical name of the cell.
 	Name CellName `json:"name"`
-	// Zone indicates the physical availability zone.
+	// Zone indicates the physical availability zone name (e.g. us-east-1a).
+	// +optional
 	Zone Zone `json:"zone,omitempty"`
+	// ZoneID indicates the physical availability zone ID (e.g. use1-az1).
+	// Zone IDs are consistent across AWS accounts, unlike zone names.
+	// When both zone and zoneId are specified, zoneId takes precedence.
+	// +optional
+	ZoneID ZoneID `json:"zoneId,omitempty"`
 	// Region indicates the physical region.
 	// +optional
 	Region Region `json:"region,omitempty"`

--- a/api/v1alpha1/cell_types.go
+++ b/api/v1alpha1/cell_types.go
@@ -38,13 +38,16 @@ import (
 // Cell is a child CR managed by MultigresCluster.
 
 // CellSpec defines the desired state of Cell.
-// +kubebuilder:validation:XValidation:rule="!(has(self.zone) && has(self.region))",message="cannot specify both 'zone' and 'region'"
+// +kubebuilder:validation:XValidation:rule="!(has(self.zoneId) && has(self.region))",message="cannot specify both 'zoneId' and 'region'"
+// +kubebuilder:validation:XValidation:rule="has(self.zoneId) || has(self.region)",message="at least one of 'zoneId' or 'region' must be specified"
 type CellSpec struct {
 	// Name is the logical name of the cell.
 	Name CellName `json:"name"`
-	// Zone indicates the physical availability zone.
-	Zone Zone `json:"zone,omitempty"`
-	// Region indicates the physical region.
+	// ZoneID indicates the physical availability zone ID (e.g. use1-az1).
+	// Zone IDs are consistent across AWS accounts, unlike zone names.
+	// +optional
+	ZoneID ZoneID `json:"zoneId,omitempty"`
+	// Region indicates the physical region (mutually exclusive with zoneId via CEL validation).
 	// +optional
 	Region Region `json:"region,omitempty"`
 

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -288,6 +288,12 @@ type IPAddress string
 // +kubebuilder:validation:MaxLength=63
 type Zone string
 
+// ZoneID is the cloud provider availability zone ID (e.g. use1-az1).
+// Unlike zone names, zone IDs are consistent across AWS accounts.
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=63
+type ZoneID string
+
 // Region is the cloud provider region identifier.
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=63

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -283,10 +283,11 @@ type PostgresConfigRef struct {
 // +kubebuilder:validation:Pattern=`^(([0-9]{1,3}\.){3}[0-9]{1,3})$|^(([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4})$`
 type IPAddress string
 
-// Zone is the cloud provider availability zone identifier.
+// ZoneID is the cloud provider availability zone ID (e.g. use1-az1).
+// Unlike zone names, zone IDs are consistent across AWS accounts.
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=63
-type Zone string
+type ZoneID string
 
 // Region is the cloud provider region identifier.
 // +kubebuilder:validation:MinLength=1

--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -238,15 +238,22 @@ type MultiAdminWebConfig struct {
 // CellConfig defines a cell in the cluster.
 // +kubebuilder:validation:XValidation:rule="!(has(self.spec) && has(self.cellTemplate))",message="cannot specify both 'spec' and 'cellTemplate'"
 // +kubebuilder:validation:XValidation:rule="!(has(self.spec) && has(self.overrides))",message="cannot specify both 'spec' and 'overrides'"
-// +kubebuilder:validation:XValidation:rule="!(has(self.zone) && has(self.region))",message="cannot specify both 'zone' and 'region'"
+// +kubebuilder:validation:XValidation:rule="!(has(self.zone) && has(self.zoneId))",message="cannot specify both 'zone' and 'zoneId'"
+// +kubebuilder:validation:XValidation:rule="!(has(self.region) && (has(self.zone) || has(self.zoneId)))",message="cannot specify 'region' with either 'zone' or 'zoneId'"
+// +kubebuilder:validation:XValidation:rule="has(self.zone) || has(self.zoneId) || has(self.region)",message="at least one of 'zone', 'zoneId', or 'region' must be specified"
 type CellConfig struct {
 	// Name is the logical name of the cell.
 	Name CellName `json:"name"`
 
-	// Zone indicates the physical availability zone.
+	// Zone indicates the physical availability zone name (e.g. us-east-1a).
 	// +optional
 	Zone Zone `json:"zone,omitempty"`
-	// Region indicates the physical region (mutually exclusive with zone via CEL validation).
+	// ZoneID indicates the physical availability zone ID (e.g. use1-az1).
+	// Zone IDs are consistent across AWS accounts, unlike zone names.
+	// When both zone and zoneId are specified, zoneId takes precedence.
+	// +optional
+	ZoneID ZoneID `json:"zoneId,omitempty"`
+	// Region indicates the physical region (mutually exclusive with zone and zoneId via CEL validation).
 	// +optional
 	Region Region `json:"region,omitempty"`
 

--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -238,15 +238,17 @@ type MultiAdminWebConfig struct {
 // CellConfig defines a cell in the cluster.
 // +kubebuilder:validation:XValidation:rule="!(has(self.spec) && has(self.cellTemplate))",message="cannot specify both 'spec' and 'cellTemplate'"
 // +kubebuilder:validation:XValidation:rule="!(has(self.spec) && has(self.overrides))",message="cannot specify both 'spec' and 'overrides'"
-// +kubebuilder:validation:XValidation:rule="!(has(self.zone) && has(self.region))",message="cannot specify both 'zone' and 'region'"
+// +kubebuilder:validation:XValidation:rule="!(has(self.zoneId) && has(self.region))",message="cannot specify both 'zoneId' and 'region'"
+// +kubebuilder:validation:XValidation:rule="has(self.zoneId) || has(self.region)",message="at least one of 'zoneId' or 'region' must be specified"
 type CellConfig struct {
 	// Name is the logical name of the cell.
 	Name CellName `json:"name"`
 
-	// Zone indicates the physical availability zone.
+	// ZoneID indicates the physical availability zone ID (e.g. use1-az1).
+	// Zone IDs are consistent across AWS accounts, unlike zone names.
 	// +optional
-	Zone Zone `json:"zone,omitempty"`
-	// Region indicates the physical region (mutually exclusive with zone via CEL validation).
+	ZoneID ZoneID `json:"zoneId,omitempty"`
+	// Region indicates the physical region (mutually exclusive with zoneId via CEL validation).
 	// +optional
 	Region Region `json:"region,omitempty"`
 

--- a/config/crd/bases/multigres.com_cells.yaml
+++ b/config/crd/bases/multigres.com_cells.yaml
@@ -1547,7 +1547,16 @@ spec:
                 - registerCell
                 type: object
               zone:
-                description: Zone indicates the physical availability zone.
+                description: Zone indicates the physical availability zone name (e.g.
+                  us-east-1a).
+                maxLength: 63
+                minLength: 1
+                type: string
+              zoneId:
+                description: |-
+                  ZoneID indicates the physical availability zone ID (e.g. use1-az1).
+                  Zone IDs are consistent across AWS accounts, unlike zone names.
+                  When both zone and zoneId are specified, zoneId takes precedence.
                 maxLength: 63
                 minLength: 1
                 type: string
@@ -1558,8 +1567,12 @@ spec:
             - name
             type: object
             x-kubernetes-validations:
-            - message: cannot specify both 'zone' and 'region'
-              rule: '!(has(self.zone) && has(self.region))'
+            - message: cannot specify both 'zone' and 'zoneId'
+              rule: '!(has(self.zone) && has(self.zoneId))'
+            - message: cannot specify 'region' with either 'zone' or 'zoneId'
+              rule: '!(has(self.region) && (has(self.zone) || has(self.zoneId)))'
+            - message: at least one of 'zone', 'zoneId', or 'region' must be specified
+              rule: has(self.zone) || has(self.zoneId) || has(self.region)
           status:
             description: CellStatus defines the observed state of Cell.
             properties:

--- a/config/crd/bases/multigres.com_cells.yaml
+++ b/config/crd/bases/multigres.com_cells.yaml
@@ -1343,7 +1343,8 @@ spec:
                     type: string
                 type: object
               region:
-                description: Region indicates the physical region.
+                description: Region indicates the physical region (mutually exclusive
+                  with zoneId via CEL validation).
                 maxLength: 63
                 minLength: 1
                 type: string
@@ -1546,8 +1547,10 @@ spec:
                 - prunePoolers
                 - registerCell
                 type: object
-              zone:
-                description: Zone indicates the physical availability zone.
+              zoneId:
+                description: |-
+                  ZoneID indicates the physical availability zone ID (e.g. use1-az1).
+                  Zone IDs are consistent across AWS accounts, unlike zone names.
                 maxLength: 63
                 minLength: 1
                 type: string
@@ -1558,8 +1561,10 @@ spec:
             - name
             type: object
             x-kubernetes-validations:
-            - message: cannot specify both 'zone' and 'region'
-              rule: '!(has(self.zone) && has(self.region))'
+            - message: cannot specify both 'zoneId' and 'region'
+              rule: '!(has(self.zoneId) && has(self.region))'
+            - message: at least one of 'zoneId' or 'region' must be specified
+              rule: has(self.zoneId) || has(self.region)
           status:
             description: CellStatus defines the observed state of Cell.
             properties:

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -1258,7 +1258,7 @@ spec:
                       type: object
                     region:
                       description: Region indicates the physical region (mutually
-                        exclusive with zone via CEL validation).
+                        exclusive with zone and zoneId via CEL validation).
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -2534,7 +2534,16 @@ spec:
                           yet supported
                         rule: '!has(self.localTopoServer)'
                     zone:
-                      description: Zone indicates the physical availability zone.
+                      description: Zone indicates the physical availability zone name
+                        (e.g. us-east-1a).
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    zoneId:
+                      description: |-
+                        ZoneID indicates the physical availability zone ID (e.g. use1-az1).
+                        Zone IDs are consistent across AWS accounts, unlike zone names.
+                        When both zone and zoneId are specified, zoneId takes precedence.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -2546,8 +2555,13 @@ spec:
                     rule: '!(has(self.spec) && has(self.cellTemplate))'
                   - message: cannot specify both 'spec' and 'overrides'
                     rule: '!(has(self.spec) && has(self.overrides))'
-                  - message: cannot specify both 'zone' and 'region'
-                    rule: '!(has(self.zone) && has(self.region))'
+                  - message: cannot specify both 'zone' and 'zoneId'
+                    rule: '!(has(self.zone) && has(self.zoneId))'
+                  - message: cannot specify 'region' with either 'zone' or 'zoneId'
+                    rule: '!(has(self.region) && (has(self.zone) || has(self.zoneId)))'
+                  - message: at least one of 'zone', 'zoneId', or 'region' must be
+                      specified
+                    rule: has(self.zone) || has(self.zoneId) || has(self.region)
                 maxItems: 50
                 type: array
                 x-kubernetes-list-map-keys:

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -1258,7 +1258,7 @@ spec:
                       type: object
                     region:
                       description: Region indicates the physical region (mutually
-                        exclusive with zone via CEL validation).
+                        exclusive with zoneId via CEL validation).
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -2533,8 +2533,10 @@ spec:
                       - message: local topology servers (localTopoServer) are not
                           yet supported
                         rule: '!has(self.localTopoServer)'
-                    zone:
-                      description: Zone indicates the physical availability zone.
+                    zoneId:
+                      description: |-
+                        ZoneID indicates the physical availability zone ID (e.g. use1-az1).
+                        Zone IDs are consistent across AWS accounts, unlike zone names.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -2546,8 +2548,10 @@ spec:
                     rule: '!(has(self.spec) && has(self.cellTemplate))'
                   - message: cannot specify both 'spec' and 'overrides'
                     rule: '!(has(self.spec) && has(self.overrides))'
-                  - message: cannot specify both 'zone' and 'region'
-                    rule: '!(has(self.zone) && has(self.region))'
+                  - message: cannot specify both 'zoneId' and 'region'
+                    rule: '!(has(self.zoneId) && has(self.region))'
+                  - message: at least one of 'zoneId' or 'region' must be specified
+                    rule: has(self.zoneId) || has(self.region)
                 maxItems: 50
                 type: array
                 x-kubernetes-list-map-keys:

--- a/config/kind/kind-config-topology.yaml
+++ b/config/kind/kind-config-topology.yaml
@@ -4,10 +4,10 @@ nodes:
   - role: control-plane
   - role: worker
     labels:
-      topology.kubernetes.io/zone: us-east-1a
+      topology.k8s.aws/zone-id: use1-az1
   - role: worker
     labels:
-      topology.kubernetes.io/zone: us-east-1b
+      topology.k8s.aws/zone-id: use1-az2
   - role: worker
     labels:
-      topology.kubernetes.io/zone: us-east-1c
+      topology.k8s.aws/zone-id: use1-az3

--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -27,7 +27,7 @@ metadata:
 spec:
   cells:
     - name: "zone-a"
-      zone: "us-east-1a"
+      zoneId: "use1-az1"
 ```
 
 **What happens:**
@@ -54,10 +54,10 @@ spec:
     cellTemplate: "standard-cell"    # Defines MultiGateway & LocalTopoServer
     shardTemplate: "standard-shard"  # Defines MultiOrch & Pools
   cells:
-    - name: "us-east-1a"
-      zone: "us-east-1a" # Inherits 'standard-cell' config
-    - name: "us-east-1b"
-      zone: "us-east-1b" # Inherits 'standard-cell' config
+    - name: "az1"
+      zoneId: "use1-az1" # Inherits 'standard-cell' config
+    - name: "az2"
+      zoneId: "use1-az2" # Inherits 'standard-cell' config
 ```
 
 **What happens:**

--- a/config/samples/templated-cluster.yaml
+++ b/config/samples/templated-cluster.yaml
@@ -12,10 +12,10 @@ spec:
 
   # 2. Define Cells (Inherits 'standard-cell')
   cells:
-    - name: "us-east-1a"
-      # zone: "us-east-1a"
-    - name: "us-east-1b"
-      # zone: "us-east-1b"
+    - name: "az1"
+      zoneId: "use1-az1"
+    - name: "az2"
+      zoneId: "use1-az2"
 
   # 3. Configure the System Database
   # We explicitly define this to ensure it uses our 'standard-shard' template
@@ -34,5 +34,5 @@ spec:
                   main-app:
                     # Spread the primary pool across both available cells
                     cells:
-                      - "us-east-1a"
-                      - "us-east-1b"
+                      - "az1"
+                      - "az2"

--- a/config/samples/topology.yaml
+++ b/config/samples/topology.yaml
@@ -1,5 +1,5 @@
 # To try this sample, use: make kind-deploy-topology
-# This creates a kind cluster with 3 worker nodes labeled with topology zones.
+# This creates a kind cluster with 3 worker nodes labeled with topology zone IDs.
 apiVersion: multigres.com/v1alpha1
 kind: MultigresCluster
 metadata:
@@ -42,7 +42,7 @@ spec:
   # ----------------------------------------------------------------
   cells:
     - name: "z1"
-      zone: "us-east-1a"
+      zoneId: "use1-az1"
       spec:
          multigateway:
            replicas: 2
@@ -55,7 +55,7 @@ spec:
                memory: "256Mi"
 
     - name: "z2"
-      zone: "us-east-1b"
+      zoneId: "use1-az2"
       spec:
          multigateway:
            replicas: 2
@@ -68,7 +68,7 @@ spec:
                memory: "256Mi"
 
     - name: "z3"
-      zone: "us-east-1c"
+      zoneId: "use1-az3"
       spec:
          multigateway:
            replicas: 2

--- a/demo/observability/demo.md
+++ b/demo/observability/demo.md
@@ -132,7 +132,7 @@ metadata:
 spec:
   cells:
     - name: "zone-a"
-      zone: "us-east-1a"
+      zoneId: "use1-az1"
 ```
 
 The operator fills in all defaults: a 3-node etcd TopoServer, a MultiAdmin,
@@ -940,7 +940,7 @@ spec:
   # observability: not set → inherits operator's OTEL_EXPORTER_OTLP_ENDPOINT
   cells:
     - name: "zone-a"
-      zone: "us-east-1a"
+      zoneId: "use1-az1"
 ```
 
 #### Override per cluster
@@ -961,7 +961,7 @@ spec:
     tracesSampler: "parentbased_traceidratio"
   cells:
     - name: "zone-a"
-      zone: "us-east-1a"
+      zoneId: "use1-az1"
 ```
 
 #### Disable data-plane telemetry

--- a/demo/webhook/demo.md
+++ b/demo/webhook/demo.md
@@ -101,7 +101,7 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
-    zone: us-east-1a
+    zoneId: use1-az1
   databases:
   - default: true          # <--- System Catalog Created
     name: postgres
@@ -160,8 +160,8 @@ kubectl get multigrescluster standard-ha-cluster -o yaml
 ```yaml
 spec:
   cells:
-  - name: us-east-1a
-    zone: us-east-1a
+  - name: az1
+    zoneId: use1-az1
   databases:
   - default: true
     name: postgres
@@ -174,8 +174,8 @@ spec:
           pools:
             main-app:        # <--- Inherited from 'standard-shard' Template
               cells:
-              - us-east-1a
-              - us-east-1b
+              - az1
+              - az2
               replicasPerCell: 2 # <--- Overrides default (1)
   templateDefaults:
     cellTemplate: standard-cell
@@ -269,7 +269,7 @@ spec:
     overrides:
       multigateway:
         replicas: 3          # <--- Specific Override
-    zone: us-east-1a
+    zoneId: use1-az1
   databases:
   - default: true
     name: postgres
@@ -369,7 +369,7 @@ kubectl get multigrescluster minimal -o yaml
 spec:
   cells:
   - name: zone-a
-    zone: us-east-1a
+    zoneId: use1-az1
   images: {}                 # <--- Empty! No Defaults Injected
   templateDefaults: {}
 ```

--- a/docs/development/cell-topology.md
+++ b/docs/development/cell-topology.md
@@ -1,4 +1,4 @@
-# Cell Topology and Zone/Region Allocation
+# Cell Topology and Zone ID/Region Allocation
 
 ## Local TopoServer (Cell Children) — Not Yet Implemented
 
@@ -109,17 +109,18 @@ This means cells are the mechanism by which multigres guarantees that a committe
 
 However, this guarantee is only real if the cell's pods actually run in the correct zone. If the Kubernetes scheduler places `zone-1` pool pods on `us-east-1b` nodes, the cross-cell quorum is meaningless — both "cells" are on the same physical infrastructure.
 
-## Zone/Region Scheduling Implementation
+## Zone ID/Region Scheduling Implementation
 
-The operator natively integrates Cell topology with Kubernetes node scheduling via the `zone` and `region` fields on the `Cell` and `CellConfig` definitions.
+The operator natively integrates Cell topology with Kubernetes node scheduling via the `zoneId` and `region` fields on the `Cell` and `CellConfig` definitions.
 
 ### 1. Optional Topology Constraint
 
-The `zone` and `region` fields are optional and mutually exclusive (validated via `!(has(self.zone) && has(self.region))`).
+The `zoneId` and `region` fields are optional and mutually exclusive (validated via CEL: `!(has(self.zoneId) && has(self.region))`). At least one of the two must be specified.
 
-- `zone` set → injects `nodeSelector: { topology.kubernetes.io/zone: <zone> }`
+- `zoneId` set → injects `nodeSelector: { topology.k8s.aws/zone-id: <zoneId> }`
 - `region` set → injects `nodeSelector: { topology.kubernetes.io/region: <region> }`
-- **neither set** → no `nodeSelector` is injected, and pods will schedule on any available node. This is essential for single-node environments like Kind or Minikube where topology labels do not exist.
+
+`zoneId` uses the AWS availability zone ID (e.g. `use1-az1`) exposed via the `topology.k8s.aws/zone-id` node label set by the [AWS Node Labeler](https://github.com/aws/aws-node-labeler). Unlike zone names (e.g. `us-east-1a`), zone IDs are consistent across AWS accounts, making them the correct identifier for cross-account or shared-infrastructure deployments.
 
 ### 2. Auto-injection of `nodeSelector`
 
@@ -130,7 +131,7 @@ The injected `nodeSelector` is **strict** and **additive**:
 The components receiving this injection are:
 | Component | Injection Logic |
 |---|---|
-| **MultiGateway Deployment** | Determined directly from the Cell CR `Spec.Zone` / `Spec.Region` |
+| **MultiGateway Deployment** | Determined directly from the Cell CR `Spec.ZoneID` / `Spec.Region` |
 | **Pool Pods** | Looked up via `CellTopologyLabels` in `ShardSpec` |
 | **MultiOrch Deployment** | Looked up via `CellTopologyLabels` in `ShardSpec` |
 
@@ -143,9 +144,9 @@ To avoid independent API reads, the cluster controller builds a `CellTopologyLab
 ### 4. Pre-flight Validation Warnings
 
 The operator's validating webhook (`ValidateClusterLogic` in `resolver.go`) checks the live cluster for nodes matching the specified topology labels. Specifically, it lists all `corev1.Node` objects at admission time.
-If a cell specifies a `zone` or `region` that does not exist on any current nodes, the webhook emits a Kubernetes Admission **Warning**:
+If a cell specifies a `zoneId` or `region` that does not exist on any current nodes, the webhook emits a Kubernetes Admission **Warning**:
 
-`cell 'X': no nodes currently match topology.kubernetes.io/zone=Y; pods will be Pending until matching nodes are available`
+`cell 'X': no nodes currently match topology.k8s.aws/zone-id=Y; pods will be Pending until matching nodes are available`
 
 We use warnings rather than rejections because cluster nodes are ephemeral (e.g., Karpenter or Cluster Autoscaler may spin up a new AZ from zero upon spotting Pending pods).
 

--- a/docs/durability-policy.md
+++ b/docs/durability-policy.md
@@ -27,9 +27,9 @@ spec:
   durabilityPolicy: "AT_LEAST_2"
   cells:
     - name: zone-a
-      zone: us-east-1a
+      zoneId: use1-az1
     - name: zone-b
-      zone: us-east-1b
+      zoneId: use1-az2
   databases:
     - name: postgres
       default: true
@@ -50,9 +50,9 @@ spec:
   durabilityPolicy: "AT_LEAST_2"  # default for all databases
   cells:
     - name: zone-a
-      zone: us-east-1a
+      zoneId: use1-az1
     - name: zone-b
-      zone: us-east-1b
+      zoneId: use1-az2
   databases:
     - name: postgres
       default: true
@@ -77,7 +77,7 @@ In this example, the `postgres` database uses `MULTI_CELL_AT_LEAST_2` (cross-AZ 
 | Multi-AZ with cross-zone durability requirement | `MULTI_CELL_AT_LEAST_2` |
 | Development / testing | `AT_LEAST_2` |
 
-When using `MULTI_CELL_AT_LEAST_2`, ensure your shard's pools span at least 2 cells and that each cell maps to a distinct availability zone via `spec.cells[].zone`. See [Cell Topology](development/cell-topology.md) for details on how cells map to Kubernetes scheduling constraints.
+When using `MULTI_CELL_AT_LEAST_2`, ensure your shard's pools span at least 2 cells and that each cell maps to a distinct availability zone via `spec.cells[].zoneId`. See [Cell Topology](development/cell-topology.md) for details on how cells map to Kubernetes scheduling constraints.
 
 ## Replica Count Considerations
 

--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
@@ -42,6 +42,7 @@ func BuildCell(
 		Spec: multigresv1alpha1.CellSpec{
 			Name:   cellCfg.Name,
 			Zone:   cellCfg.Zone,
+			ZoneID: cellCfg.ZoneID,
 			Region: cellCfg.Region,
 			Images: multigresv1alpha1.CellImages{
 				MultiGateway:     cluster.Spec.Images.MultiGateway,

--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell.go
@@ -41,7 +41,7 @@ func BuildCell(
 		},
 		Spec: multigresv1alpha1.CellSpec{
 			Name:   cellCfg.Name,
-			Zone:   cellCfg.Zone,
+			ZoneID: cellCfg.ZoneID,
 			Region: cellCfg.Region,
 			Images: multigresv1alpha1.CellImages{
 				MultiGateway:     cluster.Spec.Images.MultiGateway,

--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell_test.go
@@ -81,6 +81,29 @@ func TestBuildCell(t *testing.T) {
 		}
 	})
 
+	t.Run("Propagates ZoneID", func(t *testing.T) {
+		cellCfgWithZoneID := &multigresv1alpha1.CellConfig{
+			Name:   "zone-a",
+			ZoneID: "use1-az1",
+		}
+		got, err := BuildCell(
+			cluster,
+			cellCfgWithZoneID,
+			gatewaySpec,
+			noGatewayPlacement,
+			localTopoSpec,
+			globalTopoRef,
+			allCells,
+			scheme,
+		)
+		if err != nil {
+			t.Fatalf("BuildCell() error = %v", err)
+		}
+		if got.Spec.ZoneID != "use1-az1" {
+			t.Errorf("ZoneID = %v, want use1-az1", got.Spec.ZoneID)
+		}
+	})
+
 	t.Run("ControllerRefError", func(t *testing.T) {
 		emptyScheme := runtime.NewScheme()
 		_, err := BuildCell(

--- a/pkg/cluster-handler/controller/multigrescluster/builders_cell_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_cell_test.go
@@ -30,8 +30,8 @@ func TestBuildCell(t *testing.T) {
 	}
 
 	cellCfg := &multigresv1alpha1.CellConfig{
-		Name: "zone-a",
-		Zone: "us-east-1a",
+		Name:   "zone-a",
+		ZoneID: "use1-az1",
 	}
 
 	gatewaySpec := &multigresv1alpha1.StatelessSpec{
@@ -65,8 +65,8 @@ func TestBuildCell(t *testing.T) {
 		if got.Name != expectedName {
 			t.Errorf("Name = %v, want %v", got.Name, expectedName)
 		}
-		if got.Spec.Zone != "us-east-1a" {
-			t.Errorf("Zone = %v, want %v", got.Spec.Zone, "us-east-1a")
+		if got.Spec.ZoneID != "use1-az1" {
+			t.Errorf("ZoneID = %v, want %v", got.Spec.ZoneID, "use1-az1")
 		}
 		if got.Spec.Images.MultiGateway != "gateway:latest" {
 			t.Errorf("Gateway Image = %v, want %v", got.Spec.Images.MultiGateway, "gateway:latest")
@@ -78,6 +78,29 @@ func TestBuildCell(t *testing.T) {
 		// Verify OwnerReference
 		if len(got.OwnerReferences) != 1 {
 			t.Errorf("OwnerReferences count = %v, want 1", len(got.OwnerReferences))
+		}
+	})
+
+	t.Run("Propagates ZoneID", func(t *testing.T) {
+		cellCfgWithZoneID := &multigresv1alpha1.CellConfig{
+			Name:   "zone-a",
+			ZoneID: "use1-az1",
+		}
+		got, err := BuildCell(
+			cluster,
+			cellCfgWithZoneID,
+			gatewaySpec,
+			noGatewayPlacement,
+			localTopoSpec,
+			globalTopoRef,
+			allCells,
+			scheme,
+		)
+		if err != nil {
+			t.Fatalf("BuildCell() error = %v", err)
+		}
+		if got.Spec.ZoneID != "use1-az1" {
+			t.Errorf("ZoneID = %v, want use1-az1", got.Spec.ZoneID)
 		}
 	})
 

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
@@ -95,14 +95,19 @@ func mergeDurabilityPolicy(child, parent string) string {
 }
 
 // buildCellTopologyLabels builds a map of cell name → nodeSelector labels from the cluster's cells.
+// ZoneID cells get {metadata.NodeLabelZoneID: value} and take precedence over zone name.
 // Zone cells get {"topology.kubernetes.io/zone": value}, region cells get
-// {"topology.kubernetes.io/region": value}. Cells without zone or region are omitted.
+// {"topology.kubernetes.io/region": value}. Cells without zone, zoneId, or region are omitted.
 func buildCellTopologyLabels(
 	cluster *multigresv1alpha1.MultigresCluster,
 ) map[multigresv1alpha1.CellName]map[string]string {
 	m := make(map[multigresv1alpha1.CellName]map[string]string)
 	for _, cell := range cluster.Spec.Cells {
 		switch {
+		case cell.ZoneID != "":
+			m[cell.Name] = map[string]string{
+				metadata.NodeLabelZoneID: string(cell.ZoneID),
+			}
 		case cell.Zone != "":
 			m[cell.Name] = map[string]string{
 				"topology.kubernetes.io/zone": string(cell.Zone),

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
@@ -95,17 +95,17 @@ func mergeDurabilityPolicy(child, parent string) string {
 }
 
 // buildCellTopologyLabels builds a map of cell name → nodeSelector labels from the cluster's cells.
-// Zone cells get {"topology.kubernetes.io/zone": value}, region cells get
-// {"topology.kubernetes.io/region": value}. Cells without zone or region are omitted.
+// ZoneID cells get {metadata.NodeLabelZoneID: value}, region cells get
+// {"topology.kubernetes.io/region": value}. Cells without zoneId or region are omitted.
 func buildCellTopologyLabels(
 	cluster *multigresv1alpha1.MultigresCluster,
 ) map[multigresv1alpha1.CellName]map[string]string {
 	m := make(map[multigresv1alpha1.CellName]map[string]string)
 	for _, cell := range cluster.Spec.Cells {
 		switch {
-		case cell.Zone != "":
+		case cell.ZoneID != "":
 			m[cell.Name] = map[string]string{
-				"topology.kubernetes.io/zone": string(cell.Zone),
+				metadata.NodeLabelZoneID: string(cell.ZoneID),
 			}
 		case cell.Region != "":
 			m[cell.Name] = map[string]string{

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
@@ -101,6 +101,69 @@ func TestBuildTableGroup(t *testing.T) {
 		}
 	})
 
+	t.Run("CellTopologyLabels ZoneID", func(t *testing.T) {
+		c := &multigresv1alpha1.MultigresCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster",
+				Namespace: "default",
+				UID:       "cluster-uid",
+			},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{{Name: "az-cell", ZoneID: "use1-az1"}},
+			},
+		}
+		got, err := BuildTableGroup(
+			c,
+			dbCfg,
+			&multigresv1alpha1.TableGroupConfig{Name: "tg"},
+			[]multigresv1alpha1.ShardResolvedSpec{{Name: "s0"}},
+			globalTopoRef,
+			scheme,
+		)
+		if err != nil {
+			t.Fatalf("BuildTableGroup() error = %v", err)
+		}
+		if got.Spec.CellTopologyLabels["az-cell"]["topology.k8s.aws/zone-id"] != "use1-az1" {
+			t.Errorf(
+				"expected topology.k8s.aws/zone-id=use1-az1, got %v",
+				got.Spec.CellTopologyLabels["az-cell"],
+			)
+		}
+	})
+
+	t.Run("CellTopologyLabels ZoneID takes precedence over Zone", func(t *testing.T) {
+		c := &multigresv1alpha1.MultigresCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster",
+				Namespace: "default",
+				UID:       "cluster-uid",
+			},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{
+					{Name: "both-cell", Zone: "us-east-1a", ZoneID: "use1-az1"},
+				},
+			},
+		}
+		got, err := BuildTableGroup(
+			c,
+			dbCfg,
+			&multigresv1alpha1.TableGroupConfig{Name: "tg"},
+			[]multigresv1alpha1.ShardResolvedSpec{{Name: "s0"}},
+			globalTopoRef,
+			scheme,
+		)
+		if err != nil {
+			t.Fatalf("BuildTableGroup() error = %v", err)
+		}
+		labels := got.Spec.CellTopologyLabels["both-cell"]
+		if labels["topology.k8s.aws/zone-id"] != "use1-az1" {
+			t.Errorf("expected topology.k8s.aws/zone-id=use1-az1, got %v", labels)
+		}
+		if _, hasZone := labels["topology.kubernetes.io/zone"]; hasZone {
+			t.Error("topology.kubernetes.io/zone should be absent when zoneId is set")
+		}
+	})
+
 	t.Run("CellTopologyLabels Region", func(t *testing.T) {
 		regionCluster := &multigresv1alpha1.MultigresCluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
@@ -101,6 +101,66 @@ func TestBuildTableGroup(t *testing.T) {
 		}
 	})
 
+	t.Run("CellTopologyLabels ZoneID", func(t *testing.T) {
+		c := &multigresv1alpha1.MultigresCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster",
+				Namespace: "default",
+				UID:       "cluster-uid",
+			},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{{Name: "az-cell", ZoneID: "use1-az1"}},
+			},
+		}
+		got, err := BuildTableGroup(
+			c,
+			dbCfg,
+			&multigresv1alpha1.TableGroupConfig{Name: "tg"},
+			[]multigresv1alpha1.ShardResolvedSpec{{Name: "s0"}},
+			globalTopoRef,
+			scheme,
+		)
+		if err != nil {
+			t.Fatalf("BuildTableGroup() error = %v", err)
+		}
+		if got.Spec.CellTopologyLabels["az-cell"]["topology.k8s.aws/zone-id"] != "use1-az1" {
+			t.Errorf(
+				"expected topology.k8s.aws/zone-id=use1-az1, got %v",
+				got.Spec.CellTopologyLabels["az-cell"],
+			)
+		}
+	})
+
+	t.Run("CellTopologyLabels ZoneID only", func(t *testing.T) {
+		c := &multigresv1alpha1.MultigresCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-cluster",
+				Namespace: "default",
+				UID:       "cluster-uid",
+			},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				Cells: []multigresv1alpha1.CellConfig{
+					{Name: "both-cell", ZoneID: "use1-az1"},
+				},
+			},
+		}
+		got, err := BuildTableGroup(
+			c,
+			dbCfg,
+			&multigresv1alpha1.TableGroupConfig{Name: "tg"},
+			[]multigresv1alpha1.ShardResolvedSpec{{Name: "s0"}},
+			globalTopoRef,
+			scheme,
+		)
+		if err != nil {
+			t.Fatalf("BuildTableGroup() error = %v", err)
+		}
+		labels := got.Spec.CellTopologyLabels["both-cell"]
+		if labels["topology.k8s.aws/zone-id"] != "use1-az1" {
+			t.Errorf("expected topology.k8s.aws/zone-id=use1-az1, got %v", labels)
+		}
+	})
+
 	t.Run("CellTopologyLabels Region", func(t *testing.T) {
 		regionCluster := &multigresv1alpha1.MultigresCluster{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster-handler/controller/multigrescluster/integration_adminweb_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_adminweb_test.go
@@ -43,7 +43,7 @@ func TestExternalAdminWeb_EnableDisableLifecycle(t *testing.T) {
 				ShardTemplate: "default",
 			},
 			Cells: []multigresv1alpha1.CellConfig{
-				{Name: "zone-a", Zone: "us-east-1a"},
+				{Name: "zone-a", ZoneID: "use1-az1"},
 			},
 			ExternalAdminWeb: &multigresv1alpha1.ExternalAdminWebConfig{
 				Enabled:     true,
@@ -209,7 +209,7 @@ func TestExternalAdminWeb_NoReadyAdminWebTransition(t *testing.T) {
 				ShardTemplate: "default",
 			},
 			Cells: []multigresv1alpha1.CellConfig{
-				{Name: "zone-a", Zone: "us-east-1a"},
+				{Name: "zone-a", ZoneID: "use1-az1"},
 			},
 			ExternalAdminWeb: &multigresv1alpha1.ExternalAdminWebConfig{
 				Enabled:     true,

--- a/pkg/cluster-handler/controller/multigrescluster/integration_gateway_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_gateway_test.go
@@ -45,7 +45,7 @@ func TestExternalGateway_EnableDisableLifecycle(t *testing.T) {
 				ShardTemplate: "default",
 			},
 			Cells: []multigresv1alpha1.CellConfig{
-				{Name: "zone-a", Zone: "us-east-1a"},
+				{Name: "zone-a", ZoneID: "use1-az1"},
 			},
 			ExternalGateway: &multigresv1alpha1.ExternalGatewayConfig{
 				Enabled:     true,
@@ -270,7 +270,7 @@ func TestExternalGateway_NoReadyGatewaysTransition(t *testing.T) {
 				ShardTemplate: "default",
 			},
 			Cells: []multigresv1alpha1.CellConfig{
-				{Name: "zone-a", Zone: "us-east-1a"},
+				{Name: "zone-a", ZoneID: "use1-az1"},
 			},
 			ExternalGateway: &multigresv1alpha1.ExternalGatewayConfig{
 				Enabled:     true,

--- a/pkg/cluster-handler/controller/multigrescluster/integration_lifecycle_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_lifecycle_test.go
@@ -53,7 +53,7 @@ func TestMultigresCluster_Lifecycle(t *testing.T) {
 				// Actually, TableGroups don't need cells if not defined inline?
 				// The error message might help: "unknown field Spec".
 				// Ah, DatabaseConfig has fields directly embedded or defined.
-				Cells: []multigresv1alpha1.CellConfig{{Name: "zone-a", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "zone-a", ZoneID: "use1-az1"}},
 			},
 		}
 

--- a/pkg/cluster-handler/controller/multigrescluster/integration_resolution_enforcement_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_resolution_enforcement_test.go
@@ -59,19 +59,19 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 				},
 				Cells: []multigresv1alpha1.CellConfig{
 					// Case A: Fallback to Cluster Default (Expect 1)
-					{Name: "zone-a", Zone: "us-east-1a"},
+					{Name: "zone-a", ZoneID: "use1-az1"},
 
 					// Case B: Explicit Template Ref (Expect 5)
 					{
 						Name:         "zone-b",
-						Zone:         "us-east-1b",
+						ZoneID:       "use1-az2",
 						CellTemplate: "large",
 					},
 
 					// Case C: Explicit Template Ref + Inline Override (Expect 3)
 					{
 						Name:         "zone-c",
-						Zone:         "us-east-1c",
+						ZoneID:       "use1-az3",
 						CellTemplate: "large",
 						Overrides: &multigresv1alpha1.CellOverrides{
 							MultiGateway: &multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(3))},
@@ -81,7 +81,7 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 					// Case D: Inline Spec (Highest Priority) (Expect 9)
 					{
 						Name: "zone-d",
-						Zone: "us-east-1d",
+						ZoneID: "use1-az4",
 						Spec: &multigresv1alpha1.CellInlineSpec{
 							MultiGateway: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(9))},
 						},
@@ -115,7 +115,10 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 				},
 				Spec: multigresv1alpha1.CellSpec{
 					Name: multigresv1alpha1.CellName(zone),
-					Zone: multigresv1alpha1.Zone("us-east-1" + zone[len(zone)-1:]), // construct zone from name (e.g. zone-a -> us-east-1a)
+					ZoneID: func() multigresv1alpha1.ZoneID {
+						azSuffix := map[byte]string{'a': "1", 'b': "2", 'c': "3", 'd': "4"}
+						return multigresv1alpha1.ZoneID("use1-az" + azSuffix[zone[len(zone)-1]])
+					}(), // construct zoneId from name (e.g. zone-a -> use1-az1)
 					Images: multigresv1alpha1.CellImages{
 						MultiGateway:    resolver.DefaultMultiGatewayImage,
 						ImagePullPolicy: resolver.DefaultImagePullPolicy,
@@ -173,7 +176,7 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 			Spec: multigresv1alpha1.MultigresClusterSpec{
 				TemplateDefaults: multigresv1alpha1.TemplateDefaults{}, // Empty, relying on implicit "default"
 				Cells: []multigresv1alpha1.CellConfig{
-					{Name: "zone-a", Zone: "us-east-1a"},
+					{Name: "zone-a", ZoneID: "use1-az1"},
 				},
 			},
 		}
@@ -196,7 +199,7 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 			},
 			Spec: multigresv1alpha1.CellSpec{
 				Name: "zone-a",
-				Zone: "us-east-1a",
+				ZoneID: "use1-az1",
 				Images: multigresv1alpha1.CellImages{
 					MultiGateway:    resolver.DefaultMultiGatewayImage,
 					ImagePullPolicy: resolver.DefaultImagePullPolicy,
@@ -254,8 +257,8 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testNamespace},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
 				Cells: []multigresv1alpha1.CellConfig{
-					{Name: "zone-a", Zone: "us-east-1a"},
-					{Name: "zone-c", Zone: "us-east-1c"},
+					{Name: "zone-a", ZoneID: "use1-az1"},
+					{Name: "zone-c", ZoneID: "use1-az3"},
 				},
 				Databases: []multigresv1alpha1.DatabaseConfig{
 					{
@@ -302,8 +305,8 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 			},
 			Spec: multigresv1alpha1.TableGroupSpec{
 				CellTopologyLabels: map[multigresv1alpha1.CellName]map[string]string{
-					"zone-a": {"topology.kubernetes.io/zone": "us-east-1a"},
-					"zone-c": {"topology.kubernetes.io/zone": "us-east-1c"},
+					"zone-a": {"topology.k8s.aws/zone-id": "use1-az1"},
+					"zone-c": {"topology.k8s.aws/zone-id": "use1-az3"},
 				},
 				DatabaseName: "postgres",
 				LogLevels: multigresv1alpha1.ComponentLogLevels{
@@ -390,7 +393,7 @@ func TestMultigresCluster_EnforcementLogic(t *testing.T) {
 		Spec: multigresv1alpha1.MultigresClusterSpec{
 			Cells: []multigresv1alpha1.CellConfig{
 				{
-					Name: "zone-a", Zone: "us-east-1a",
+					Name: "zone-a", ZoneID: "use1-az1",
 					Spec: &multigresv1alpha1.CellInlineSpec{
 						MultiGateway: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(2))},
 					},
@@ -417,7 +420,7 @@ func TestMultigresCluster_EnforcementLogic(t *testing.T) {
 		},
 		Spec: multigresv1alpha1.CellSpec{
 			Name: "zone-a",
-			Zone: "us-east-1a",
+			ZoneID: "use1-az1",
 			Images: multigresv1alpha1.CellImages{
 				MultiGateway:    resolver.DefaultMultiGatewayImage,
 				ImagePullPolicy: resolver.DefaultImagePullPolicy,
@@ -560,7 +563,7 @@ func TestMultigresCluster_TemplateOverrides(t *testing.T) {
 				ShardTemplate: multigresv1alpha1.TemplateRef(tplName),
 			},
 			Cells: []multigresv1alpha1.CellConfig{
-				{Name: "zone-a", Zone: "us-east-1a"},
+				{Name: "zone-a", ZoneID: "use1-az1"},
 			},
 			Databases: []multigresv1alpha1.DatabaseConfig{
 				{
@@ -597,7 +600,7 @@ func TestMultigresCluster_TemplateOverrides(t *testing.T) {
 		},
 		Spec: multigresv1alpha1.TableGroupSpec{
 			CellTopologyLabels: map[multigresv1alpha1.CellName]map[string]string{
-				"zone-a": {"topology.kubernetes.io/zone": "us-east-1a"},
+				"zone-a": {"topology.k8s.aws/zone-id": "use1-az1"},
 			},
 			DatabaseName: "postgres",
 			LogLevels: multigresv1alpha1.ComponentLogLevels{

--- a/pkg/cluster-handler/controller/multigrescluster/integration_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_test.go
@@ -204,7 +204,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						Spec: &multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
 					},
 					Cells: []multigresv1alpha1.CellConfig{
-						{Name: "zone-a", Zone: "us-east-1a", Spec: &multigresv1alpha1.CellInlineSpec{
+						{Name: "zone-a", ZoneID: "use1-az1", Spec: &multigresv1alpha1.CellInlineSpec{
 							MultiGateway: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
 						}},
 					},
@@ -469,7 +469,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 					},
 					Spec: multigresv1alpha1.CellSpec{
 						Name: "zone-a",
-						Zone: "us-east-1a",
+						ZoneID: "use1-az1",
 						Images: multigresv1alpha1.CellImages{
 							MultiGateway:     "gateway:latest",
 							ImagePullPolicy:  corev1.PullAlways,
@@ -508,7 +508,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 					},
 					Spec: multigresv1alpha1.TableGroupSpec{
 						CellTopologyLabels: map[multigresv1alpha1.CellName]map[string]string{
-							"zone-a": {"topology.kubernetes.io/zone": "us-east-1a"},
+							"zone-a": {"topology.k8s.aws/zone-id": "use1-az1"},
 						},
 						DatabaseName: "postgres",
 						LogLevels: multigresv1alpha1.ComponentLogLevels{
@@ -594,7 +594,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						TemplateRef: "default",
 					},
 					Cells: []multigresv1alpha1.CellConfig{
-						{Name: "zone-a", Zone: "us-east-1a"},
+						{Name: "zone-a", ZoneID: "use1-az1"},
 					},
 				},
 			},
@@ -830,7 +830,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 					},
 					Spec: multigresv1alpha1.CellSpec{
 						Name: "zone-a",
-						Zone: "us-east-1a",
+						ZoneID: "use1-az1",
 						Images: multigresv1alpha1.CellImages{
 							MultiGateway:    resolver.DefaultMultiGatewayImage,
 							ImagePullPolicy: resolver.DefaultImagePullPolicy,
@@ -868,7 +868,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 					},
 					Spec: multigresv1alpha1.TableGroupSpec{
 						CellTopologyLabels: map[multigresv1alpha1.CellName]map[string]string{
-							"zone-a": {"topology.kubernetes.io/zone": "us-east-1a"},
+							"zone-a": {"topology.k8s.aws/zone-id": "use1-az1"},
 						},
 						DatabaseName: "postgres",
 						LogLevels: multigresv1alpha1.ComponentLogLevels{
@@ -952,7 +952,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						ShardTemplate: "default",
 					},
 					Cells: []multigresv1alpha1.CellConfig{
-						{Name: "zone-a", Zone: "us-east-1a"},
+						{Name: "zone-a", ZoneID: "use1-az1"},
 					},
 				},
 			},
@@ -1188,7 +1188,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 					},
 					Spec: multigresv1alpha1.CellSpec{
 						Name: "zone-a",
-						Zone: "us-east-1a",
+						ZoneID: "use1-az1",
 						Images: multigresv1alpha1.CellImages{
 							MultiGateway:    resolver.DefaultMultiGatewayImage,
 							ImagePullPolicy: resolver.DefaultImagePullPolicy,
@@ -1226,7 +1226,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 					},
 					Spec: multigresv1alpha1.TableGroupSpec{
 						CellTopologyLabels: map[multigresv1alpha1.CellName]map[string]string{
-							"zone-a": {"topology.kubernetes.io/zone": "us-east-1a"},
+							"zone-a": {"topology.k8s.aws/zone-id": "use1-az1"},
 						},
 						DatabaseName: "postgres",
 						LogLevels: multigresv1alpha1.ComponentLogLevels{

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
@@ -320,7 +320,7 @@ func setupFixtures(tb testing.TB) (
 				TemplateRef: "default-core",
 			},
 			Cells: []multigresv1alpha1.CellConfig{
-				{Name: "zone-a", Zone: "us-east-1a"},
+				{Name: "zone-a", ZoneID: "use1-az1"},
 			},
 			Databases: []multigresv1alpha1.DatabaseConfig{
 				{

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_cells_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_cells_test.go
@@ -26,7 +26,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 				GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
 					TemplateRef: "non-existent-core",
 				},
-				Cells: []multigresv1alpha1.CellConfig{{Name: "zone-a", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "zone-a", ZoneID: "use1-az1"}},
 			},
 		}
 
@@ -57,7 +57,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 				},
 				Cells: []multigresv1alpha1.CellConfig{{
 					Name:         "zone-a",
-					Zone:         "us-east-1a",
+					ZoneID:       "use1-az1",
 					CellTemplate: "non-existent-cell",
 				}},
 			},
@@ -114,7 +114,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 					Etcd: &multigresv1alpha1.EtcdSpec{Image: "etcd"},
 				},
 				Cells: []multigresv1alpha1.CellConfig{
-					{Name: "zone-a", Zone: "us-east-1a"},
+					{Name: "zone-a", ZoneID: "use1-az1"},
 				},
 			},
 		}
@@ -189,7 +189,7 @@ func TestReconcileCells_ErrorPaths(t *testing.T) {
 					Etcd: &multigresv1alpha1.EtcdSpec{Image: "etcd"},
 				},
 				Cells: []multigresv1alpha1.CellConfig{
-					{Name: "zone-a", Zone: "us-east-1a"},
+					{Name: "zone-a", ZoneID: "use1-az1"},
 				},
 			},
 		}
@@ -224,7 +224,7 @@ func TestReconcileCells_HappyPath(t *testing.T) {
 					Etcd: &multigresv1alpha1.EtcdSpec{Image: "etcd"},
 				},
 				Cells: []multigresv1alpha1.CellConfig{
-					{Name: "zone-new", Zone: "us-east-1a"},
+					{Name: "zone-new", ZoneID: "use1-az1"},
 				},
 			},
 		}

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_database_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_database_test.go
@@ -110,8 +110,8 @@ func TestReconcile_Databases(t *testing.T) {
 		"Reconcile: Implicit Cell Sorting": {
 			preReconcileUpdate: func(t testing.TB, c *multigresv1alpha1.MultigresCluster) {
 				c.Spec.Cells = []multigresv1alpha1.CellConfig{
-					{Name: "zone-b", Zone: "us-east-1b"},
-					{Name: "zone-a", Zone: "us-east-1a"},
+					{Name: "zone-b", ZoneID: "use1-az2"},
+					{Name: "zone-a", ZoneID: "use1-az1"},
 				}
 			},
 			existingObjects: []client.Object{

--- a/pkg/resolver/validation.go
+++ b/pkg/resolver/validation.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
 
 // ============================================================================
@@ -709,6 +710,9 @@ func (r *Resolver) validateCellTopology(
 	for _, cell := range cells {
 		var key, value string
 		switch {
+		case cell.ZoneID != "":
+			key = metadata.NodeLabelZoneID
+			value = string(cell.ZoneID)
 		case cell.Zone != "":
 			key = "topology.kubernetes.io/zone"
 			value = string(cell.Zone)
@@ -744,11 +748,15 @@ func (r *Resolver) validateCellTopology(
 
 	// Build a set of available topology values
 	availableZones := make(map[string]bool)
+	availableZoneIDs := make(map[string]bool)
 	availableRegions := make(map[string]bool)
 	for i := range nodeList.Items {
 		labels := nodeList.Items[i].Labels
 		if z, ok := labels["topology.kubernetes.io/zone"]; ok {
 			availableZones[z] = true
+		}
+		if zoneID, ok := labels[metadata.NodeLabelZoneID]; ok {
+			availableZoneIDs[zoneID] = true
 		}
 		if reg, ok := labels["topology.kubernetes.io/region"]; ok {
 			availableRegions[reg] = true
@@ -758,6 +766,8 @@ func (r *Resolver) validateCellTopology(
 	for _, tc := range checks {
 		var found bool
 		switch tc.key {
+		case metadata.NodeLabelZoneID:
+			found = availableZoneIDs[tc.value]
 		case "topology.kubernetes.io/zone":
 			found = availableZones[tc.value]
 		case "topology.kubernetes.io/region":

--- a/pkg/resolver/validation.go
+++ b/pkg/resolver/validation.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
 
 // ============================================================================
@@ -709,9 +710,9 @@ func (r *Resolver) validateCellTopology(
 	for _, cell := range cells {
 		var key, value string
 		switch {
-		case cell.Zone != "":
-			key = "topology.kubernetes.io/zone"
-			value = string(cell.Zone)
+		case cell.ZoneID != "":
+			key = metadata.NodeLabelZoneID
+			value = string(cell.ZoneID)
 		case cell.Region != "":
 			key = "topology.kubernetes.io/region"
 			value = string(cell.Region)
@@ -743,12 +744,12 @@ func (r *Resolver) validateCellTopology(
 	}
 
 	// Build a set of available topology values
-	availableZones := make(map[string]bool)
+	availableZoneIDs := make(map[string]bool)
 	availableRegions := make(map[string]bool)
 	for i := range nodeList.Items {
 		labels := nodeList.Items[i].Labels
-		if z, ok := labels["topology.kubernetes.io/zone"]; ok {
-			availableZones[z] = true
+		if zoneID, ok := labels[metadata.NodeLabelZoneID]; ok {
+			availableZoneIDs[zoneID] = true
 		}
 		if reg, ok := labels["topology.kubernetes.io/region"]; ok {
 			availableRegions[reg] = true
@@ -758,8 +759,8 @@ func (r *Resolver) validateCellTopology(
 	for _, tc := range checks {
 		var found bool
 		switch tc.key {
-		case "topology.kubernetes.io/zone":
-			found = availableZones[tc.value]
+		case metadata.NodeLabelZoneID:
+			found = availableZoneIDs[tc.value]
 		case "topology.kubernetes.io/region":
 			found = availableRegions[tc.value]
 		}

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -208,6 +208,12 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			Labels: map[string]string{"topology.kubernetes.io/region": "us-east-1"},
 		},
 	}
+	nodeZoneID := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-zone-id",
+			Labels: map[string]string{"topology.k8s.aws/zone-id": "use1-az1"},
+		},
+	}
 	withZoneAClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(shardTpl, badPoolTpl, defaultSC, nodeZoneA).
@@ -215,6 +221,10 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 	withRegionClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(shardTpl, badPoolTpl, defaultSC, nodeRegionEast).
+		Build()
+	withZoneIDClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(shardTpl, badPoolTpl, defaultSC, nodeZoneID).
 		Build()
 	noMatchingNodeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -574,6 +584,49 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			customClient: noMatchingNodeClient,
 			wantWarnings: []string{
 				"no nodes currently match topology.kubernetes.io/region=eu-west-1",
+			},
+		},
+		"Cell ZoneID matches node - no topology warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "az-a", ZoneID: "use1-az1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{
+							{
+								Shards: []multigresv1alpha1.ShardConfig{
+									{Name: "s0", ShardTemplate: "prod-shard"},
+								},
+							},
+						},
+					}},
+				},
+			},
+			customClient: withZoneIDClient,
+		},
+		"Cell ZoneID no matching node - topology warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "az-b", ZoneID: "use1-az2"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{
+							{
+								Shards: []multigresv1alpha1.ShardConfig{
+									{Name: "s0", ShardTemplate: "prod-shard"},
+								},
+							},
+						},
+					}},
+				},
+			},
+			customClient: noMatchingNodeClient,
+			wantWarnings: []string{
+				"no nodes currently match topology.k8s.aws/zone-id=use1-az2",
 			},
 		},
 		// COVERAGE: quorum warning for readWrite pools with low replica count

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -196,25 +196,25 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 		WithObjects(shardTpl, badPoolTpl).
 		Build()
 
-	nodeZoneA := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node-zone-a",
-			Labels: map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
-		},
-	}
 	nodeRegionEast := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node-region-east",
 			Labels: map[string]string{"topology.kubernetes.io/region": "us-east-1"},
 		},
 	}
-	withZoneAClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(shardTpl, badPoolTpl, defaultSC, nodeZoneA).
-		Build()
+	nodeZoneID := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-zone-id",
+			Labels: map[string]string{"topology.k8s.aws/zone-id": "use1-az1"},
+		},
+	}
 	withRegionClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(shardTpl, badPoolTpl, defaultSC, nodeRegionEast).
+		Build()
+	withZoneIDClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(shardTpl, badPoolTpl, defaultSC, nodeZoneID).
 		Build()
 	noMatchingNodeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -493,13 +493,13 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			},
 			// Uses fakeClient which HAS a default StorageClass
 		},
-		// COVERAGE: validateCellTopology zone/region branches
-		"Cell Zone matches node - no topology warning": {
+		// COVERAGE: validateCellTopology zoneId/region branches
+		"Cell ZoneID matches node via withZoneIDClient - no topology warning": {
 			cluster: &multigresv1alpha1.MultigresCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
 				Spec: multigresv1alpha1.MultigresClusterSpec{
 					Cells: []multigresv1alpha1.CellConfig{
-						{Name: "zone-a", Zone: "us-east-1a"},
+						{Name: "zone-a", ZoneID: "use1-az1"},
 					},
 					Databases: []multigresv1alpha1.DatabaseConfig{{
 						TableGroups: []multigresv1alpha1.TableGroupConfig{{
@@ -511,14 +511,14 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 					}},
 				},
 			},
-			customClient: withZoneAClient,
+			customClient: withZoneIDClient,
 		},
-		"Cell Zone no matching node - topology warning": {
+		"Cell ZoneID no matching node - topology warning": {
 			cluster: &multigresv1alpha1.MultigresCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
 				Spec: multigresv1alpha1.MultigresClusterSpec{
 					Cells: []multigresv1alpha1.CellConfig{
-						{Name: "zone-b", Zone: "us-west-2a"},
+						{Name: "zone-b", ZoneID: "usw2-az1"},
 					},
 					Databases: []multigresv1alpha1.DatabaseConfig{{
 						TableGroups: []multigresv1alpha1.TableGroupConfig{{
@@ -532,7 +532,7 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			},
 			customClient: noMatchingNodeClient,
 			wantWarnings: []string{
-				"no nodes currently match topology.kubernetes.io/zone=us-west-2a",
+				"no nodes currently match topology.k8s.aws/zone-id=usw2-az1",
 			},
 		},
 		"Cell Region matches node - no topology warning": {
@@ -575,6 +575,26 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			wantWarnings: []string{
 				"no nodes currently match topology.kubernetes.io/region=eu-west-1",
 			},
+		},
+		"Cell ZoneID matches node - no topology warning": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "az-a", ZoneID: "use1-az1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{
+							{
+								Shards: []multigresv1alpha1.ShardConfig{
+									{Name: "s0", ShardTemplate: "prod-shard"},
+								},
+							},
+						},
+					}},
+				},
+			},
+			customClient: withZoneIDClient,
 		},
 		// COVERAGE: quorum warning for readWrite pools with low replica count
 		"Quorum Warning: readWrite pool with 2 replicas": {
@@ -1006,13 +1026,13 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			},
 			wantErr: "failed to check for default StorageClass",
 		},
-		"Two cells same zone - topology dedup": {
+		"Two cells same zoneId - topology dedup": {
 			cluster: &multigresv1alpha1.MultigresCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
 				Spec: multigresv1alpha1.MultigresClusterSpec{
 					Cells: []multigresv1alpha1.CellConfig{
-						{Name: "cell-a", Zone: "us-east-1a"},
-						{Name: "cell-b", Zone: "us-east-1a"},
+						{Name: "cell-a", ZoneID: "use1-az1"},
+						{Name: "cell-b", ZoneID: "use1-az1"},
 					},
 					Databases: []multigresv1alpha1.DatabaseConfig{{
 						TableGroups: []multigresv1alpha1.TableGroupConfig{{
@@ -1026,8 +1046,8 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			},
 			customClient: noMatchingNodeClient,
 			wantWarnings: []string{
-				"cell 'cell-a': no nodes currently match topology.kubernetes.io/zone=us-east-1a",
-				"cell 'cell-b': no nodes currently match topology.kubernetes.io/zone=us-east-1a",
+				"cell 'cell-a': no nodes currently match topology.k8s.aws/zone-id=use1-az1",
+				"cell 'cell-b': no nodes currently match topology.k8s.aws/zone-id=use1-az1",
 			},
 		},
 		"Invalid Pool Name (uppercase and special chars)": {
@@ -1130,7 +1150,7 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
 				Spec: multigresv1alpha1.MultigresClusterSpec{
 					Cells: []multigresv1alpha1.CellConfig{
-						{Name: "zone-a", Zone: "us-east-1a"},
+						{Name: "zone-a", ZoneID: "use1-az1"},
 					},
 					Databases: []multigresv1alpha1.DatabaseConfig{{
 						TableGroups: []multigresv1alpha1.TableGroupConfig{{

--- a/pkg/resource-handler/controller/cell/integration_test.go
+++ b/pkg/resource-handler/controller/cell/integration_test.go
@@ -80,7 +80,7 @@ func TestCellReconciliation(t *testing.T) {
 						Multigateway: "info",
 					},
 
-					Zone: "us-west-1a",
+					ZoneID: "usw1-az1",
 					Images: multigresv1alpha1.CellImages{
 						MultiGateway: "ghcr.io/multigres/multigres:main",
 					},
@@ -102,17 +102,17 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "test-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
+						Labels:          cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "usw1-az1"),
 						OwnerReferences: cellOwnerRefs(t, "test-cell"),
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas: ptr.To(int32(2)),
 						Selector: &metav1.LabelSelector{
-							MatchLabels: metadata.GetSelectorLabels(cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a")),
+							MatchLabels: metadata.GetSelectorLabels(cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "usw1-az1")),
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
-								Labels: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
+								Labels: cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "usw1-az1"),
 								Annotations: map[string]string{
 									"multigres.com/project-ref": "test-cluster",
 								},
@@ -170,7 +170,7 @@ func TestCellReconciliation(t *testing.T) {
 									},
 								},
 								NodeSelector: map[string]string{
-									"topology.kubernetes.io/zone": "us-west-1a",
+									"topology.k8s.aws/zone-id": "usw1-az1",
 								},
 							},
 						},
@@ -180,7 +180,7 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "test-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a"),
+						Labels:          cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "usw1-az1"),
 						OwnerReferences: cellOwnerRefs(t, "test-cell"),
 					},
 					Spec: corev1.ServiceSpec{
@@ -190,7 +190,7 @@ func TestCellReconciliation(t *testing.T) {
 							tcpServicePort(t, "grpc", 15170),
 							tcpServicePort(t, "postgres", 5432),
 						},
-						Selector: metadata.GetSelectorLabels(cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "us-west-1a")),
+						Selector: metadata.GetSelectorLabels(cellLabels(t, "test-cell-multigateway", "multigateway", "zone1", "usw1-az1")),
 					},
 				},
 			},
@@ -212,7 +212,7 @@ func TestCellReconciliation(t *testing.T) {
 						Multigateway: "info",
 					},
 
-					Zone: "us-west-1b",
+					ZoneID: "usw1-az2",
 					Images: multigresv1alpha1.CellImages{
 						MultiGateway: "ghcr.io/multigres/multigres:main",
 					},
@@ -234,17 +234,17 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "custom-replicas-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
+						Labels:          cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "usw1-az2"),
 						OwnerReferences: cellOwnerRefs(t, "custom-replicas-cell"),
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas: ptr.To(int32(3)),
 						Selector: &metav1.LabelSelector{
-							MatchLabels: metadata.GetSelectorLabels(cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b")),
+							MatchLabels: metadata.GetSelectorLabels(cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "usw1-az2")),
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
-								Labels: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
+								Labels: cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "usw1-az2"),
 								Annotations: map[string]string{
 									"multigres.com/project-ref": "test-cluster",
 								},
@@ -302,7 +302,7 @@ func TestCellReconciliation(t *testing.T) {
 									},
 								},
 								NodeSelector: map[string]string{
-									"topology.kubernetes.io/zone": "us-west-1b",
+									"topology.k8s.aws/zone-id": "usw1-az2",
 								},
 							},
 						},
@@ -312,7 +312,7 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "custom-replicas-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b"),
+						Labels:          cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "usw1-az2"),
 						OwnerReferences: cellOwnerRefs(t, "custom-replicas-cell"),
 					},
 					Spec: corev1.ServiceSpec{
@@ -322,7 +322,7 @@ func TestCellReconciliation(t *testing.T) {
 							tcpServicePort(t, "grpc", 15170),
 							tcpServicePort(t, "postgres", 5432),
 						},
-						Selector: metadata.GetSelectorLabels(cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "us-west-1b")),
+						Selector: metadata.GetSelectorLabels(cellLabels(t, "custom-replicas-cell-multigateway", "multigateway", "zone2", "usw1-az2")),
 					},
 				},
 			},
@@ -344,7 +344,7 @@ func TestCellReconciliation(t *testing.T) {
 						Multigateway: "info",
 					},
 
-					Zone: "us-west-1c",
+					ZoneID: "usw1-az3",
 					Images: multigresv1alpha1.CellImages{
 						MultiGateway: "custom/multigateway:v1.0.0",
 					},
@@ -366,17 +366,17 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "custom-images-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
+						Labels:          cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "usw1-az3"),
 						OwnerReferences: cellOwnerRefs(t, "custom-images-cell"),
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas: ptr.To(int32(2)),
 						Selector: &metav1.LabelSelector{
-							MatchLabels: metadata.GetSelectorLabels(cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c")),
+							MatchLabels: metadata.GetSelectorLabels(cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "usw1-az3")),
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
-								Labels: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
+								Labels: cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "usw1-az3"),
 								Annotations: map[string]string{
 									"multigres.com/project-ref": "test-cluster",
 								},
@@ -434,7 +434,7 @@ func TestCellReconciliation(t *testing.T) {
 									},
 								},
 								NodeSelector: map[string]string{
-									"topology.kubernetes.io/zone": "us-west-1c",
+									"topology.k8s.aws/zone-id": "usw1-az3",
 								},
 							},
 						},
@@ -444,7 +444,7 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "custom-images-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c"),
+						Labels:          cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "usw1-az3"),
 						OwnerReferences: cellOwnerRefs(t, "custom-images-cell"),
 					},
 					Spec: corev1.ServiceSpec{
@@ -454,7 +454,7 @@ func TestCellReconciliation(t *testing.T) {
 							tcpServicePort(t, "grpc", 15170),
 							tcpServicePort(t, "postgres", 5432),
 						},
-						Selector: metadata.GetSelectorLabels(cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "us-west-1c")),
+						Selector: metadata.GetSelectorLabels(cellLabels(t, "custom-images-cell-multigateway", "multigateway", "zone3", "usw1-az3")),
 					},
 				},
 			},
@@ -476,7 +476,7 @@ func TestCellReconciliation(t *testing.T) {
 						Multigateway: "info",
 					},
 
-					Zone: "us-west-1d",
+					ZoneID: "usw1-az4",
 					Images: multigresv1alpha1.CellImages{
 						MultiGateway: "ghcr.io/multigres/multigres:main",
 					},
@@ -515,17 +515,17 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "affinity-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
+						Labels:          cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "usw1-az4"),
 						OwnerReferences: cellOwnerRefs(t, "affinity-cell"),
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas: ptr.To(int32(2)),
 						Selector: &metav1.LabelSelector{
-							MatchLabels: metadata.GetSelectorLabels(cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d")),
+							MatchLabels: metadata.GetSelectorLabels(cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "usw1-az4")),
 						},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
-								Labels: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
+								Labels: cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "usw1-az4"),
 								Annotations: map[string]string{
 									"multigres.com/project-ref": "test-cluster",
 								},
@@ -600,7 +600,7 @@ func TestCellReconciliation(t *testing.T) {
 									},
 								},
 								NodeSelector: map[string]string{
-									"topology.kubernetes.io/zone": "us-west-1d",
+									"topology.k8s.aws/zone-id": "usw1-az4",
 								},
 							},
 						},
@@ -610,7 +610,7 @@ func TestCellReconciliation(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "affinity-cell-multigateway",
 						Namespace:       "default",
-						Labels:          cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d"),
+						Labels:          cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "usw1-az4"),
 						OwnerReferences: cellOwnerRefs(t, "affinity-cell"),
 					},
 					Spec: corev1.ServiceSpec{
@@ -620,7 +620,7 @@ func TestCellReconciliation(t *testing.T) {
 							tcpServicePort(t, "grpc", 15170),
 							tcpServicePort(t, "postgres", 5432),
 						},
-						Selector: metadata.GetSelectorLabels(cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "us-west-1d")),
+						Selector: metadata.GetSelectorLabels(cellLabels(t, "affinity-cell-multigateway", "multigateway", "zone4", "usw1-az4")),
 					},
 				},
 			},
@@ -720,7 +720,7 @@ func TestCellReconciliation(t *testing.T) {
 // Test helpers
 
 // cellLabels returns standard labels for cell resources in tests
-func cellLabels(t testing.TB, instanceName, component, cellName, zone string) map[string]string {
+func cellLabels(t testing.TB, instanceName, component, cellName, zoneID string) map[string]string {
 	t.Helper()
 	return map[string]string{
 		"app.kubernetes.io/component":  component,
@@ -729,7 +729,7 @@ func cellLabels(t testing.TB, instanceName, component, cellName, zone string) ma
 		"app.kubernetes.io/name":       "multigres",
 		"app.kubernetes.io/part-of":    "multigres",
 		"multigres.com/cell":           cellName,
-		"multigres.com/zone":           zone,
+		"multigres.com/zone-id":        zoneID,
 	}
 }
 

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -97,7 +97,9 @@ func BuildMultiGatewayDeployment(
 		clusterName,
 	)
 	metadata.AddCellLabel(labels, cell.Spec.Name)
-	if cell.Spec.Zone != "" {
+	if cell.Spec.ZoneID != "" {
+		metadata.AddZoneIDLabel(labels, cell.Spec.ZoneID)
+	} else if cell.Spec.Zone != "" {
 		metadata.AddZoneLabel(labels, cell.Spec.Zone)
 	}
 	if cell.Spec.Region != "" {
@@ -257,7 +259,9 @@ func BuildMultiGatewayService(
 	clusterName := cell.Labels["multigres.com/cluster"]
 	labels := metadata.BuildStandardLabels(clusterName, MultiGatewayComponentName)
 	metadata.AddCellLabel(labels, cell.Spec.Name)
-	if cell.Spec.Zone != "" {
+	if cell.Spec.ZoneID != "" {
+		metadata.AddZoneIDLabel(labels, cell.Spec.ZoneID)
+	} else if cell.Spec.Zone != "" {
 		metadata.AddZoneLabel(labels, cell.Spec.Zone)
 	}
 	if cell.Spec.Region != "" {
@@ -304,10 +308,14 @@ func BuildMultiGatewayService(
 }
 
 // buildCellNodeSelector returns a nodeSelector map for the cell's topology.
-// Returns nil if the cell has no zone or region, which means no scheduling constraint.
-// Zone and region are mutually exclusive (enforced by CEL validation on CellSpec).
+// ZoneID takes precedence over zone name when both are set, using the metadata.NodeLabelZoneID
+// node label exposed by the AWS node labeler. Returns nil if no topology is set.
 func buildCellNodeSelector(cell *multigresv1alpha1.Cell) map[string]string {
 	switch {
+	case cell.Spec.ZoneID != "":
+		return map[string]string{
+			metadata.NodeLabelZoneID: string(cell.Spec.ZoneID),
+		}
 	case cell.Spec.Zone != "":
 		return map[string]string{
 			"topology.kubernetes.io/zone": string(cell.Spec.Zone),

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -97,8 +97,8 @@ func BuildMultiGatewayDeployment(
 		clusterName,
 	)
 	metadata.AddCellLabel(labels, cell.Spec.Name)
-	if cell.Spec.Zone != "" {
-		metadata.AddZoneLabel(labels, cell.Spec.Zone)
+	if cell.Spec.ZoneID != "" {
+		metadata.AddZoneIDLabel(labels, cell.Spec.ZoneID)
 	}
 	if cell.Spec.Region != "" {
 		metadata.AddRegionLabel(labels, cell.Spec.Region)
@@ -257,8 +257,8 @@ func BuildMultiGatewayService(
 	clusterName := cell.Labels["multigres.com/cluster"]
 	labels := metadata.BuildStandardLabels(clusterName, MultiGatewayComponentName)
 	metadata.AddCellLabel(labels, cell.Spec.Name)
-	if cell.Spec.Zone != "" {
-		metadata.AddZoneLabel(labels, cell.Spec.Zone)
+	if cell.Spec.ZoneID != "" {
+		metadata.AddZoneIDLabel(labels, cell.Spec.ZoneID)
 	}
 	if cell.Spec.Region != "" {
 		metadata.AddRegionLabel(labels, cell.Spec.Region)
@@ -304,13 +304,13 @@ func BuildMultiGatewayService(
 }
 
 // buildCellNodeSelector returns a nodeSelector map for the cell's topology.
-// Returns nil if the cell has no zone or region, which means no scheduling constraint.
-// Zone and region are mutually exclusive (enforced by CEL validation on CellSpec).
+// buildCellNodeSelector returns a nodeSelector map for the cell's topology.
+// Returns nil if no topology is set.
 func buildCellNodeSelector(cell *multigresv1alpha1.Cell) map[string]string {
 	switch {
-	case cell.Spec.Zone != "":
+	case cell.Spec.ZoneID != "":
 		return map[string]string{
-			"topology.kubernetes.io/zone": string(cell.Spec.Zone),
+			metadata.NodeLabelZoneID: string(cell.Spec.ZoneID),
 		}
 	case cell.Spec.Region != "":
 		return map[string]string{

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -1469,6 +1469,42 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 	}
 }
 
+func TestBuildCellNodeSelector(t *testing.T) {
+	tests := map[string]struct {
+		spec multigresv1alpha1.CellSpec
+		want map[string]string
+	}{
+		"zone only": {
+			spec: multigresv1alpha1.CellSpec{Zone: "us-east-1a"},
+			want: map[string]string{"topology.kubernetes.io/zone": "us-east-1a"},
+		},
+		"zoneId only": {
+			spec: multigresv1alpha1.CellSpec{ZoneID: "use1-az1"},
+			want: map[string]string{"topology.k8s.aws/zone-id": "use1-az1"},
+		},
+		"zoneId takes precedence over zone": {
+			spec: multigresv1alpha1.CellSpec{Zone: "us-east-1a", ZoneID: "use1-az1"},
+			want: map[string]string{"topology.k8s.aws/zone-id": "use1-az1"},
+		},
+		"region": {
+			spec: multigresv1alpha1.CellSpec{Region: "us-west-2"},
+			want: map[string]string{"topology.kubernetes.io/region": "us-west-2"},
+		},
+		"none": {
+			spec: multigresv1alpha1.CellSpec{},
+			want: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cell := &multigresv1alpha1.Cell{Spec: tc.spec}
+			if diff := cmp.Diff(tc.want, buildCellNodeSelector(cell)); diff != "" {
+				t.Errorf("buildCellNodeSelector() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestBuildMultiGatewayDeployment_ProjectRefAnnotation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = multigresv1alpha1.AddToScheme(scheme)

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -1114,8 +1114,8 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 					Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
 				},
 				Spec: multigresv1alpha1.CellSpec{
-					Name: "zone-topo",
-					Zone: "us-east-1a",
+					Name:   "zone-topo",
+					ZoneID: "use1-az1",
 					GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
 						Address:        "global-topo:2379",
 						RootPath:       "/multigres/global",
@@ -1141,7 +1141,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 						"app.kubernetes.io/component":  "multigateway",
 						"app.kubernetes.io/part-of":    "multigres",
 						"app.kubernetes.io/managed-by": "multigres-operator",
-						"multigres.com/zone":           "us-east-1a",
+						"multigres.com/zone-id":        "use1-az1",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -1170,7 +1170,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 								"app.kubernetes.io/component":  "multigateway",
 								"app.kubernetes.io/part-of":    "multigres",
 								"app.kubernetes.io/managed-by": "multigres-operator",
-								"multigres.com/zone":           "us-east-1a",
+								"multigres.com/zone-id":        "use1-az1",
 							},
 						},
 						Spec: corev1.PodSpec{
@@ -1243,7 +1243,7 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 								},
 							},
 							NodeSelector: map[string]string{
-								"topology.kubernetes.io/zone": "us-east-1a",
+								"topology.k8s.aws/zone-id": "use1-az1",
 							},
 						},
 					},
@@ -1464,6 +1464,34 @@ func TestBuildMultiGatewayDeployment(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("BuildMultiGatewayDeployment() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildCellNodeSelector(t *testing.T) {
+	tests := map[string]struct {
+		spec multigresv1alpha1.CellSpec
+		want map[string]string
+	}{
+		"zoneId only": {
+			spec: multigresv1alpha1.CellSpec{ZoneID: "use1-az1"},
+			want: map[string]string{"topology.k8s.aws/zone-id": "use1-az1"},
+		},
+		"region": {
+			spec: multigresv1alpha1.CellSpec{Region: "us-west-2"},
+			want: map[string]string{"topology.kubernetes.io/region": "us-west-2"},
+		},
+		"none": {
+			spec: multigresv1alpha1.CellSpec{},
+			want: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cell := &multigresv1alpha1.Cell{Spec: tc.spec}
+			if diff := cmp.Diff(tc.want, buildCellNodeSelector(cell)); diff != "" {
+				t.Errorf("buildCellNodeSelector() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1740,8 +1768,8 @@ func TestBuildMultiGatewayService(t *testing.T) {
 					Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
 				},
 				Spec: multigresv1alpha1.CellSpec{
-					Name: "zone-topo",
-					Zone: "us-east-1a",
+					Name:   "zone-topo",
+					ZoneID: "use1-az1",
 				},
 			},
 			scheme: scheme,
@@ -1755,7 +1783,7 @@ func TestBuildMultiGatewayService(t *testing.T) {
 						"app.kubernetes.io/component":  "multigateway",
 						"app.kubernetes.io/part-of":    "multigres",
 						"app.kubernetes.io/managed-by": "multigres-operator",
-						"multigres.com/zone":           "us-east-1a",
+						"multigres.com/zone-id":        "use1-az1",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/pkg/util/metadata/labels.go
+++ b/pkg/util/metadata/labels.go
@@ -85,6 +85,13 @@ const (
 	// LabelMultigresZone identifies which zone a resource belongs to.
 	LabelMultigresZone = "multigres.com/zone"
 
+	// LabelMultigresZoneID identifies which zone ID a resource belongs to.
+	LabelMultigresZoneID = "multigres.com/zone-id"
+
+	// NodeLabelZoneID is the AWS node label key for the availability zone ID.
+	// Zone IDs (e.g. use1-az1) are consistent across accounts, unlike zone names.
+	NodeLabelZoneID = "topology.k8s.aws/zone-id"
+
 	// LabelMultigresRegion identifies which region a resource belongs to.
 	LabelMultigresRegion = "multigres.com/region"
 
@@ -213,6 +220,15 @@ func AddZoneLabel(
 	zoneName multigresv1alpha1.Zone,
 ) map[string]string {
 	labels[LabelMultigresZone] = string(zoneName)
+	return labels
+}
+
+// AddZoneIDLabel adds the zone ID label to the provided labels map.
+func AddZoneIDLabel(
+	labels map[string]string,
+	zoneID multigresv1alpha1.ZoneID,
+) map[string]string {
+	labels[LabelMultigresZoneID] = string(zoneID)
 	return labels
 }
 

--- a/pkg/util/metadata/labels.go
+++ b/pkg/util/metadata/labels.go
@@ -82,8 +82,12 @@ const (
 	// LabelMultigresPool identifies which pool a resource belongs to.
 	LabelMultigresPool = "multigres.com/pool"
 
-	// LabelMultigresZone identifies which zone a resource belongs to.
-	LabelMultigresZone = "multigres.com/zone"
+	// LabelMultigresZoneID identifies which zone ID a resource belongs to.
+	LabelMultigresZoneID = "multigres.com/zone-id"
+
+	// NodeLabelZoneID is the AWS node label key for the availability zone ID.
+	// Zone IDs (e.g. use1-az1) are consistent across accounts, unlike zone names.
+	NodeLabelZoneID = "topology.k8s.aws/zone-id"
 
 	// LabelMultigresRegion identifies which region a resource belongs to.
 	LabelMultigresRegion = "multigres.com/region"
@@ -207,12 +211,12 @@ func AddPoolLabel(
 	return labels
 }
 
-// AddZoneLabel adds the zone label to the provided labels map.
-func AddZoneLabel(
+// AddZoneIDLabel adds the zone ID label to the provided labels map.
+func AddZoneIDLabel(
 	labels map[string]string,
-	zoneName multigresv1alpha1.Zone,
+	zoneID multigresv1alpha1.ZoneID,
 ) map[string]string {
-	labels[LabelMultigresZone] = string(zoneName)
+	labels[LabelMultigresZoneID] = string(zoneID)
 	return labels
 }
 

--- a/pkg/util/metadata/labels_test.go
+++ b/pkg/util/metadata/labels_test.go
@@ -335,6 +335,16 @@ func TestAddExtraLabels(t *testing.T) {
 			},
 		},
 		{
+			name:    "AddZoneIDLabel",
+			initial: map[string]string{},
+			addFunc: func(m map[string]string) {
+				metadata.AddZoneIDLabel(m, "use1-az1")
+			},
+			expected: map[string]string{
+				"multigres.com/zone-id": "use1-az1",
+			},
+		},
+		{
 			name:    "AddRegionLabel",
 			initial: map[string]string{},
 			addFunc: func(m map[string]string) {

--- a/pkg/util/metadata/labels_test.go
+++ b/pkg/util/metadata/labels_test.go
@@ -325,13 +325,13 @@ func TestAddExtraLabels(t *testing.T) {
 			},
 		},
 		{
-			name:    "AddZoneLabel",
+			name:    "AddZoneIDLabel",
 			initial: map[string]string{},
 			addFunc: func(m map[string]string) {
-				metadata.AddZoneLabel(m, "zone-a")
+				metadata.AddZoneIDLabel(m, "use1-az1")
 			},
 			expected: map[string]string{
-				"multigres.com/zone": "zone-a",
+				"multigres.com/zone-id": "use1-az1",
 			},
 		},
 		{

--- a/pkg/webhook/cel_validation_test.go
+++ b/pkg/webhook/cel_validation_test.go
@@ -73,6 +73,7 @@ func TestCEL_MultigresCluster(t *testing.T) {
 					Cells: []multigresv1alpha1.CellConfig{
 						{
 							Name: "invalid-cell",
+							Zone: "us-east-1a",
 							Spec: &multigresv1alpha1.CellInlineSpec{
 								MultiGateway: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
 							},
@@ -96,6 +97,7 @@ func TestCEL_MultigresCluster(t *testing.T) {
 					Cells: []multigresv1alpha1.CellConfig{
 						{
 							Name:         "invalid-cell-template",
+							Zone:         "us-east-1a",
 							CellTemplate: "some-template",
 							Spec: &multigresv1alpha1.CellInlineSpec{
 								MultiGateway: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
@@ -105,6 +107,40 @@ func TestCEL_MultigresCluster(t *testing.T) {
 				},
 			},
 			expectError: "cannot specify both 'spec' and 'cellTemplate'",
+		},
+		{
+			name: "Invalid Cell: Neither Zone, ZoneID, nor Region",
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cel-cell-no-zone",
+					Namespace: testNamespace,
+				},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "no-zone-cell"},
+					},
+				},
+			},
+			expectError: "at least one of 'zone', 'zoneId', or 'region' must be specified",
+		},
+		{
+			name: "Invalid Cell: Both Zone and ZoneID",
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cel-cell-zone-zoneid-conflict",
+					Namespace: testNamespace,
+				},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{
+							Name:   "invalid-location",
+							Zone:   "us-east-1a",
+							ZoneID: "use1-az1",
+						},
+					},
+				},
+			},
+			expectError: "cannot specify both 'zone' and 'zoneId'",
 		},
 		{
 			name: "Invalid Cell: Both Zone and Region",
@@ -123,7 +159,26 @@ func TestCEL_MultigresCluster(t *testing.T) {
 					},
 				},
 			},
-			expectError: "cannot specify both 'zone' and 'region'",
+			expectError: "cannot specify 'region' with either 'zone' or 'zoneId'",
+		},
+		{
+			name: "Invalid Cell: Both ZoneID and Region",
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cel-cell-zoneid-region-conflict",
+					Namespace: testNamespace,
+				},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{
+							Name:   "invalid-location",
+							ZoneID: "use1-az1",
+							Region: "us-east-1",
+						},
+					},
+				},
+			},
+			expectError: "cannot specify 'region' with either 'zone' or 'zoneId'",
 		},
 		{
 			name: "Invalid Shard: Both Spec and Overrides",

--- a/pkg/webhook/cel_validation_test.go
+++ b/pkg/webhook/cel_validation_test.go
@@ -72,7 +72,8 @@ func TestCEL_MultigresCluster(t *testing.T) {
 				Spec: multigresv1alpha1.MultigresClusterSpec{
 					Cells: []multigresv1alpha1.CellConfig{
 						{
-							Name: "invalid-cell",
+							Name:   "invalid-cell",
+							ZoneID: "use1-az1",
 							Spec: &multigresv1alpha1.CellInlineSpec{
 								MultiGateway: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
 							},
@@ -96,6 +97,7 @@ func TestCEL_MultigresCluster(t *testing.T) {
 					Cells: []multigresv1alpha1.CellConfig{
 						{
 							Name:         "invalid-cell-template",
+							ZoneID:       "use1-az1",
 							CellTemplate: "some-template",
 							Spec: &multigresv1alpha1.CellInlineSpec{
 								MultiGateway: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
@@ -107,23 +109,38 @@ func TestCEL_MultigresCluster(t *testing.T) {
 			expectError: "cannot specify both 'spec' and 'cellTemplate'",
 		},
 		{
-			name: "Invalid Cell: Both Zone and Region",
+			name: "Invalid Cell: Neither ZoneID nor Region",
 			cluster: &multigresv1alpha1.MultigresCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cel-cell-location-conflict",
+					Name:      "cel-cell-no-zone",
+					Namespace: testNamespace,
+				},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "no-zone-cell"},
+					},
+				},
+			},
+			expectError: "at least one of 'zoneId' or 'region' must be specified",
+		},
+		{
+			name: "Invalid Cell: Both ZoneID and Region",
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cel-zoneid-region-conflict",
 					Namespace: testNamespace,
 				},
 				Spec: multigresv1alpha1.MultigresClusterSpec{
 					Cells: []multigresv1alpha1.CellConfig{
 						{
 							Name:   "invalid-location",
-							Zone:   "us-east-1a",
+							ZoneID: "use1-az1",
 							Region: "us-east-1",
 						},
 					},
 				},
 			},
-			expectError: "cannot specify both 'zone' and 'region'",
+			expectError: "cannot specify both 'zoneId' and 'region'",
 		},
 		{
 			name: "Invalid Shard: Both Spec and Overrides",

--- a/pkg/webhook/integration_test.go
+++ b/pkg/webhook/integration_test.go
@@ -233,7 +233,7 @@ func TestWebhook_Mutation(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 			},
 		}
 
@@ -276,7 +276,7 @@ func TestWebhook_Validation(t *testing.T) {
 				TemplateDefaults: multigresv1alpha1.TemplateDefaults{
 					CoreTemplate: "non-existent-template",
 				},
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 			},
 		}
 
@@ -306,7 +306,7 @@ func TestWebhook_TemplateProtection(t *testing.T) {
 				TemplateDefaults: multigresv1alpha1.TemplateDefaults{
 					CoreTemplate: "production-core",
 				},
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 			},
 		}
 		if err := k8sClient.Create(ctx, cluster); err != nil {
@@ -353,8 +353,8 @@ func TestWebhook_CellAppendOnly(t *testing.T) {
 			},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
 				Cells: []multigresv1alpha1.CellConfig{
-					{Name: "cell-a", Zone: "us-east-1a"},
-					{Name: "cell-b", Zone: "us-east-1b"},
+					{Name: "cell-a", ZoneID: "use1-az1"},
+					{Name: "cell-b", ZoneID: "use1-az2"},
 				},
 			},
 		}
@@ -369,7 +369,7 @@ func TestWebhook_CellAppendOnly(t *testing.T) {
 		}
 
 		fetched.Spec.Cells = []multigresv1alpha1.CellConfig{
-			{Name: "cell-a", Zone: "us-east-1a"},
+			{Name: "cell-a", ZoneID: "use1-az1"},
 		}
 		err := k8sClient.Update(ctx, fetched)
 		if err == nil {
@@ -388,7 +388,7 @@ func TestWebhook_CellAppendOnly(t *testing.T) {
 			},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
 				Cells: []multigresv1alpha1.CellConfig{
-					{Name: "original-cell", Zone: "us-east-1a"},
+					{Name: "original-cell", ZoneID: "use1-az1"},
 				},
 			},
 		}
@@ -404,7 +404,7 @@ func TestWebhook_CellAppendOnly(t *testing.T) {
 
 		// Replace the cell with a different name — effectively a rename
 		fetched.Spec.Cells = []multigresv1alpha1.CellConfig{
-			{Name: "renamed-cell", Zone: "us-east-1a"},
+			{Name: "renamed-cell", ZoneID: "use1-az1"},
 		}
 		err := k8sClient.Update(ctx, fetched)
 		if err == nil {
@@ -423,7 +423,7 @@ func TestWebhook_CellAppendOnly(t *testing.T) {
 			},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
 				Cells: []multigresv1alpha1.CellConfig{
-					{Name: "cell-x", Zone: "us-east-1a"},
+					{Name: "cell-x", ZoneID: "use1-az1"},
 				},
 			},
 		}
@@ -438,7 +438,7 @@ func TestWebhook_CellAppendOnly(t *testing.T) {
 		}
 
 		fetched.Spec.Cells = append(fetched.Spec.Cells, multigresv1alpha1.CellConfig{
-			Name: "cell-y", Zone: "us-east-1b",
+			Name: "cell-y", ZoneID: "use1-az2",
 		})
 		if err := k8sClient.Update(ctx, fetched); err != nil {
 			t.Fatalf("Expected appending a cell to succeed, got: %v", err)
@@ -472,7 +472,7 @@ func TestWebhook_OverridePrecedence(t *testing.T) {
 				MultiAdmin: &multigresv1alpha1.MultiAdminConfig{
 					Spec: &multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(3))},
 				},
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 			},
 		}
 		if err := k8sClient.Create(ctx, cluster); err != nil {
@@ -508,7 +508,7 @@ func TestWebhook_SpecificRefPrecedence(t *testing.T) {
 				MultiAdmin: &multigresv1alpha1.MultiAdminConfig{
 					TemplateRef: "specific-large",
 				},
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 			},
 		}
 		if err := k8sClient.Create(ctx, cluster); err != nil {
@@ -534,7 +534,7 @@ func TestWebhook_SystemCatalogIdempotency(t *testing.T) {
 		cluster := &multigresv1alpha1.MultigresCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "idempotency-test", Namespace: testNamespace},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 				Databases: []multigresv1alpha1.DatabaseConfig{
 					{
 						Name:    "postgres",
@@ -584,7 +584,7 @@ func TestWebhook_DeepTemplateProtection(t *testing.T) {
 				Labels:    map[string]string{metadata.LabelUsesShardTemplate: "true"},
 			},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 				Databases: []multigresv1alpha1.DatabaseConfig{
 					{
 						Name:    "postgres",
@@ -635,7 +635,7 @@ func TestWebhook_StorageClassValidation(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Spec: multigresv1alpha1.MultigresClusterSpec{
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 			},
 		}
 
@@ -682,7 +682,7 @@ func TestWebhook_StorageClassValidation(t *testing.T) {
 						Storage: multigresv1alpha1.StorageSpec{Class: "manual", Size: "5Gi"},
 					},
 				},
-				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", Zone: "us-east-1a"}},
+				Cells: []multigresv1alpha1.CellConfig{{Name: "default-cell", ZoneID: "use1-az1"}},
 				Databases: []multigresv1alpha1.DatabaseConfig{{
 					Name:    "postgres",
 					Default: true,


### PR DESCRIPTION
## Description

Cells are now identified by AZ ID (e.g. use1-az1) instead of zone name  (e.g. us-east-1a). AZ IDs are consistent across AWS accounts, which makes them a better fit for cross-account topology constraints. Region remains supported as an alternative for coarser-grained placement.

## Changes

API changes:
- Remove Zone type and zone field from CellConfig (MultigresCluster CRD)
  and CellSpec (Cell CRD)
- Add ZoneID type to common_types.go
- Add zoneId field to CellConfig and CellSpec
- CEL validation: zoneId and region are mutually exclusive; at least one
  of zoneId or region must be specified
- Regenerate CRD manifests for multigres.com_cells and
  multigres.com_multigresclusters

Controller changes:
- BuildCell propagates zoneId from CellConfig to CellSpec
- buildCellTopologyLabels uses topology.k8s.aws/zone-id for zone ID cells
- buildCellNodeSelector uses topology.k8s.aws/zone-id for zone ID cells,
  matching the node label set by the AWS node labeler
- validateCellTopology checks topology.k8s.aws/zone-id node labels
- Centralize topology.k8s.aws/zone-id as metadata.NodeLabelZoneID constant