### PR TITLE
chore: bump Go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Containerfile for multigres-operator
 
-FROM --platform=$BUILDPLATFORM golang:1.25.9-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
To follow the Go version in go.mod. The version mismatch caused a failure in https://github.com/multigres/multigres-operator/actions/runs/25813348598/job/75835419541#step:8:293