### PR TITLE
fix: avoid persisting creds when checking out code

### DIFF
--- a/.github/workflows/sync-multigres-proto.yml
+++ b/.github/workflows/sync-multigres-proto.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
During syncing proto files workflow we checkout code twice, which may cause a double auth error. This change is making the first auth "volatile" so the second attempt can go through.