### PR TITLE
fix: correct AT_LEAST_2 pool replica semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Multigres uses a configurable **durability policy** to control synchronous repli
 | **2** | 1 primary + 1 standby | **Downtime during upgrades.** Draining the standby leaves zero synchronous standbys, violating `AT_LEAST_2`. Upstream multigres rejects the `UpdateSynchronousStandbyList REMOVE` because it would empty the synchronous standby list. |
 | **3** (recommended) | 1 primary + 2 standbys | **Zero-downtime upgrades.** One standby can be drained while the other maintains quorum. |
 
-The operator enforces a **hard minimum of 1** replica per cell (the CRD rejects `replicasPerCell: 0`). For pools with fewer than 3 replicas, the webhook returns an **admission warning** (not a rejection) explaining the quorum limitation.
+Pools default to `replicasPerCell: 1`. `AT_LEAST_2` requires 2 total poolers; `MULTI_CELL_AT_LEAST_2` requires poolers in 2 cells. For high availability, use at least 3 total poolers so the policy remains achievable while one pooler is unavailable.
 
 📖 **Full documentation:** [Durability Policy](docs/durability-policy.md)
 

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -400,6 +400,14 @@ func MergePVCDeletionPolicy(child, parent *PVCDeletionPolicy) *PVCDeletionPolicy
 	return merged
 }
 
