### PR TITLE
fix: use cross-repo reference with owner/repo@SHA

### DIFF
--- a/.github/workflows/sync-multigres-proto.yml
+++ b/.github/workflows/sync-multigres-proto.yml
@@ -65,7 +65,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore(deps): bump multigres to ${{ steps.vars.outputs.short_sha }}"
           title: "chore(deps): sync multigres proto to ${{ steps.vars.outputs.short_sha }}"
-          body: "Automated sync triggered by changes in multigres@${{ github.event.client_payload.sha }}."
+          body: "Automated sync triggered by changes in multigres/multigres@${{ github.event.client_payload.sha }}."
           branch: chore/sync-proto-${{ steps.vars.outputs.short_sha }}
           base: main
           delete-branch: true


### PR DESCRIPTION
We should add the repo owner when referencing a different repository, otherwise github renders the reference with the local repository name.