### PR TITLE
refactor(shard): swap pgctld and multipooler container types

### DIFF
--- a/docs/development/phase-lifecycle.md
+++ b/docs/development/phase-lifecycle.md
@@ -79,7 +79,7 @@ Returns `true` if any container (regular or init) in the pod matches one of:
 
 The restart threshold (3) catches the gap between backoff restarts when the container is briefly in `Completed`/`Error` state before Kubernetes starts the next attempt.
 
-**Note:** Both `ContainerStatuses` and `InitContainerStatuses` are checked. This is necessary because native sidecars (init containers with `restartPolicy: Always`, such as multipooler) report their status under `InitContainerStatuses`, not `ContainerStatuses`.
+**Note:** Both `ContainerStatuses` and `InitContainerStatuses` are checked. This is necessary because native sidecars (init containers with `restartPolicy: Always`, such as pgctld) report their status under `InitContainerStatuses`, not `ContainerStatuses`.
 
 ### `AnyCrashLooping(pods)`
 

--- a/docs/development/pod-management-design.md
+++ b/docs/development/pod-management-design.md
@@ -265,16 +265,42 @@ Naming pods like `primary-0` or `replica-1` would be misleading because:
 
 ## 6. Pod Lifecycle & Decommissioning
 
+### Container Shutdown Ordering
+
+In Kubernetes native sidecar semantics (see [KEP-753](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/753-sidecar-containers/README.md)), regular containers receive SIGTERM first and shut down before sidecars. For the pooler pod, this ordering
+is important: multipooler's shutdown sequence drains in-flight queries,
+closes the connection pool, and then calls `pgctld.Stop()` over gRPC to stop
+PostgreSQL cleanly before announcing `STOPPED` to the orchestrator.
+
+The operator therefore runs:
+
+- **pgctld** as a native sidecar (init container with `restartPolicy: Always`)
+- **multipooler** as a regular container
+
+This guarantees pgctld outlives multipooler during pod termination: multipooler
+receives SIGTERM first, runs its full graceful shutdown against a live pgctld
+gRPC server, and only after multipooler exits does Kubernetes send SIGTERM to
+pgctld. No preStop hooks, polling, or external coordination is required —
+ordering is enforced by Kubernetes itself.
+
+`TerminationGracePeriodSeconds` on the pool pod is sized to fit
+multipooler's full shutdown sequence (drain + close pool + `pgctld.Stop()` +
+announce STOPPED + multipooler's own safety-net timer) plus pgctld's own
+`onterm-timeout` and headroom for slow `pg_ctl stop` before SIGKILL fires.
+
 ### What Happens on Multipooler Shutdown (SIGTERM)
 
-When a pod receives SIGTERM (e.g., from `kubectl delete pod` or operator-initiated deletion):
+When a pool pod receives SIGTERM (e.g., from `kubectl delete pod` or
+operator-initiated deletion), the sequence is:
 
-1. Multipooler's `Shutdown()` is called:
-   - Calls `toporeg.Unregister()` → which executes the `unregisterFunc`
-   - `unregisterFunc` sets `ServingStatus = NOT_SERVING` in etcd
-   - Closes the topology store connection
-2. The multipooler process exits
-3. Kubernetes terminates the pod
+1. Kubernetes sends SIGTERM to **multipooler** only (the regular container).
+   pgctld is a native sidecar and does not receive SIGTERM yet.
+2. Multipooler runs its graceful shutdown.
+3. The multipooler process exits.
+4. **Only now** does Kubernetes send SIGTERM to pgctld. pgctld runs its
+   `OnTermSync` hooks (gRPC `GracefulStop`, etc.) with no in-flight RPCs
+   outstanding and exits.
+5. Kubernetes terminates the pod.
 
 **Critical: the multipooler does NOT delete its registration from etcd.** The entry persists with `ServingStatus = NOT_SERVING`. The rationale in the code is: *"For poolers, we don't un-register them on shutdown (they are persistent component). If they are actually deleted, they need to be cleaned up outside the lifecycle of starting/stopping."*
 