+// MergeDurabilityPolicy returns the child durability policy when set, otherwise parent.
+func MergeDurabilityPolicy(child, parent string) string {
+	if child != "" {
+		return child
+	}
+	return parent
+}
+
 // MergeBackupConfig merges child and parent backup config with child taking precedence.
 // Implements deep merge logic where appropriate.
 func MergeBackupConfig(child, parent *BackupConfig) *BackupConfig {

--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -74,10 +74,8 @@ type PoolSpec struct {
 	// +kubebuilder:validation:XValidation:rule="oldSelf.all(c, c in self)",message="Cells cannot be removed from a pool (Append-Only)"
 	Cells []CellName `json:"cells,omitempty"`
 
-	// ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
-	// Sidecars (like Multipooler) will scale alongside the Postgres pods.
-	// Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
-	// (AT_LEAST_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
+	// ReplicasPerCell is the desired number of pool pods per selected cell.
+	// The default and minimum is 1.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=32
 	// +optional

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -5305,10 +5305,8 @@ spec:
                                             type: object
                                           replicasPerCell:
                                             description: |-
-                                              ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
-                                              Sidecars (like Multipooler) will scale alongside the Postgres pods.
-                                              Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
-                                              (AT_LEAST_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
+                                              ReplicasPerCell is the desired number of pool pods per selected cell.
+                                              The default and minimum is 1.
                                             format: int32
                                             maximum: 32
                                             minimum: 1
@@ -7751,10 +7749,8 @@ spec:
                                             type: object
                                           replicasPerCell:
                                             description: |-
-                                              ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
-                                              Sidecars (like Multipooler) will scale alongside the Postgres pods.
-                                              Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
-                                              (AT_LEAST_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
+                                              ReplicasPerCell is the desired number of pool pods per selected cell.
+                                              The default and minimum is 1.
                                             format: int32
                                             maximum: 32
                                             minimum: 1

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -2588,10 +2588,8 @@ spec:
                       type: object
                     replicasPerCell:
                       description: |-
-                        ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
-                        Sidecars (like Multipooler) will scale alongside the Postgres pods.
-                        Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
-                        (AT_LEAST_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
+                        ReplicasPerCell is the desired number of pool pods per selected cell.
+                        The default and minimum is 1.
                       format: int32
                       maximum: 32
                       minimum: 1

--- a/config/crd/bases/multigres.com_shardtemplates.yaml
+++ b/config/crd/bases/multigres.com_shardtemplates.yaml
@@ -2222,10 +2222,8 @@ spec:
                       type: object
                     replicasPerCell:
                       description: |-
-                        ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
-                        Sidecars (like Multipooler) will scale alongside the Postgres pods.
-                        Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
-                        (AT_LEAST_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
+                        ReplicasPerCell is the desired number of pool pods per selected cell.
+                        The default and minimum is 1.
                       format: int32
                       maximum: 32
                       minimum: 1

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -2760,10 +2760,8 @@ spec:
                             type: object
                           replicasPerCell:
                             description: |-
-                              ReplicasPerCell is the desired number of Postgres data pods PER CELL in this pool.
-                              Sidecars (like Multipooler) will scale alongside the Postgres pods.
-                              Minimum 1 is required; readWrite pools need at least 3 for zero-downtime rolling upgrades
-                              (AT_LEAST_2 durability requires 1 primary + 2 standbys to maintain quorum during drain).
+                              ReplicasPerCell is the desired number of pool pods per selected cell.
+                              The default and minimum is 1.
                             format: int32
                             maximum: 32
                             minimum: 1

--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -122,8 +122,7 @@ This allows you to set "sane defaults" at the Namespace level (Level 3), overrid
 
 ## 5. Pool Replica Requirements
 
-- **Minimum**: `replicasPerCell` must be at least **1** (CRD-enforced). Setting it to 0 is rejected.
-- **Recommended**: at least **3** replicas per cell. The `AT_LEAST_2` durability policy requires 1 primary + 2 synchronous standbys so that one standby can be drained during rolling upgrades while the other maintains write quorum. The operator issues an admission warning if a pool has fewer than 3 replicas.
+Pools default to `replicasPerCell: 1`. `AT_LEAST_2` requires 2 total poolers; `MULTI_CELL_AT_LEAST_2` requires poolers in 2 cells. For high availability, use at least 3 total poolers so the policy remains achievable while one pooler is unavailable.
 
 ---
 

--- a/docs/development/pod-management-design.md
+++ b/docs/development/pod-management-design.md
@@ -174,7 +174,7 @@ These constraints are already enforced or need to be enforced via CEL validation
 | Constraint | Status | Risk |
 |---|---|---|
 | **Cell rename prevention** | ✅ **Implemented** | CEL append-only rule added to `MultigresCluster` and `Shard` CRDs. Cells cannot be removed or renamed after creation. |
-| **Pool replica count floor** | ✅ **Validated** | CRD enforces minimum=1. Webhook warns for pools with <3 replicas (`AT_LEAST_2` quorum requires 1 primary + 2 standbys for rolling upgrades). |
+| **Pool replica count floor** | ✅ **Validated** | CRD enforces minimum=1. Webhook warns when a resolved pool cannot satisfy its durability policy (`AT_LEAST_2` needs 2 total poolers; `MULTI_CELL_AT_LEAST_2` needs 2 cells). |
 
 ### Explicitly NOT Supported (v1alpha1)
 

--- a/docs/durability-policy.md
+++ b/docs/durability-policy.md
@@ -81,4 +81,4 @@ When using `MULTI_CELL_AT_LEAST_2`, ensure your shard's pools span at least 2 ce
 
 ## Replica Count Considerations
 
-The `AT_LEAST_2` policy requires at least 3 replicas per pool (1 primary + 2 standbys) for zero-downtime rolling upgrades, since quorum must be maintained while one node is being drained. The CRD enforces a minimum of 1 replica, but pools with fewer than 3 replicas will lose quorum during drain operations.
+Pools default to `replicasPerCell: 1`. `AT_LEAST_2` requires 2 total poolers; `MULTI_CELL_AT_LEAST_2` requires poolers in 2 cells. For high availability, use at least 3 total poolers so the policy remains achievable while one pooler is unavailable.

--- a/docs/gitops-and-webhook-defaults.md
+++ b/docs/gitops-and-webhook-defaults.md
@@ -27,7 +27,7 @@ On every `CREATE` and `UPDATE` of a `MultigresCluster`, the webhook materialises
 | `spec.multiAdminWeb` | 1 replica, default resources |
 | Per-cell `spec.multiGateway` | 1 replica, default resources |
 | Per-shard `spec.multiOrch` | 1 replica, default resources |
-| Per-shard `spec.pools` | `default` pool, 3 replicas/cell, 1Gi storage, default container resources |
+| Per-shard `spec.pools` | `default` pool with 1 replica per selected cell, 1Gi storage, default container resources |
 | Per-shard `spec.backup` | Filesystem, default path and storage |
 | `spec.templateDefaults` | Promoted to `"default"` if a matching template exists in the namespace |
 

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
@@ -71,7 +71,7 @@ func BuildTableGroup(
 			LogLevels:          cluster.Spec.LogLevels,
 			CellTopologyLabels: buildCellTopologyLabels(cluster),
 			TopologyPruning:    cluster.Spec.TopologyPruning,
-			DurabilityPolicy: mergeDurabilityPolicy(
+			DurabilityPolicy: multigresv1alpha1.MergeDurabilityPolicy(
 				dbCfg.DurabilityPolicy,
 				cluster.Spec.DurabilityPolicy,
 			),
@@ -84,14 +84,6 @@ func BuildTableGroup(
 	}
 
 	return tgCR, nil
-}
-
-// mergeDurabilityPolicy returns the child value if set, otherwise falls back to the parent.
-func mergeDurabilityPolicy(child, parent string) string {
-	if child != "" {
-		return child
-	}
-	return parent
 }
 
 // buildCellTopologyLabels builds a map of cell name → nodeSelector labels from the cluster's cells.

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
@@ -248,12 +248,3 @@ func TestBuildTableGroup(t *testing.T) {
 		}
 	})
 }
-
-func TestMergeDurabilityPolicy(t *testing.T) {
-	if got := mergeDurabilityPolicy("child", "parent"); got != "child" {
-		t.Errorf("mergeDurabilityPolicy(child, parent) = %v, want child", got)
-	}
-	if got := mergeDurabilityPolicy("", "parent"); got != "parent" {
-		t.Errorf("mergeDurabilityPolicy('', parent) = %v, want parent", got)
-	}
-}

--- a/pkg/cluster-handler/controller/multigrescluster/integration_resolution_enforcement_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_resolution_enforcement_test.go
@@ -80,7 +80,7 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 
 					// Case D: Inline Spec (Highest Priority) (Expect 9)
 					{
-						Name: "zone-d",
+						Name:   "zone-d",
 						ZoneID: "use1-az4",
 						Spec: &multigresv1alpha1.CellInlineSpec{
 							MultiGateway: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(9))},
@@ -198,7 +198,7 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 				Namespace: testNamespace,
 			},
 			Spec: multigresv1alpha1.CellSpec{
-				Name: "zone-a",
+				Name:   "zone-a",
 				ZoneID: "use1-az1",
 				Images: multigresv1alpha1.CellImages{
 					MultiGateway:    resolver.DefaultMultiGatewayImage,
@@ -344,7 +344,7 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 							"default": {
 								Type:            "readWrite",
 								Cells:           []multigresv1alpha1.CellName{"zone-c"},
-								ReplicasPerCell: ptr.To(int32(3)),
+								ReplicasPerCell: ptr.To(resolver.DefaultPoolReplicasPerCell),
 								Storage:         multigresv1alpha1.StorageSpec{Size: "1Gi"},
 								Postgres: multigresv1alpha1.ContainerConfig{
 									Resources: resolver.DefaultResourcesPostgres(),
@@ -419,7 +419,7 @@ func TestMultigresCluster_EnforcementLogic(t *testing.T) {
 			Namespace: testNamespace,
 		},
 		Spec: multigresv1alpha1.CellSpec{
-			Name: "zone-a",
+			Name:   "zone-a",
 			ZoneID: "use1-az1",
 			Images: multigresv1alpha1.CellImages{
 				MultiGateway:    resolver.DefaultMultiGatewayImage,
@@ -637,7 +637,7 @@ func TestMultigresCluster_TemplateOverrides(t *testing.T) {
 						"default": {
 							Type:            "readWrite",
 							Cells:           []multigresv1alpha1.CellName{"zone-a"},
-							ReplicasPerCell: ptr.To(int32(3)),
+							ReplicasPerCell: ptr.To(resolver.DefaultPoolReplicasPerCell),
 							Storage:         multigresv1alpha1.StorageSpec{Size: "1Gi"},
 							Postgres: multigresv1alpha1.ContainerConfig{
 								Resources: resolver.DefaultResourcesPostgres(),

--- a/pkg/cluster-handler/controller/multigrescluster/integration_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_test.go
@@ -468,7 +468,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						OwnerReferences: clusterOwnerRefs(t, clusterName),
 					},
 					Spec: multigresv1alpha1.CellSpec{
-						Name: "zone-a",
+						Name:   "zone-a",
 						ZoneID: "use1-az1",
 						Images: multigresv1alpha1.CellImages{
 							MultiGateway:     "gateway:latest",
@@ -829,7 +829,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						OwnerReferences: clusterOwnerRefs(t, "minimal-cluster"),
 					},
 					Spec: multigresv1alpha1.CellSpec{
-						Name: "zone-a",
+						Name:   "zone-a",
 						ZoneID: "use1-az1",
 						Images: multigresv1alpha1.CellImages{
 							MultiGateway:    resolver.DefaultMultiGatewayImage,
@@ -906,7 +906,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 									"default": {
 										Type:            "readWrite",
 										Cells:           []multigresv1alpha1.CellName{"zone-a"},
-										ReplicasPerCell: ptr.To(int32(3)),
+										ReplicasPerCell: ptr.To(resolver.DefaultPoolReplicasPerCell),
 										Storage:         multigresv1alpha1.StorageSpec{Size: resolver.DefaultEtcdStorageSize}, // "1Gi"
 										Postgres: multigresv1alpha1.ContainerConfig{
 											Resources: resolver.DefaultResourcesPostgres(),
@@ -1187,7 +1187,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 						OwnerReferences: clusterOwnerRefs(t, "lazy-cluster"),
 					},
 					Spec: multigresv1alpha1.CellSpec{
-						Name: "zone-a",
+						Name:   "zone-a",
 						ZoneID: "use1-az1",
 						Images: multigresv1alpha1.CellImages{
 							MultiGateway:    resolver.DefaultMultiGatewayImage,
@@ -1264,7 +1264,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 									"default": {
 										Type:            "readWrite",
 										Cells:           []multigresv1alpha1.CellName{"zone-a"},
-										ReplicasPerCell: ptr.To(int32(3)),
+										ReplicasPerCell: ptr.To(resolver.DefaultPoolReplicasPerCell),
 										Storage:         multigresv1alpha1.StorageSpec{Size: resolver.DefaultEtcdStorageSize}, // "1Gi"
 										Postgres: multigresv1alpha1.ContainerConfig{
 											Resources: resolver.DefaultResourcesPostgres(),

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_databases.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_databases.go
@@ -67,8 +67,11 @@ func (r *MultigresClusterReconciler) reconcileDatabases(
 				orch, pools, pvcPolicy, finalShardBackup, initdbArgs, postgresConfigRef, err := res.ResolveShard(
 					ctx,
 					shardCfg,
-					allCellNames,
-					tgBackup,
+					resolver.ResolveShardOptions{
+						AllCellNames:            allCellNames,
+						InheritedBackup:         tgBackup,
+						MaterializeCellDefaults: true,
+					},
 				)
 				if err != nil {
 					r.Recorder.Eventf(

--- a/pkg/resolver/defaults.go
+++ b/pkg/resolver/defaults.go
@@ -26,6 +26,9 @@ const (
 	// DefaultPoolName is the name used for the default pool when no pools are specified in a ShardTemplate.
 	DefaultPoolName = "default"
 
+	// DefaultPoolReplicasPerCell is the default number of Postgres pods to run in each selected cell.
+	DefaultPoolReplicasPerCell int32 = 1
+
 	// DefaultTopoRootPath is the default etcd key prefix for the global topology server.
 	DefaultTopoRootPath = "/multigres/global"
 

--- a/pkg/resolver/shard.go
+++ b/pkg/resolver/shard.go
@@ -13,12 +13,17 @@ import (
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 )
 
+type ResolveShardOptions struct {
+	AllCellNames            []multigresv1alpha1.CellName
+	InheritedBackup         *multigresv1alpha1.BackupConfig
+	MaterializeCellDefaults bool
+}
+
 // ResolveShard determines the final configuration for a specific Shard.
 func (r *Resolver) ResolveShard(
 	ctx context.Context,
 	shardSpec *multigresv1alpha1.ShardConfig,
-	allCellNames []multigresv1alpha1.CellName,
-	inheritedBackup *multigresv1alpha1.BackupConfig,
+	opts ResolveShardOptions,
 ) (*multigresv1alpha1.MultiOrchSpec, map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec, *multigresv1alpha1.PVCDeletionPolicy, *multigresv1alpha1.BackupConfig, multigresv1alpha1.InitdbArgs, *multigresv1alpha1.PostgresConfigRef, error) {
 	// 1. Fetch Template
 	templateName := shardSpec.ShardTemplate
@@ -33,7 +38,7 @@ func (r *Resolver) ResolveShard(
 		shardSpec.Overrides,
 		shardSpec.Spec,
 		shardSpec.Backup,
-		inheritedBackup,
+		opts.InheritedBackup,
 	)
 
 	// 3. Apply Deep Defaults (Level 4)
@@ -49,8 +54,8 @@ func (r *Resolver) ResolveShard(
 	// Contextual Defaulting: Lazy Cell Injection
 	// If the resolved configuration has no cells defined, it means "run everywhere".
 	// We inject the full list of cluster cells here.
-	if len(multiOrch.Cells) == 0 && len(allCellNames) > 0 {
-		for _, c := range allCellNames {
+	if opts.MaterializeCellDefaults && len(multiOrch.Cells) == 0 && len(opts.AllCellNames) > 0 {
+		for _, c := range opts.AllCellNames {
 			multiOrch.Cells = append(multiOrch.Cells, multigresv1alpha1.CellName(c))
 		}
 		// Sort for deterministic output
@@ -66,17 +71,17 @@ func (r *Resolver) ResolveShard(
 
 	for name := range pools {
 		p := pools[name]
-		defaultPoolSpec(&p)
 
 		// Contextual Defaulting for Pools
-		if len(p.Cells) == 0 && len(allCellNames) > 0 {
-			for _, c := range allCellNames {
+		if opts.MaterializeCellDefaults && len(p.Cells) == 0 && len(opts.AllCellNames) > 0 {
+			for _, c := range opts.AllCellNames {
 				p.Cells = append(p.Cells, multigresv1alpha1.CellName(c))
 			}
 			// Sort for deterministic output
 			slices.Sort(p.Cells)
 		}
 
+		defaultPoolSpec(&p)
 		pools[name] = p
 	}
 
@@ -268,12 +273,7 @@ func mergePoolSpec(
 
 func defaultPoolSpec(spec *multigresv1alpha1.PoolSpec) {
 	if spec.ReplicasPerCell == nil {
-		// Default to 3 replicas to satisfy multiorch's AT_LEAST_2 durability policy
-		// requirement.
-		// TODO: multiorch currently only supports AT_LEAST_2 or MULTI_CELL_AT_LEAST_2,
-		// both of which require at least 2 replicas for quorum. Single-node
-		// policies are not yet supported.
-		spec.ReplicasPerCell = ptr.To(int32(3))
+		spec.ReplicasPerCell = ptr.To(DefaultPoolReplicasPerCell)
 	}
 	if spec.Storage.Size == "" {
 		spec.Storage.Size = DefaultEtcdStorageSize

--- a/pkg/resolver/shard_test.go
+++ b/pkg/resolver/shard_test.go
@@ -45,7 +45,7 @@ func TestResolver_ResolveShard(t *testing.T) {
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"default": {
 					Type:            "readWrite",
-					ReplicasPerCell: ptr.To(int32(3)),
+					ReplicasPerCell: ptr.To(DefaultPoolReplicasPerCell),
 					Storage: multigresv1alpha1.StorageSpec{
 						Size: DefaultEtcdStorageSize,
 					},
@@ -77,10 +77,9 @@ func TestResolver_ResolveShard(t *testing.T) {
 					Resources: DefaultResourcesOrch(),
 				},
 			},
-			// FIX: Updated to expect fully hydrated defaults for pool "p"
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"p": {
-					ReplicasPerCell: ptr.To(int32(3)),
+					ReplicasPerCell: ptr.To(DefaultPoolReplicasPerCell),
 					Storage: multigresv1alpha1.StorageSpec{
 						Size: DefaultEtcdStorageSize, // "1Gi"
 					},
@@ -112,7 +111,7 @@ func TestResolver_ResolveShard(t *testing.T) {
 			},
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"p": {
-					ReplicasPerCell: ptr.To(int32(3)),
+					ReplicasPerCell: ptr.To(DefaultPoolReplicasPerCell),
 					FSGroup:         ptr.To(int64(1234)),
 					Storage: multigresv1alpha1.StorageSpec{
 						Size: DefaultEtcdStorageSize,
@@ -150,9 +149,81 @@ func TestResolver_ResolveShard(t *testing.T) {
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"p1": {
 					Type:            "read",
-					ReplicasPerCell: ptr.To(int32(3)),
+					ReplicasPerCell: ptr.To(DefaultPoolReplicasPerCell),
 					// Expect injected cells
 					Cells: []multigresv1alpha1.CellName{"zone-a", "zone-b"},
+					Storage: multigresv1alpha1.StorageSpec{
+						Size: DefaultEtcdStorageSize,
+					},
+					Postgres: multigresv1alpha1.ContainerConfig{
+						Resources: DefaultResourcesPostgres(),
+					},
+					Multipooler: multigresv1alpha1.ContainerConfig{
+						Resources: DefaultResourcesPooler(),
+					},
+				},
+			},
+		},
+		"Dynamic Cell Injection Three Cells Defaults To One Replica Per Cell": {
+			config: &multigresv1alpha1.ShardConfig{
+				Spec: &multigresv1alpha1.ShardInlineSpec{
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"p1": {Type: "readWrite"},
+					},
+				},
+			},
+			allCellNames: []multigresv1alpha1.CellName{"zone-a", "zone-b", "zone-c"},
+			wantOrch: &multigresv1alpha1.MultiOrchSpec{
+				StatelessSpec: multigresv1alpha1.StatelessSpec{
+					Replicas:  ptr.To(int32(1)),
+					Resources: DefaultResourcesOrch(),
+				},
+				Cells: []multigresv1alpha1.CellName{"zone-a", "zone-b", "zone-c"},
+			},
+			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"p1": {
+					Type:            "readWrite",
+					ReplicasPerCell: ptr.To(DefaultPoolReplicasPerCell),
+					Cells:           []multigresv1alpha1.CellName{"zone-a", "zone-b", "zone-c"},
+					Storage: multigresv1alpha1.StorageSpec{
+						Size: DefaultEtcdStorageSize,
+					},
+					Postgres: multigresv1alpha1.ContainerConfig{
+						Resources: DefaultResourcesPostgres(),
+					},
+					Multipooler: multigresv1alpha1.ContainerConfig{
+						Resources: DefaultResourcesPooler(),
+					},
+				},
+			},
+		},
+		"Explicit Two Pool Cells Defaults To One Replica Per Cell": {
+			config: &multigresv1alpha1.ShardConfig{
+				Spec: &multigresv1alpha1.ShardInlineSpec{
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"p1": {
+							Type:  "readWrite",
+							Cells: []multigresv1alpha1.CellName{"zone-a", "zone-b"},
+						},
+					},
+				},
+			},
+			allCellNames: []multigresv1alpha1.CellName{"zone-a", "zone-b", "zone-c"},
+			wantOrch: &multigresv1alpha1.MultiOrchSpec{
+				StatelessSpec: multigresv1alpha1.StatelessSpec{
+					Replicas:  ptr.To(int32(1)),
+					Resources: DefaultResourcesOrch(),
+				},
+				Cells: []multigresv1alpha1.CellName{"zone-a", "zone-b", "zone-c"},
+			},
+			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"p1": {
+					Type:            "readWrite",
+					ReplicasPerCell: ptr.To(DefaultPoolReplicasPerCell),
+					Cells:           []multigresv1alpha1.CellName{"zone-a", "zone-b"},
 					Storage: multigresv1alpha1.StorageSpec{
 						Size: DefaultEtcdStorageSize,
 					},
@@ -185,7 +256,7 @@ func TestResolver_ResolveShard(t *testing.T) {
 			},
 			wantPools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 				"p": {
-					ReplicasPerCell: ptr.To(int32(3)),
+					ReplicasPerCell: ptr.To(DefaultPoolReplicasPerCell),
 					Storage:         multigresv1alpha1.StorageSpec{Size: DefaultEtcdStorageSize},
 					Postgres: multigresv1alpha1.ContainerConfig{
 						Resources: DefaultResourcesPostgres(),
@@ -210,8 +281,10 @@ func TestResolver_ResolveShard(t *testing.T) {
 			orch, pools, pvcPolicy, _, _, _, err := r.ResolveShard(
 				t.Context(),
 				tc.config,
-				tc.allCellNames,
-				nil,
+				ResolveShardOptions{
+					AllCellNames:            tc.allCellNames,
+					MaterializeCellDefaults: true,
+				},
 			)
 			if tc.wantErr {
 				if err == nil {
@@ -920,7 +993,7 @@ func TestResolveShard_PVCDeletionPolicy(t *testing.T) {
 
 		_, _, policy, _, _, _, err := r.ResolveShard(t.Context(), &multigresv1alpha1.ShardConfig{
 			ShardTemplate: "tpl-pvc",
-		}, nil, nil)
+		}, ResolveShardOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -947,7 +1020,7 @@ func TestResolveShard_PVCDeletionPolicy(t *testing.T) {
 					},
 				},
 			},
-		}, nil, nil)
+		}, ResolveShardOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1075,7 +1148,7 @@ func TestResolveShard_InheritedBackup(t *testing.T) {
 					"default": {Type: "readWrite"},
 				},
 			},
-		}, nil, inherited)
+		}, ResolveShardOptions{InheritedBackup: inherited})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1114,7 +1187,7 @@ func TestResolveShard_InheritedBackup(t *testing.T) {
 					Path: "/shard-override",
 				},
 			},
-		}, nil, inherited)
+		}, ResolveShardOptions{InheritedBackup: inherited})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1134,7 +1207,7 @@ func TestResolveShard_InheritedBackup(t *testing.T) {
 					"default": {Type: "readWrite"},
 				},
 			},
-		}, nil, nil)
+		}, ResolveShardOptions{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/resolver/validation.go
+++ b/pkg/resolver/validation.go
@@ -389,8 +389,11 @@ func (r *Resolver) ValidateClusterLogic(
 				orch, pools, _, backupCfg, _, _, err := r.ResolveShard(
 					ctx,
 					&shard,
-					cellNames,
-					tgBackup,
+					ResolveShardOptions{
+						AllCellNames:            cellNames,
+						InheritedBackup:         tgBackup,
+						MaterializeCellDefaults: true,
+					},
 				)
 				if err != nil {
 					return nil, fmt.Errorf(
@@ -454,25 +457,52 @@ func (r *Resolver) ValidateClusterLogic(
 				}
 
 				// ------------------------------------------------------------------
-				// 3. Quorum Warning for pools with insufficient total replicas
+				// 3. Durability achievability warnings
 				// ------------------------------------------------------------------
 				for poolName, pool := range pools {
-					replicas := int32(3) // default
+					durabilityPolicy := effectiveDatabaseDurabilityPolicy(db, cluster)
+					if durabilityPolicy == "" {
+						durabilityPolicy = DefaultDurabilityPolicy
+					}
+					replicas := DefaultPoolReplicasPerCell
 					if pool.ReplicasPerCell != nil {
 						replicas = *pool.ReplicasPerCell
 					}
 					cellCount := len(pool.Cells)
+					if cellCount == 0 {
+						cellCount = len(cellNames)
+					}
 					totalReplicas := int(replicas) * cellCount
-					if totalReplicas < 3 {
+
+					switch durabilityPolicy {
+					case "MULTI_CELL_AT_LEAST_2":
+						if cellCount >= 2 {
+							continue
+						}
+						warnings = append(warnings, fmt.Sprintf(
+							"pool '%s' in shard '%s' spans %d cell(s); "+
+								"durability policy %q requires at least %d distinct cells.",
+							poolName,
+							shard.Name,
+							cellCount,
+							durabilityPolicy,
+							2,
+						))
+
+					default:
+						if totalReplicas >= 2 {
+							continue
+						}
 						warnings = append(warnings, fmt.Sprintf(
 							"pool '%s' in shard '%s' has replicasPerCell=%d across %d cell(s) (%d total); "+
-								"The HA baseline for AT_LEAST_2 is at least 3 total pods (1 primary + 2 standbys). "+
-								"For zero-downtime rolling upgrades within a single cell, use at least 3 replicas in that cell.",
+								"durability policy %q requires at least %d total poolers.",
 							poolName,
 							shard.Name,
 							replicas,
 							cellCount,
 							totalReplicas,
+							durabilityPolicy,
+							2,
 						))
 					}
 				}
@@ -565,8 +595,11 @@ func (r *Resolver) ValidateClusterLogic(
 				_, pools, _, backupCfg, _, _, err := r.ResolveShard(
 					ctx,
 					&shard,
-					cellNames,
-					tgBackup,
+					ResolveShardOptions{
+						AllCellNames:            cellNames,
+						InheritedBackup:         tgBackup,
+						MaterializeCellDefaults: true,
+					},
 				)
 				if err != nil {
 					continue // already validated in section 2
@@ -640,6 +673,16 @@ func getEffectiveEtcdReplicas(cluster *multigresv1alpha1.MultigresCluster) int32
 		return *cluster.Spec.GlobalTopoServer.Etcd.Replicas
 	}
 	return DefaultEtcdReplicas
+}
+
+func effectiveDatabaseDurabilityPolicy(
+	db multigresv1alpha1.DatabaseConfig,
+	cluster *multigresv1alpha1.MultigresCluster,
+) string {
+	return multigresv1alpha1.MergeDurabilityPolicy(
+		db.DurabilityPolicy,
+		cluster.Spec.DurabilityPolicy,
+	)
 }
 
 // dnsLabelRegex matches valid DNS labels per RFC 1123. This mirrors the

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -596,11 +596,53 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			},
 			customClient: withZoneIDClient,
 		},
-		// COVERAGE: quorum warning for readWrite pools with low replica count
-		"Quorum Warning: readWrite pool with 2 replicas": {
+		// COVERAGE: durability warning for readWrite pools below AT_LEAST_2 achievability
+		"Durability Warning: AT_LEAST_2 pool with 1 total pooler": {
 			cluster: &multigresv1alpha1.MultigresCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
 				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Storage: multigresv1alpha1.StorageSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteMany,
+								},
+							},
+						},
+					},
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			wantWarnings: []string{
+				"replicasPerCell=1 across 1 cell(s) (1 total)",
+				"durability policy \"AT_LEAST_2\" requires at least 2 total poolers",
+			},
+		},
+		"No Durability Warning: AT_LEAST_2 pool with 2 replicas in one cell": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Backup: &multigresv1alpha1.BackupConfig{
+						Type: multigresv1alpha1.BackupTypeFilesystem,
+						Filesystem: &multigresv1alpha1.FilesystemBackupConfig{
+							Storage: multigresv1alpha1.StorageSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteMany,
+								},
+							},
+						},
+					},
 					Cells: []multigresv1alpha1.CellConfig{
 						{Name: "zone-1"},
 					},
@@ -621,9 +663,27 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 					}},
 				},
 			},
-			wantWarnings: []string{
-				"replicasPerCell=2 across 1 cell(s) (2 total)",
+			wantNoWarnings: true,
+		},
+		"No Durability Warning: AT_LEAST_2 pool with 2 cells and 1 replica per cell": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+						{Name: "zone-2"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
 			},
+			wantNoWarnings: true,
 		},
 		"No Quorum Warning: three cells with 1 replica per cell": {
 			cluster: &multigresv1alpha1.MultigresCluster{
@@ -646,6 +706,27 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 										},
 									},
 								},
+							}},
+						}},
+					}},
+				},
+			},
+			wantNoWarnings: true,
+		},
+		"No Quorum Warning: three cells with omitted replicas default to 1 per cell": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+						{Name: "zone-2"},
+						{Name: "zone-3"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
 							}},
 						}},
 					}},
