### PR TITLE
fix: cleanup deprecated structures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.9
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
-	github.com/multigres/multigres v0.0.0-20260512091317-f23e6fb46dad
+	github.com/multigres/multigres v0.0.0-20260513090037-13502a56b55b
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/multigres/multigres v0.0.0-20260512091317-f23e6fb46dad h1:nNLl5tqjaC71lxl7mEjgl7h507qashlv2NIx4PoLlc8=
 github.com/multigres/multigres v0.0.0-20260512091317-f23e6fb46dad/go.mod h1:aPCcP/x+KTupMMYXIhcsBkTCru+jEDO7gxWEFY8onHI=
+github.com/multigres/multigres v0.0.0-20260513090037-13502a56b55b h1:5kZCvWY8d0l95s6ymkz/0odlh61YB8HlymPAGOLnzvE=
+github.com/multigres/multigres v0.0.0-20260513090037-13502a56b55b/go.mod h1:aPCcP/x+KTupMMYXIhcsBkTCru+jEDO7gxWEFY8onHI=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=

--- a/pkg/data-handler/drain/execute_test.go
+++ b/pkg/data-handler/drain/execute_test.go
@@ -118,21 +118,25 @@ func TestReplicaDrainFlow(t *testing.T) {
 
 	// Add primary
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
-		Hostname:   "primary-pod",
-		Type:       clustermetadata.PoolerType_PRIMARY,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
+		Hostname: "primary-pod",
+		Type:     clustermetadata.PoolerType_PRIMARY,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 	// Add our replica pod
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
-		Hostname:   "test-pod-0",
-		Type:       clustermetadata.PoolerType_REPLICA,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
+		Hostname: "test-pod-0",
+		Type:     clustermetadata.PoolerType_REPLICA,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 
 	// Step 1: Requested -> Draining
@@ -230,16 +234,20 @@ func TestPrimaryDrainFlow(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
 		Hostname: "test-pod-0", Type: clustermetadata.PoolerType_PRIMARY,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod"},
 		Hostname: "replica-pod", Type: clustermetadata.PoolerType_REPLICA,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 
 	// PRIMARY drain should advance to DrainStateDraining without calling Promote.
@@ -308,16 +316,20 @@ func TestPrimaryDrainFlowNilRPCClient(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
 		Hostname: "test-pod-0", Type: clustermetadata.PoolerType_PRIMARY,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod"},
 		Hostname: "replica-pod", Type: clustermetadata.PoolerType_REPLICA,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 
 	// With nil rpcClient, drain should proceed instead of looping forever
@@ -385,9 +397,11 @@ func TestStuckTerminatingPod(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
 		Hostname: "test-pod-0", Type: clustermetadata.PoolerType_REPLICA,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 
 	// Delete the pod using the client to set DeletionTimestamp
@@ -537,20 +551,24 @@ func TestReplicaDrain_SkipsRPCWhenPrimaryDraining(t *testing.T) {
 
 	// Register primary and replica in topo
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
-		Hostname:   "primary-pod",
-		Type:       clustermetadata.PoolerType_PRIMARY,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
+		Hostname: "primary-pod",
+		Type:     clustermetadata.PoolerType_PRIMARY,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
-		Id:         &clustermetadata.ID{Cell: "cell1", Name: "replica-pod-0"},
-		Hostname:   "replica-pod-0",
-		Type:       clustermetadata.PoolerType_REPLICA,
-		Database:   "test-db",
-		TableGroup: "test-tg",
-		Shard:      "0",
+		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod-0"},
+		Hostname: "replica-pod-0",
+		Type:     clustermetadata.PoolerType_REPLICA,
+		ShardKey: &clustermetadata.ShardKey{
+			Database:   "test-db",
+			TableGroup: "test-tg",
+			Shard:      "0",
+		},
 	}, false)
 
 	// Execute drain for replica while primary is draining
@@ -629,7 +647,7 @@ func TestReplicaDrain_DrainingState_FindPrimaryError(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod-0"},
 		Hostname: "replica-pod-0", Type: clustermetadata.PoolerType_REPLICA,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 
 	// Since there's no primary in topo, findPrimaryPooler returns nil,nil.
@@ -702,12 +720,12 @@ func TestReplicaDrain_DrainingState_PrimaryDraining(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
 		Hostname: "primary-pod", Type: clustermetadata.PoolerType_PRIMARY,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod-0"},
 		Hostname: "replica-pod-0", Type: clustermetadata.PoolerType_REPLICA,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 
 	// In DrainStateDraining, if primary is draining, should requeue without advancing
@@ -861,12 +879,12 @@ func TestReplicaDrain_PrimaryTerminatingOrMissing(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
 		Hostname: "primary-pod", Type: clustermetadata.PoolerType_PRIMARY,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod-0"},
 		Hostname: "replica-pod-0", Type: clustermetadata.PoolerType_REPLICA,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 
 	requeue, err := drain.ExecuteDrainStateMachine(
@@ -948,12 +966,12 @@ func TestReplicaDrain_DrainingState_PrimaryTerminating(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
 		Hostname: "primary-pod", Type: clustermetadata.PoolerType_PRIMARY,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod-0"},
 		Hostname: "replica-pod-0", Type: clustermetadata.PoolerType_REPLICA,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 
 	// In DrainStateDraining, primary is terminating, should skip standby verification
@@ -1084,7 +1102,7 @@ func TestDrain_StuckDrainTimeout_DeletionTimestampFallback(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "test-pod-0"},
 		Hostname: "test-pod-0", Type: clustermetadata.PoolerType_REPLICA,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 
 	requeue, err := drain.ExecuteDrainStateMachine(ctx, c, nil, recorder, store, shardObj, pod)
@@ -1230,12 +1248,12 @@ func TestReplicaDrain_RPCError(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
 		Hostname: "primary-pod", Type: clustermetadata.PoolerType_PRIMARY,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod-0"},
 		Hostname: "replica-pod-0", Type: clustermetadata.PoolerType_REPLICA,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 
 	// RPC error on UpdateConsensusRule should requeue
@@ -1314,12 +1332,12 @@ func TestReplicaDrain_DrainingState_RPCError(t *testing.T) {
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary-pod"},
 		Hostname: "primary-pod", Type: clustermetadata.PoolerType_PRIMARY,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 	_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 		Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod-0"},
 		Hostname: "replica-pod-0", Type: clustermetadata.PoolerType_REPLICA,
-		Database: "test-db", TableGroup: "test-tg", Shard: "0",
+		ShardKey: &clustermetadata.ShardKey{Database: "test-db", TableGroup: "test-tg", Shard: "0"},
 	}, false)
 
 	requeue, err := drain.ExecuteDrainStateMachine(
@@ -1475,12 +1493,14 @@ func TestDrainStateMachine_RandomizedInvariants(t *testing.T) {
 
 		for j := range numPods {
 			_ = store.RegisterMultiPooler(context.Background(), &clustermetadata.MultiPooler{
-				Id:         &clustermetadata.ID{Cell: "cell1", Name: podNames[j]},
-				Hostname:   podNames[j],
-				Type:       podTypes[j],
-				Database:   "db",
-				TableGroup: "tg",
-				Shard:      "0",
+				Id:       &clustermetadata.ID{Cell: "cell1", Name: podNames[j]},
+				Hostname: podNames[j],
+				Type:     podTypes[j],
+				ShardKey: &clustermetadata.ShardKey{
+					Database:   "db",
+					TableGroup: "tg",
+					Shard:      "0",
+				},
 			}, false)
 		}
 

--- a/pkg/data-handler/topo/pooler_test.go
+++ b/pkg/data-handler/topo/pooler_test.go
@@ -81,12 +81,12 @@ func TestFindPrimaryPooler(t *testing.T) {
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica-pod"},
 			Hostname: "replica-pod", Type: clustermetadata.PoolerType_REPLICA,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell2", Name: "primary-pod"},
 			Hostname: "primary-pod", Type: clustermetadata.PoolerType_PRIMARY,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{
@@ -233,17 +233,17 @@ func TestPrunePoolers(t *testing.T) {
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "active-pod"},
 			Hostname: "active-pod", Type: clustermetadata.PoolerType_REPLICA,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "stale-pod"},
 			Hostname: "stale-pod", Type: clustermetadata.PoolerType_REPLICA,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "dead-pod"},
 			Hostname: "dead-pod", Type: clustermetadata.PoolerType_DRAINED,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{
@@ -286,7 +286,7 @@ func TestPrunePoolers(t *testing.T) {
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "pod-1"},
 			Hostname: "pod-1", Type: clustermetadata.PoolerType_REPLICA,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{
@@ -349,13 +349,13 @@ func TestPrunePoolers(t *testing.T) {
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "active-pod"},
 			Hostname: "active-pod.headless-svc.ns.svc.cluster.local",
 			Type:     clustermetadata.PoolerType_PRIMARY,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "stale-pod"},
 			Hostname: "stale-pod.headless-svc.ns.svc.cluster.local",
 			Type:     clustermetadata.PoolerType_REPLICA,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{
@@ -412,8 +412,13 @@ func TestPrunePoolers(t *testing.T) {
 				p := &topoclient.MultiPoolerInfo{
 					MultiPooler: &clustermetadata.MultiPooler{
 						Id:       &clustermetadata.ID{Cell: "cell1", Name: "stale-pod"},
-						Hostname: "stale-pod", Type: clustermetadata.PoolerType_REPLICA,
-						Database: "db", TableGroup: "tg", Shard: "0",
+						Hostname: "stale-pod",
+						Type:     clustermetadata.PoolerType_REPLICA,
+						ShardKey: &clustermetadata.ShardKey{
+							Database:   "db",
+							TableGroup: "tg",
+							Shard:      "0",
+						},
 					},
 				}
 				return []*topoclient.MultiPoolerInfo{p}, nil
@@ -448,8 +453,13 @@ func TestPrunePoolers(t *testing.T) {
 				p := &topoclient.MultiPoolerInfo{
 					MultiPooler: &clustermetadata.MultiPooler{
 						Id:       &clustermetadata.ID{Cell: "cell1", Name: "stale-pod-no-hostname"},
-						Hostname: "", Type: clustermetadata.PoolerType_REPLICA,
-						Database: "db", TableGroup: "tg", Shard: "0",
+						Hostname: "",
+						Type:     clustermetadata.PoolerType_REPLICA,
+						ShardKey: &clustermetadata.ShardKey{
+							Database:   "db",
+							TableGroup: "tg",
+							Shard:      "0",
+						},
 					},
 				}
 				return []*topoclient.MultiPoolerInfo{p}, nil
@@ -508,7 +518,7 @@ func TestForceUnregisterPod(t *testing.T) {
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "other-pod"},
 			Hostname: "other-pod", Type: clustermetadata.PoolerType_REPLICA,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{
@@ -540,7 +550,7 @@ func TestForceUnregisterPod(t *testing.T) {
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "my-pod"},
 			Hostname: "my-pod", Type: clustermetadata.PoolerType_REPLICA,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{
@@ -633,17 +643,17 @@ func TestGetPoolerStatus(t *testing.T) {
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "primary"},
 			Hostname: "primary", Type: clustermetadata.PoolerType_PRIMARY,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "replica"},
 			Hostname: "replica", Type: clustermetadata.PoolerType_REPLICA,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "drained"},
 			Hostname: "drained", Type: clustermetadata.PoolerType_DRAINED,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{
@@ -683,7 +693,7 @@ func TestGetPoolerStatus(t *testing.T) {
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "orphaned-pod"},
 			Hostname: "orphaned-pod", Type: clustermetadata.PoolerType_PRIMARY,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{
@@ -737,7 +747,7 @@ func TestGetPoolerStatus(t *testing.T) {
 		_ = store.RegisterMultiPooler(ctx, &clustermetadata.MultiPooler{
 			Id:       &clustermetadata.ID{Cell: "cell1", Name: "my-pod-0"},
 			Hostname: "", Type: clustermetadata.PoolerType_PRIMARY,
-			Database: "db", TableGroup: "tg", Shard: "0",
+			ShardKey: &clustermetadata.ShardKey{Database: "db", TableGroup: "tg", Shard: "0"},
 		}, false)
 
 		shard := &multigresv1alpha1.Shard{


### PR DESCRIPTION
## Description

After [this multigres commit](https://github.com/multigres/multigres/commit/13502a56b55b95f03f304ed963376007ca26350c), `clustermetadata.MultiPooler` no longer has top-level `Database`, `TableGroup`, and `Shard`. Those fields live on `ShardKey` now.

## Changes

- `pkg/data-handler/topo/pooler_test.go`: Every MultiPooler literal now sets shard identity with ShardKey: `&clustermetadata.ShardKey{Database: ..., TableGroup: ..., Shard: ...}`.

- `pkg/data-handler/drain/execute_test.go`: Same ShardKey migration for all RegisterMultiPooler / benchmark literals (multi-line test-db blocks, one-line test-db form, and the db/tg/0 benchmark case).