--- a/docs/development/postgresql-image-strategy.md
+++ b/docs/development/postgresql-image-strategy.md
@@ -8,7 +8,7 @@ The operator currently uses a single all-in-one image (`ghcr.io/multigres/pgctld
 - pgctld binary (manages the PostgreSQL lifecycle)
 - pgbackrest (backup/restore)
 
-This approach was chosen for simplicity and compatibility during the initial release. The `buildPgctldContainer()` function in `containers.go` is the sole code path for building the postgres container spec.
+This approach was chosen for simplicity and compatibility during the initial release. The `buildPgctldSidecar()` function in `containers.go` is the sole code path for building the postgres container spec.
 
 ## Future Plan: Custom PostgreSQL Image Support
 

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -119,12 +119,15 @@ func buildPgHbaVolume(shardName string) corev1.Volume {
 // sidecarRestartPolicy is the restart policy for native sidecar containers
 var sidecarRestartPolicy = corev1.ContainerRestartPolicyAlways
 
-// buildPgctldContainer creates the postgres container spec using the pgctld image.
+// buildPgctldSidecar creates the postgres container spec using the pgctld image.
+// Runs as a native sidecar so it outlives multipooler on pod termination;
+// see docs/development/pod-management-design.md §6 for the full rationale.
+//
 // Uses DefaultPostgresImage (ghcr.io/multigres/pgctld:main) which includes:
 //   - PostgreSQL 17
 //   - pgctld binary at /usr/local/bin/pgctld
 //   - pgbackrest for backup/restore operations
-func buildPgctldContainer(
+func buildPgctldSidecar(
 	shard *multigresv1alpha1.Shard,
 	pool multigresv1alpha1.PoolSpec,
 ) corev1.Container {
@@ -225,6 +228,7 @@ func buildPgctldContainer(
 		Command:         []string{"/usr/local/bin/pgctld"},
 		Args:            args,
 		Resources:       pool.Postgres.Resources,
+		RestartPolicy:   &sidecarRestartPolicy,
 		Env:             env,
 		SecurityContext: buildContainerSecurityContext(pool.FSGroup),
 		VolumeMounts:    volumeMounts,
@@ -306,10 +310,11 @@ func BuildPoolServiceID(podName string) string {
 	return "p-" + nameutil.Hash([]string{podName})
 }
 
-// buildMultiPoolerSidecar creates the multipooler sidecar container spec.
-// Implemented as native sidecar (init container with restartPolicy: Always) because
-// multipooler must restart with postgres to maintain connection pool consistency.
-func buildMultiPoolerSidecar(
+// buildMultiPoolerContainer creates the multipooler container spec.
+// Runs as a regular (non-sidecar) container so it receives SIGTERM before
+// pgctld and can call pgctld.Stop() during its graceful shutdown; see
+// docs/development/pod-management-design.md §6 for the full rationale.
+func buildMultiPoolerContainer(
 	shard *multigresv1alpha1.Shard,
 	pool multigresv1alpha1.PoolSpec,
 	poolName string,
@@ -362,7 +367,6 @@ func buildMultiPoolerSidecar(
 		Args:            args,
 		Ports:           buildMultiPoolerContainerPorts(),
 		Resources:       pool.Multipooler.Resources,
-		RestartPolicy:   &sidecarRestartPolicy,
 		SecurityContext: buildContainerSecurityContext(pool.FSGroup),
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -15,7 +15,7 @@ import (
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 )
 
-func TestBuildMultiPoolerSidecar(t *testing.T) {
+func TestBuildMultiPoolerContainer(t *testing.T) {
 	tests := map[string]struct {
 		shard     *multigresv1alpha1.Shard
 		poolSpec  multigresv1alpha1.PoolSpec
@@ -72,9 +72,8 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					"--connpool-admin-capacity=5",
 					"--log-level=info",
 				},
-				Ports:         buildMultiPoolerContainerPorts(),
-				Resources:     corev1.ResourceRequirements{},
-				RestartPolicy: &sidecarRestartPolicy,
+				Ports:     buildMultiPoolerContainerPorts(),
+				Resources: corev1.ResourceRequirements{},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot: ptr.To(true),
 				},
@@ -179,9 +178,8 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 					"--connpool-admin-capacity=5",
 					"--log-level=info",
 				},
-				Ports:         buildMultiPoolerContainerPorts(),
-				Resources:     corev1.ResourceRequirements{},
-				RestartPolicy: &sidecarRestartPolicy,
+				Ports:     buildMultiPoolerContainerPorts(),
+				Resources: corev1.ResourceRequirements{},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot: ptr.To(true),
 				},
@@ -306,7 +304,6 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("512Mi"),
 					},
 				},
-				RestartPolicy: &sidecarRestartPolicy,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot: ptr.To(true),
 				},
@@ -363,7 +360,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := buildMultiPoolerSidecar(
+			got := buildMultiPoolerContainer(
 				tc.shard,
 				tc.poolSpec,
 				"primary",
@@ -372,7 +369,7 @@ func TestBuildMultiPoolerSidecar(t *testing.T) {
 			)
 
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("buildMultiPoolerSidecar() mismatch (-want +got):\n%s", diff)
+				t.Errorf("buildMultiPoolerContainer() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -453,12 +450,12 @@ func TestPoolContainers_CustomPostgresSuperuser(t *testing.T) {
 	}
 
 	t.Run("pgctld", func(t *testing.T) {
-		c := buildPgctldContainer(shard, pool)
+		c := buildPgctldSidecar(shard, pool)
 		assertEnvVarValue(t, c.Env, "POSTGRES_USER", customSuperuser)
 	})
 
 	t.Run("multipooler", func(t *testing.T) {
-		c := buildMultiPoolerSidecar(shard, pool, "primary", "zone1", "p-test-id")
+		c := buildMultiPoolerContainer(shard, pool, "primary", "zone1", "p-test-id")
 		assertEnvVarValue(t, c.Env, "POSTGRES_USER", customSuperuser)
 	})
 
@@ -585,10 +582,10 @@ func otelShard() *multigresv1alpha1.Shard {
 	}
 }
 
-func TestBuildPgctldContainer(t *testing.T) {
+func TestBuildPgctldSidecar(t *testing.T) {
 	t.Run("default image", func(t *testing.T) {
 		shard := &multigresv1alpha1.Shard{Spec: multigresv1alpha1.ShardSpec{}}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		if c.Image != multigresv1alpha1.DefaultPostgresImage {
 			t.Errorf("Image = %q, want %q", c.Image, multigresv1alpha1.DefaultPostgresImage)
 		}
@@ -613,15 +610,15 @@ func TestBuildPgctldContainer(t *testing.T) {
 				Images: multigresv1alpha1.ShardImages{Postgres: "custom/pgctld:v1"},
 			},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		if c.Image != "custom/pgctld:v1" {
 			t.Errorf("Image = %q, want %q", c.Image, "custom/pgctld:v1")
 		}
 	})
 
 	t.Run("with observability", func(t *testing.T) {
-		c := buildPgctldContainer(otelShard(), multigresv1alpha1.PoolSpec{})
-		assertContainsOTELEnvVar(t, c.Env, "buildPgctldContainer")
+		c := buildPgctldSidecar(otelShard(), multigresv1alpha1.PoolSpec{})
+		assertContainsOTELEnvVar(t, c.Env, "buildPgctldSidecar")
 		assertEnvVarValue(
 			t,
 			c.Env,
@@ -644,7 +641,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 				},
 			},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertContainsFlag(t, c.Args, "--pgbackrest-cert-dir="+PgBackRestCertMountPath)
 		assertContainsFlag(t, c.Args, "--pgbackrest-port=8432")
 		assertNotContainsFlag(t, c.Args, "--backup-type")
@@ -663,7 +660,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 				},
 			},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertContainsFlag(t, c.Args, "--pgbackrest-cert-dir="+PgBackRestCertMountPath)
 		assertContainsFlag(t, c.Args, "--pgbackrest-port=8432")
 		assertNotContainsFlag(t, c.Args, "--backup-type")
@@ -675,7 +672,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 		shard := &multigresv1alpha1.Shard{
 			Spec: multigresv1alpha1.ShardSpec{},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertNotContainsFlag(t, c.Args, "--pgbackrest-cert-dir")
 		assertNotContainsFlag(t, c.Args, "--pgbackrest-port")
 		assertNotContainsFlag(t, c.Args, "--backup-type")
@@ -694,7 +691,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 				},
 			},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertContainsEnvVar(t, c.Env, "AWS_REGION")
 		assertContainsEnvVar(t, c.Env, "AWS_ACCESS_KEY_ID")
 		assertContainsEnvVar(t, c.Env, "AWS_SECRET_ACCESS_KEY")
@@ -708,7 +705,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 				},
 			},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertNotContainsEnvVar(t, c.Env, "AWS_REGION")
 		assertNotContainsEnvVar(t, c.Env, "AWS_ACCESS_KEY_ID")
 	})
@@ -719,7 +716,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 				InitdbArgs: "--locale-provider=icu --icu-locale=en_US.UTF-8",
 			},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertContainsEnvVar(t, c.Env, "POSTGRES_INITDB_ARGS")
 		for _, e := range c.Env {
 			if e.Name == "POSTGRES_INITDB_ARGS" {
@@ -736,7 +733,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 		shard := &multigresv1alpha1.Shard{
 			Spec: multigresv1alpha1.ShardSpec{},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertNotContainsEnvVar(t, c.Env, "POSTGRES_INITDB_ARGS")
 	})
 
@@ -747,7 +744,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 				Key:  "custom.conf",
 			},
 		}}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertContainsEnvVar(t, c.Env, "POSTGRES_INITDB_EXTRA_CONF")
 		for _, e := range c.Env {
 			if e.Name == "POSTGRES_INITDB_EXTRA_CONF" {
@@ -764,7 +761,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 
 	t.Run("no POSTGRES_INITDB_EXTRA_CONF env when postgresConfigRef nil", func(t *testing.T) {
 		shard := &multigresv1alpha1.Shard{Spec: multigresv1alpha1.ShardSpec{}}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertNotContainsEnvVar(t, c.Env, "POSTGRES_INITDB_EXTRA_CONF")
 	})
 
@@ -775,7 +772,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 				Key:  "custom.conf",
 			},
 		}}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertContainsVolumeMount(t, c.VolumeMounts, PostgresConfigVolumeName)
 		for _, m := range c.VolumeMounts {
 			if m.Name == PostgresConfigVolumeName {
@@ -795,7 +792,7 @@ func TestBuildPgctldContainer(t *testing.T) {
 
 	t.Run("no postgres config volume mount when postgresConfigRef nil", func(t *testing.T) {
 		shard := &multigresv1alpha1.Shard{Spec: multigresv1alpha1.ShardSpec{}}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		for _, m := range c.VolumeMounts {
 			if m.Name == PostgresConfigVolumeName {
 				t.Error(
@@ -948,15 +945,15 @@ func assertContainsFlag(t *testing.T, args []string, want string) {
 	t.Errorf("args %v does not contain flag %q", args, want)
 }
 
-func TestBuildMultiPoolerSidecar_WithObservability(t *testing.T) {
-	c := buildMultiPoolerSidecar(
+func TestBuildMultiPoolerContainer_WithObservability(t *testing.T) {
+	c := buildMultiPoolerContainer(
 		otelShard(),
 		multigresv1alpha1.PoolSpec{},
 		"primary",
 		"zone1",
 		"p-otel1234",
 	)
-	assertContainsOTELEnvVar(t, c.Env, "buildMultiPoolerSidecar")
+	assertContainsOTELEnvVar(t, c.Env, "buildMultiPoolerContainer")
 	assertEnvVarValue(
 		t,
 		c.Env,
@@ -1232,7 +1229,7 @@ func TestPgctldContainer_PgBackRestCertArgs(t *testing.T) {
 				},
 			},
 		}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertContainsFlag(t, c.Args, "--pgbackrest-cert-dir=/certs/pgbackrest")
 		assertContainsFlag(t, c.Args, "--pgbackrest-port=8432")
 		assertContainsVolumeMount(t, c.VolumeMounts, PgBackRestCertVolumeName)
@@ -1247,7 +1244,7 @@ func TestPgctldContainer_PgBackRestCertArgs(t *testing.T) {
 
 	t.Run("no cert args when no backup", func(t *testing.T) {
 		shard := &multigresv1alpha1.Shard{Spec: multigresv1alpha1.ShardSpec{}}
-		c := buildPgctldContainer(shard, multigresv1alpha1.PoolSpec{})
+		c := buildPgctldSidecar(shard, multigresv1alpha1.PoolSpec{})
 		assertNotContainsFlag(t, c.Args, "--pgbackrest-cert-dir")
 		assertNotContainsFlag(t, c.Args, "--pgbackrest-port")
 		assertNotContainsVolumeMount(t, c.VolumeMounts, PgBackRestCertVolumeName)
@@ -1276,7 +1273,7 @@ func TestMultiPoolerSidecar_PgBackRestCertArgs(t *testing.T) {
 			Type: multigresv1alpha1.BackupTypeS3,
 			S3:   &multigresv1alpha1.S3BackupConfig{Bucket: "b", Region: "r"},
 		}
-		c := buildMultiPoolerSidecar(
+		c := buildMultiPoolerContainer(
 			shard,
 			multigresv1alpha1.PoolSpec{},
 			"primary",
@@ -1291,7 +1288,7 @@ func TestMultiPoolerSidecar_PgBackRestCertArgs(t *testing.T) {
 
 	t.Run("no cert args when no backup", func(t *testing.T) {
 		shard := baseShard.DeepCopy()
-		c := buildMultiPoolerSidecar(
+		c := buildMultiPoolerContainer(
 			shard,
 			multigresv1alpha1.PoolSpec{},
 			"primary",

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -99,11 +99,13 @@ func BuildPoolPod(
 		Spec: corev1.PodSpec{
 			SecurityContext:               buildPoolPodSecurityContext(poolSpec),
 			TerminationGracePeriodSeconds: ptr.To(defaultTerminationGracePeriod),
+			// pgctld is the native sidecar so it outlives multipooler on pod
+			// termination, see docs/development/pod-management-design.md §6.
 			InitContainers: []corev1.Container{
-				buildMultiPoolerSidecar(shard, poolSpec, poolName, cellName, serviceID),
+				buildPgctldSidecar(shard, poolSpec),
 			},
 			Containers: []corev1.Container{
-				buildPgctldContainer(shard, poolSpec),
+				buildMultiPoolerContainer(shard, poolSpec, poolName, cellName, serviceID),
 				buildPostgresExporterContainer(shard, poolSpec),
 			},
 			Volumes:      volumes,

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -151,26 +151,26 @@ func TestBuildPoolPod_Containers(t *testing.T) {
 
 	if len(pod.Spec.InitContainers) != 1 {
 		t.Fatalf(
-			"expected 1 init container (multipooler sidecar), got %d",
+			"expected 1 init container (pgctld sidecar), got %d",
 			len(pod.Spec.InitContainers),
 		)
 	}
-	if pod.Spec.InitContainers[0].Name != "multipooler" {
+	if pod.Spec.InitContainers[0].Name != "postgres" {
 		t.Errorf(
 			"init container name = %q, want %q",
 			pod.Spec.InitContainers[0].Name,
-			"multipooler",
+			"postgres",
 		)
 	}
 
 	if len(pod.Spec.Containers) != 2 {
 		t.Fatalf(
-			"expected 2 containers (postgres + postgres-exporter), got %d",
+			"expected 2 containers (multipooler + postgres-exporter), got %d",
 			len(pod.Spec.Containers),
 		)
 	}
-	if pod.Spec.Containers[0].Name != "postgres" {
-		t.Errorf("container name = %q, want %q", pod.Spec.Containers[0].Name, "postgres")
+	if pod.Spec.Containers[0].Name != "multipooler" {
+		t.Errorf("container name = %q, want %q", pod.Spec.Containers[0].Name, "multipooler")
 	}
 	if pod.Spec.Containers[1].Name != "postgres-exporter" {
 		t.Errorf(

--- a/tools/skills/pin_upstream_images/SKILL.md
+++ b/tools/skills/pin_upstream_images/SKILL.md
@@ -91,7 +91,7 @@ For every potentially impactful upstream change:
 
 3. **Do not speculate.** Every recommendation must be backed by a concrete search result (or confirmed absence) in the operator codebase. No "if the operator does X" phrasing -- either it does or it doesn't.
 
-4. **Per-container analysis is mandatory.** When an upstream change affects a component's requirements (env vars, flags, volumes, config files), verify the requirement is satisfied on the **specific container** for that component in `containers.go`. Finding a reference elsewhere in the operator is NOT sufficient — each container builder (`buildPgctldContainer`, `buildMultiPoolerSidecar`, `buildMultiOrchContainer`, etc.) is independent. A requirement met on one container does NOT mean it is met on another.
+4. **Per-container analysis is mandatory.** When an upstream change affects a component's requirements (env vars, flags, volumes, config files), verify the requirement is satisfied on the **specific container** for that component in `containers.go`. Finding a reference elsewhere in the operator is NOT sufficient — each container builder (`buildPgctldSidecar`, `buildMultiPoolerContainer`, `buildMultiOrchContainer`, etc.) is independent. A requirement met on one container does NOT mean it is met on another.
 
 ### 4a. Flag Compatibility Audit
 
@@ -129,8 +129,8 @@ For every potentially impactful upstream change:
    ```
 
 2. For each required env var found, check `containers.go` to confirm it is set on the **specific container** for that component:
-   - `multipooler` env vars → must be in `buildMultiPoolerSidecar`
-   - `pgctld` env vars → must be in `buildPgctldContainer`
+   - `multipooler` env vars → must be in `buildMultiPoolerContainer`
+   - `pgctld` env vars → must be in `buildPgctldSidecar`
    - `multiorch` env vars → must be in `buildMultiOrchContainer`
    - `multigateway` env vars → must be in `buildMultiGatewayContainer` (if exists)
 


### PR DESCRIPTION
## Description
In k8s native sidecar semantics ([KEP-753](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/753-sidecar-containers/README.md#proposal)), regular containers receive SIGTERM first, sidecars stay alive until regular containers exit. Old layout had multipooler as sidecar and pgctld as regular, this is problematic when trying to do a clean shutdown:

1. SIGTERM -> pgctld shuts down first
2. pgctld gRPC server gone, PID namespace teardown takes Postgres
3. multipooler's stopPostgresWithEscalation calls pgctld.Stop(), no server, error logged
4. Postgres receives SIGKILL instead of clean shutdown
5. Entire graceful shutdown sequence achieves nothing for Postgres cleanliness

Proposed layout (pgctld=sidecar, multipooler=regular) flips it:
1. SIGTERM -> multipooler
2. multipooler runs GracefulShutdown(): drain queries, close pool, call pgctld.Stop() (pgctld still alive), announce STOPPED, exit
3. K8s then SIGTERMs pgctld
4. pgctld exits with no in-flight RPCs

## Changes
- pgctld moves to InitContainers with `restartPolicy: Always`
- multipooler moved as a regular containers, inherits `restartPolicy: Always` from pod spec.
- Bump TerminationGracePeriodSeconds 30 -> 90 to cover multipooler's full graceful shutdown plus pgctld's own onterm-timeout before SIGKILL
- pod-management-design.md: new §6 subsection "Container Shutdown Ordering" with the full SIGTERM-ordering rationale. Rewrite of "What Happens on Multipooler Shutdown" to reflect the actual 5-step sequence