@@ -678,7 +759,7 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 				},
 			},
 		},
-		"Quorum Warning: pool with 2 replicas": {
+		"Durability Warning: inline AT_LEAST_2 pool with 1 total pooler": {
 			cluster: &multigresv1alpha1.MultigresCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
 				Spec: multigresv1alpha1.MultigresClusterSpec{
@@ -692,8 +773,7 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 								Spec: &multigresv1alpha1.ShardInlineSpec{
 									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 										"main-rw": {
-											Type:            "readWrite",
-											ReplicasPerCell: ptr.To(int32(2)),
+											Type: "readWrite",
 										},
 									},
 								},
@@ -702,7 +782,80 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 					}},
 				},
 			},
-			wantWarnings: []string{"has replicasPerCell=2 across 1 cell(s) (2 total)"},
+			wantWarnings: []string{"has replicasPerCell=1 across 1 cell(s) (1 total)"},
+		},
+		"Durability Warning: MULTI_CELL_AT_LEAST_2 pool in one cell": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					DurabilityPolicy: "MULTI_CELL_AT_LEAST_2",
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"default": {
+											ReplicasPerCell: ptr.To(int32(3)),
+										},
+									},
+								},
+							}},
+						}},
+					}},
+				},
+			},
+			wantWarnings: []string{
+				"spans 1 cell(s)",
+				"durability policy \"MULTI_CELL_AT_LEAST_2\" requires at least 2 distinct cells",
+			},
+		},
+		"No Durability Warning: MULTI_CELL_AT_LEAST_2 pool in two cells": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					DurabilityPolicy: "MULTI_CELL_AT_LEAST_2",
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+						{Name: "zone-2"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			wantNoWarnings: true,
+		},
+		"No Durability Warning: MULTI_CELL_AT_LEAST_2 pool in three cells": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					DurabilityPolicy: "MULTI_CELL_AT_LEAST_2",
+					Cells: []multigresv1alpha1.CellConfig{
+						{Name: "zone-1"},
+						{Name: "zone-2"},
+						{Name: "zone-3"},
+					},
+					Databases: []multigresv1alpha1.DatabaseConfig{{
+						TableGroups: []multigresv1alpha1.TableGroupConfig{{
+							Shards: []multigresv1alpha1.ShardConfig{{
+								Name:          "s0",
+								ShardTemplate: "prod-shard",
+							}},
+						}},
+					}},
+				},
+			},
+			wantNoWarnings: true,
 		},
 		"Etcd 1 replica warning": {
 			cluster: &multigresv1alpha1.MultigresCluster{

--- a/pkg/webhook/handlers/defaulter.go
+++ b/pkg/webhook/handlers/defaulter.go
@@ -193,6 +193,10 @@ func (d *MultigresClusterDefaulter) Default(ctx context.Context, obj runtime.Obj
 	// D. Resolve Shards
 	hasGlobalShard := cluster.Spec.TemplateDefaults.ShardTemplate != ""
 	hasImplicitShard, _ := scopedResolver.ShardTemplateExists(ctx, resolver.FallbackShardTemplate)
+	var allCellNames []multigresv1alpha1.CellName
+	for _, cell := range cluster.Spec.Cells {
+		allCellNames = append(allCellNames, cell.Name)
+	}
 
 	for i := range cluster.Spec.Databases {
 		dbBackup := multigresv1alpha1.MergeBackupConfig(
@@ -211,13 +215,15 @@ func (d *MultigresClusterDefaulter) Default(ctx context.Context, obj runtime.Obj
 				isUsingTemplate := hasInline || hasGlobalShard || hasImplicitShard
 
 				if !isUsingTemplate {
-					// We pass 'nil' for allCellNames to prevent "Sticky Context Defaults".
-					// We want the Stored Spec to remain empty (dynamic) rather than locking in the current list of cells.
+					// We pass cell names for contextual cell defaulting, but leave
+					// MaterializeCellDefaults false so the stored spec remains dynamic.
 					multiOrchSpec, poolsSpec, resolvedPvcPolicy, resolvedBackupConfig, resolvedInitdbArgs, resolvedPostgresConfigRef, err := scopedResolver.ResolveShard(
 						ctx,
 						shard,
-						nil,
-						tgBackup,
+						resolver.ResolveShardOptions{
+							AllCellNames:    allCellNames,
+							InheritedBackup: tgBackup,
+						},
 					)
 					if err != nil {
 						return fmt.Errorf("failed to resolve shard '%s': %w", shard.Name, err)

--- a/pkg/webhook/handlers/defaulter_test.go
+++ b/pkg/webhook/handlers/defaulter_test.go
@@ -139,8 +139,10 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 													"default": {
 														Type: "readWrite",
 														// Cells should be nil to avoid sticky defaults
-														Cells:           nil,
-														ReplicasPerCell: ptr.To(int32(3)),
+														Cells: nil,
+														ReplicasPerCell: ptr.To(
+															resolver.DefaultPoolReplicasPerCell,
+														),
 														Storage: multigresv1alpha1.StorageSpec{
 															Size: "1Gi",
 														},
@@ -442,8 +444,10 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 											},
 											Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 												"default": {
-													Type:            "readWrite",
-													ReplicasPerCell: ptr.To(int32(3)),
+													Type: "readWrite",
+													ReplicasPerCell: ptr.To(
+														resolver.DefaultPoolReplicasPerCell,
+													),
 													Storage: multigresv1alpha1.StorageSpec{
 														Size: resolver.DefaultEtcdStorageSize,
 													},


### PR DESCRIPTION
## Description

this pr fixes the operator’s previous interpretation of `AT_LEAST_2` pool sizing. Follow-up to #472 .

`replicasPerCell` is applied per selected cell, but the operator was treating `3` as the durability baseline. That was incorrect for Multigres: `AT_LEAST_2` requires 2 total poolers, while `MULTI_CELL_AT_LEAST_2` requires poolers in 2 distinct cells. Three total poolers is HA operating guidance so the policy can remain achievable while one pooler is unavailable, not the policy minimum.

## Changes

- Default pools to `replicasPerCell: 1`, matching the field’s per-cell meaning.
- Update durability validation to check the resolved pool shape against the actual policy semantics:
  - `AT_LEAST_2`: at least 2 total poolers.
  - `MULTI_CELL_AT_LEAST_2`: at least 2 selected cells with poolers.
- Keep stored webhook defaults dynamic by using cell context without materializing cell lists into the stored spec.
- Share durability policy inheritance logic between tablegroup resolution and validation.
- Update API comments, generated CRD descriptions, samples, and docs so 3 total poolers is documented as HA guidance rather than the policy minimum.

## Tests

Test coverage was updated around the resolved pool shapes that matter for these policies: single-cell pools below and at the `AT_LEAST_2` minimum, multi-cell pools with one replica per cell, omitted `replicasPerCell` defaults, and `MULTI_CELL_AT_LEAST_2` cases with one, two, and three cells.