### PR TITLE
fix: pin correct version SHA for pull-request action

### DIFF
--- a/.github/workflows/sync-multigres-proto.yml
+++ b/.github/workflows/sync-multigres-proto.yml
@@ -59,7 +59,7 @@ jobs:
           go mod tidy
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@5e914681df9dc83ac74969da89efb39d9f0ee814 # v8.1.1
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore(deps): bump multigres to ${{ steps.vars.outputs.short_sha }}"


### PR DESCRIPTION
Previous commit SHA does not seem to be part of the peter-evans/create-pull-request repository. This change is pinning a known SHA and version.