### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @multigres/owners-operator


### PR DESCRIPTION
For now, use a catch-all rule to match all the reviews with the owners-operator group.