### PR TITLE
feat(topology): support shared local topology registration

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
@@ -63,7 +63,8 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 	// Register all cells.
 	for _, cellCfg := range cluster.Spec.Cells {
 		cellCfgForResolution := cellCfg
-		if cellCfgForResolution.CellTemplate == "" && cluster.Spec.TemplateDefaults.CellTemplate != "" {
+		if cellCfgForResolution.CellTemplate == "" &&
+			cluster.Spec.TemplateDefaults.CellTemplate != "" {
 			cellCfgForResolution.CellTemplate = cluster.Spec.TemplateDefaults.CellTemplate
 		}
 		_, _, localTopoSpec, err := res.ResolveCell(ctx, &cellCfgForResolution)

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
@@ -62,8 +62,18 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 
 	// Register all cells.
 	for _, cellCfg := range cluster.Spec.Cells {
+		cellCfgForResolution := cellCfg
+		if cellCfgForResolution.CellTemplate == "" && cluster.Spec.TemplateDefaults.CellTemplate != "" {
+			cellCfgForResolution.CellTemplate = cluster.Spec.TemplateDefaults.CellTemplate
+		}
+		_, _, localTopoSpec, err := res.ResolveCell(ctx, &cellCfgForResolution)
+		if err != nil {
+			r.Recorder.Event(cluster, "Warning", "TemplateMissing", err.Error())
+			return ctrl.Result{}, fmt.Errorf("failed to resolve cell '%s': %w", cellCfg.Name, err)
+		}
+
 		if err := topo.RegisterCellFromSpec(
-			topoCtx, store, r.Recorder, cluster, cellCfg, globalTopoRef,
+			topoCtx, store, r.Recorder, cluster, cellCfg, localTopoSpec, globalTopoRef,
 		); err != nil {
 			if topo.IsTopoUnavailable(err) {
 				return r.handleTopoUnavailable(cluster, logger)

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_test.go
@@ -34,8 +34,10 @@ func TestReconcileTopologySharedTopo(t *testing.T) {
 				Spec: &multigresv1alpha1.CellInlineSpec{
 					LocalTopoServer: &multigresv1alpha1.LocalTopoServerSpec{
 						External: &multigresv1alpha1.ExternalTopoServerSpec{
-							Endpoints: []multigresv1alpha1.EndpointUrl{"http://cell1-local-etcd:2379"},
-							RootPath:  "/multigres/clusters/cluster/cells/cell1",
+							Endpoints: []multigresv1alpha1.EndpointUrl{
+								"http://cell1-local-etcd:2379",
+							},
+							RootPath: "/multigres/clusters/cluster/cells/cell1",
 						},
 					},
 				},

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_test.go
@@ -1,0 +1,111 @@
+package multigrescluster
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/resolver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReconcileTopologySharedTopo(t *testing.T) {
+	t.Parallel()
+
+	scheme := setupScheme()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{
+					Endpoints: []multigresv1alpha1.EndpointUrl{"http://global-etcd:2379"},
+					RootPath:  "/multigres/clusters/cluster/global",
+				},
+			},
+			Cells: []multigresv1alpha1.CellConfig{{
+				Name:   "cell1",
+				ZoneID: "use1-az1",
+				Spec: &multigresv1alpha1.CellInlineSpec{
+					LocalTopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+						External: &multigresv1alpha1.ExternalTopoServerSpec{
+							Endpoints: []multigresv1alpha1.EndpointUrl{"http://cell1-local-etcd:2379"},
+							RootPath:  "/multigres/clusters/cluster/cells/cell1",
+						},
+					},
+				},
+			}},
+			Databases: []multigresv1alpha1.DatabaseConfig{{Name: "commerce"}},
+		},
+	}
+
+	store := newClusterTopologyMemoryStore(t)
+	var openedRef multigresv1alpha1.GlobalTopoServerRef
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	reconciler := &MultigresClusterReconciler{
+		Client:   client,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		CreateTopoStore: func(ref multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+			openedRef = ref
+			return noCloseStore{Store: store}, nil
+		},
+	}
+
+	if _, err := reconciler.reconcileTopology(
+		context.Background(),
+		cluster,
+		resolver.NewResolver(client, "default"),
+	); err != nil {
+		t.Fatalf("reconcileTopology() error = %v", err)
+	}
+
+	if openedRef.Address != "http://global-etcd:2379" {
+		t.Fatalf("expected topology store to open global address, got %q", openedRef.Address)
+	}
+	if openedRef.RootPath != "/multigres/clusters/cluster/global" {
+		t.Fatalf("expected topology store to open global root, got %q", openedRef.RootPath)
+	}
+
+	cell, err := store.GetCell(context.Background(), "cell1")
+	if err != nil {
+		t.Fatalf("cell not found: %v", err)
+	}
+	if !reflect.DeepEqual(cell.ServerAddresses, []string{"http://cell1-local-etcd:2379"}) {
+		t.Errorf("expected cell record to point at local topology, got %v", cell.ServerAddresses)
+	}
+	if cell.Root != "/multigres/clusters/cluster/cells/cell1" {
+		t.Errorf("expected cell record local root, got %q", cell.Root)
+	}
+
+	db, err := store.GetDatabase(context.Background(), "commerce")
+	if err != nil {
+		t.Fatalf("database not found in global topology store: %v", err)
+	}
+	if db.Name != "commerce" {
+		t.Errorf("expected database commerce, got %q", db.Name)
+	}
+}
+
+func newClusterTopologyMemoryStore(t *testing.T) topoclient.Store {
+	t.Helper()
+	_, factory := memorytopo.NewServerAndFactory(context.Background())
+	store := topoclient.NewWithFactory(
+		factory, "", []string{""}, topoclient.NewDefaultTopoConfig(),
+	)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+type noCloseStore struct {
+	topoclient.Store
+}
+
+func (s noCloseStore) Close() error {
+	return nil
+}

--- a/pkg/data-handler/topo/cell.go
+++ b/pkg/data-handler/topo/cell.go
@@ -24,7 +24,9 @@ func RegisterCell(
 
 	cellName := string(cell.Spec.Name)
 
-	cellMetadata := cellMetadataFromTopoRefs(cellName, cell.Spec.TopoServer, cell.Spec.GlobalTopoServer)
+	cellMetadata := cellMetadataFromTopoRefs(
+		cellName, cell.Spec.TopoServer, cell.Spec.GlobalTopoServer,
+	)
 
 	created, err := createOrUpdateCell(ctx, store, cellName, cellMetadata)
 	if err != nil {

--- a/pkg/data-handler/topo/cell.go
+++ b/pkg/data-handler/topo/cell.go
@@ -24,20 +24,10 @@ func RegisterCell(
 
 	cellName := string(cell.Spec.Name)
 
-	cellMetadata := &clustermetadata.Cell{
-		Name:            cellName,
-		ServerAddresses: []string{cell.Spec.GlobalTopoServer.Address},
-		Root:            cell.Spec.GlobalTopoServer.RootPath,
-	}
+	cellMetadata := cellMetadataFromTopoRefs(cellName, cell.Spec.TopoServer, cell.Spec.GlobalTopoServer)
 
-	if err := store.CreateCell(ctx, cellName, cellMetadata); err != nil {
-		var topoErr topoclient.TopoError
-		if errors.As(err, &topoErr) && topoErr.Code == topoclient.NodeExists {
-			logger.V(1).Info("Cell already exists in topology; "+
-				"if cell config changed, manual topo cleanup may be required",
-				"cellName", cellName)
-			return nil
-		}
+	created, err := createOrUpdateCell(ctx, store, cellName, cellMetadata)
+	if err != nil {
 		recorder.Eventf(
 			cell,
 			"Warning",
@@ -45,7 +35,12 @@ func RegisterCell(
 			"Failed to register cell in topology: %v",
 			err,
 		)
-		return fmt.Errorf("failed to create cell in topology: %w", err)
+		return err
+	}
+
+	if !created {
+		logger.V(1).Info("Updated existing cell in topology", "cellName", cellName)
+		return nil
 	}
 
 	logger.Info("Cell metadata stored in topology", "cellName", cellName)
@@ -57,6 +52,58 @@ func RegisterCell(
 		cellName,
 	)
 	return nil
+}
+
+func cellMetadataFromTopoRefs(
+	cellName string,
+	localTopo *multigresv1alpha1.LocalTopoServerSpec,
+	globalTopo multigresv1alpha1.GlobalTopoServerRef,
+) *clustermetadata.Cell {
+	if localTopo != nil && localTopo.External != nil && len(localTopo.External.Endpoints) > 0 {
+		addresses := make([]string, 0, len(localTopo.External.Endpoints))
+		for _, endpoint := range localTopo.External.Endpoints {
+			addresses = append(addresses, string(endpoint))
+		}
+		return &clustermetadata.Cell{
+			Name:            cellName,
+			ServerAddresses: addresses,
+			Root:            localTopo.External.RootPath,
+		}
+	}
+
+	return &clustermetadata.Cell{
+		Name:            cellName,
+		ServerAddresses: []string{globalTopo.Address},
+		Root:            globalTopo.RootPath,
+	}
+}
+
+func createOrUpdateCell(
+	ctx context.Context,
+	store topoclient.Store,
+	cellName string,
+	cellMetadata *clustermetadata.Cell,
+) (bool, error) {
+	if err := store.CreateCell(ctx, cellName, cellMetadata); err != nil {
+		var topoErr topoclient.TopoError
+		if errors.As(err, &topoErr) && topoErr.Code == topoclient.NodeExists {
+			if err := store.UpdateCellFields(
+				ctx,
+				cellName,
+				func(existing *clustermetadata.Cell) error {
+					existing.Name = cellMetadata.Name
+					existing.ServerAddresses = cellMetadata.ServerAddresses
+					existing.Root = cellMetadata.Root
+					return nil
+				},
+			); err != nil {
+				return false, fmt.Errorf("updating existing cell %s in topology: %w", cellName, err)
+			}
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to create cell in topology: %w", err)
+	}
+	return true, nil
 }
 
 // UnregisterCell removes the cell metadata from the global topology.

--- a/pkg/data-handler/topo/cell_test.go
+++ b/pkg/data-handler/topo/cell_test.go
@@ -3,6 +3,7 @@ package topo_test
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -24,14 +25,24 @@ func newTestCell(name string) *multigresv1alpha1.Cell {
 				Address:  "localhost:2379",
 				RootPath: "/test",
 			},
+			TopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{
+					Endpoints: []multigresv1alpha1.EndpointUrl{
+						"http://local-etcd-1:2379",
+						"http://local-etcd-2:2379",
+					},
+					RootPath: "/multigres/cells/" + name,
+				},
+			},
 		},
 	}
 }
 
 type mockTopoStore struct {
 	topoclient.Store
-	createCellFunc func(ctx context.Context, cellName string, cell *clustermetadata.Cell) error
-	deleteCellFunc func(ctx context.Context, cellName string, force bool) error
+	createCellFunc       func(ctx context.Context, cellName string, cell *clustermetadata.Cell) error
+	updateCellFieldsFunc func(ctx context.Context, cellName string, updater func(*clustermetadata.Cell) error) error
+	deleteCellFunc       func(ctx context.Context, cellName string, force bool) error
 }
 
 func (m *mockTopoStore) CreateCell(
@@ -41,6 +52,17 @@ func (m *mockTopoStore) CreateCell(
 ) error {
 	if m.createCellFunc != nil {
 		return m.createCellFunc(ctx, cellName, cell)
+	}
+	return nil
+}
+
+func (m *mockTopoStore) UpdateCellFields(
+	ctx context.Context,
+	cellName string,
+	updater func(*clustermetadata.Cell) error,
+) error {
+	if m.updateCellFieldsFunc != nil {
+		return m.updateCellFieldsFunc(ctx, cellName, updater)
 	}
 	return nil
 }
@@ -78,6 +100,15 @@ func TestRegisterCell(t *testing.T) {
 		if got.Name != "cell2" {
 			t.Errorf("expected cell name cell2, got %s", got.Name)
 		}
+		if !reflect.DeepEqual(
+			got.ServerAddresses,
+			[]string{"http://local-etcd-1:2379", "http://local-etcd-2:2379"},
+		) {
+			t.Errorf("expected local topo addresses, got %v", got.ServerAddresses)
+		}
+		if got.Root != "/multigres/cells/cell2" {
+			t.Errorf("expected local topo root, got %s", got.Root)
+		}
 	})
 
 	t.Run("returns error on failure", func(t *testing.T) {
@@ -113,6 +144,75 @@ func TestRegisterCell(t *testing.T) {
 		}
 		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
 			t.Fatalf("second registration should succeed (idempotent), got: %v", err)
+		}
+	})
+
+	t.Run("updates stale cell topology on re-registration", func(t *testing.T) {
+		t.Parallel()
+		_, factory := memorytopo.NewServerAndFactory(context.Background(), "cell1")
+		store := topoclient.NewWithFactory(
+			factory, "", []string{""}, topoclient.NewDefaultTopoConfig(),
+		)
+		defer func() { _ = store.Close() }()
+
+		recorder := record.NewFakeRecorder(10)
+		cell := newTestCell("cell1")
+		if err := store.UpdateCellFields(
+			context.Background(),
+			"cell1",
+			func(existing *clustermetadata.Cell) error {
+				existing.ServerAddresses = []string{"http://stale-local-etcd:2379"}
+				existing.Root = "/stale/root"
+				return nil
+			},
+		); err != nil {
+			t.Fatalf("seeding stale cell: %v", err)
+		}
+
+		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+			t.Fatalf("re-registration should update stale cell, got: %v", err)
+		}
+
+		got, err := store.GetCell(context.Background(), "cell1")
+		if err != nil {
+			t.Fatalf("cell not found: %v", err)
+		}
+		if !reflect.DeepEqual(
+			got.ServerAddresses,
+			[]string{"http://local-etcd-1:2379", "http://local-etcd-2:2379"},
+		) {
+			t.Errorf("expected local topo addresses, got %v", got.ServerAddresses)
+		}
+		if got.Root != "/multigres/cells/cell1" {
+			t.Errorf("expected local topo root, got %s", got.Root)
+		}
+	})
+
+	t.Run("falls back to global topology when no local topology is configured", func(t *testing.T) {
+		t.Parallel()
+		_, factory := memorytopo.NewServerAndFactory(context.Background(), "cell1")
+		store := topoclient.NewWithFactory(
+			factory, "", []string{""}, topoclient.NewDefaultTopoConfig(),
+		)
+		defer func() { _ = store.Close() }()
+
+		recorder := record.NewFakeRecorder(10)
+		cell := newTestCell("cell2")
+		cell.Spec.TopoServer = nil
+
+		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got, err := store.GetCell(context.Background(), "cell2")
+		if err != nil {
+			t.Fatalf("cell not found: %v", err)
+		}
+		if !reflect.DeepEqual(got.ServerAddresses, []string{"localhost:2379"}) {
+			t.Errorf("expected global topo address fallback, got %v", got.ServerAddresses)
+		}
+		if got.Root != "/test" {
+			t.Errorf("expected global topo root fallback, got %s", got.Root)
 		}
 	})
 }

--- a/pkg/data-handler/topo/topology.go
+++ b/pkg/data-handler/topo/topology.go
@@ -106,34 +106,32 @@ func RegisterDatabaseFromSpec(
 	return nil
 }
 
-// RegisterCellFromSpec registers a cell in the topology using the cluster
-// spec. It uses the GlobalTopoServerRef to build the cell metadata.
+// RegisterCellFromSpec registers a cell in the global topology using the
+// cluster spec. The cell record points clients at the cell-local topology
+// server when one is configured, and falls back to the global topology for
+// existing clusters without local topology.
 func RegisterCellFromSpec(
 	ctx context.Context,
 	store topoclient.Store,
 	recorder record.EventRecorder,
 	owner runtime.Object,
 	cellConfig multigresv1alpha1.CellConfig,
+	localTopo *multigresv1alpha1.LocalTopoServerSpec,
 	topoRef multigresv1alpha1.GlobalTopoServerRef,
 ) error {
 	logger := log.FromContext(ctx)
 	cellName := string(cellConfig.Name)
 
-	cellMetadata := &clustermetadatapb.Cell{
-		Name:            cellName,
-		ServerAddresses: []string{topoRef.Address},
-		Root:            topoRef.RootPath,
+	cellMetadata := cellMetadataFromTopoRefs(cellName, localTopo, topoRef)
+
+	created, err := createOrUpdateCell(ctx, store, cellName, cellMetadata)
+	if err != nil {
+		return err
 	}
 
-	if err := store.CreateCell(ctx, cellName, cellMetadata); err != nil {
-		var topoErr topoclient.TopoError
-		if isNodeExists(err, &topoErr) {
-			logger.Info("Cell already registered in topology, skipping update "+
-				"(cell fields are immutable in v1alpha1)",
-				"cellName", cellName)
-			return nil
-		}
-		return fmt.Errorf("failed to create cell in topology: %w", err)
+	if !created {
+		logger.Info("Updated existing cell in topology", "cellName", cellName)
+		return nil
 	}
 
 	logger.Info("Cell metadata stored in topology", "cellName", cellName)

--- a/pkg/data-handler/topo/topology_test.go
+++ b/pkg/data-handler/topo/topology_test.go
@@ -407,11 +407,15 @@ func TestRegisterCellFromSpec(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 		ctx := context.Background()
 
-		if err := store.UpdateCellFields(ctx, "cell1", func(existing *clustermetadatapb.Cell) error {
-			existing.ServerAddresses = []string{"http://stale-cell1-local:2379"}
-			existing.Root = "/stale/cell1"
-			return nil
-		}); err != nil {
+		if err := store.UpdateCellFields(
+			ctx,
+			"cell1",
+			func(existing *clustermetadatapb.Cell) error {
+				existing.ServerAddresses = []string{"http://stale-cell1-local:2379"}
+				existing.Root = "/stale/cell1"
+				return nil
+			},
+		); err != nil {
 			t.Fatalf("seeding stale cell: %v", err)
 		}
 

--- a/pkg/data-handler/topo/topology_test.go
+++ b/pkg/data-handler/topo/topology_test.go
@@ -3,6 +3,7 @@ package topo_test
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -31,6 +32,7 @@ type mockTopologyStore struct {
 	createDatabaseFunc       func(ctx context.Context, dbName string, db *clustermetadatapb.Database) error
 	updateDatabaseFieldsFunc func(ctx context.Context, dbName string, updater func(*clustermetadatapb.Database) error) error
 	createCellFunc           func(ctx context.Context, cellName string, cell *clustermetadatapb.Cell) error
+	updateCellFieldsFunc     func(ctx context.Context, cellName string, updater func(*clustermetadatapb.Cell) error) error
 	getDatabaseNamesFunc     func(ctx context.Context) ([]string, error)
 	deleteDatabaseFunc       func(ctx context.Context, dbName string, force bool) error
 	getCellNamesFunc         func(ctx context.Context) ([]string, error)
@@ -68,6 +70,17 @@ func (s *mockTopologyStore) CreateCell(
 		return s.createCellFunc(ctx, cellName, cell)
 	}
 	return s.Store.CreateCell(ctx, cellName, cell)
+}
+
+func (s *mockTopologyStore) UpdateCellFields(
+	ctx context.Context,
+	cellName string,
+	updater func(*clustermetadatapb.Cell) error,
+) error {
+	if s.updateCellFieldsFunc != nil {
+		return s.updateCellFieldsFunc(ctx, cellName, updater)
+	}
+	return s.Store.UpdateCellFields(ctx, cellName, updater)
 }
 
 func (s *mockTopologyStore) GetDatabaseNames(ctx context.Context) ([]string, error) {
@@ -322,9 +335,15 @@ func TestRegisterCellFromSpec(t *testing.T) {
 		store := newMemoryStore(t, "cell1")
 		recorder := record.NewFakeRecorder(10)
 
+		localTopo := &multigresv1alpha1.LocalTopoServerSpec{
+			External: &multigresv1alpha1.ExternalTopoServerSpec{
+				Endpoints: []multigresv1alpha1.EndpointUrl{"http://cell2-local:2379"},
+				RootPath:  "/multigres/cells/cell2",
+			},
+		}
 		cellCfg := multigresv1alpha1.CellConfig{Name: "cell2"} // cell2 does not exist yet!
 		err := topo.RegisterCellFromSpec(
-			context.Background(), store, recorder, owner, cellCfg, topoRef,
+			context.Background(), store, recorder, owner, cellCfg, localTopo, topoRef,
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -337,6 +356,12 @@ func TestRegisterCellFromSpec(t *testing.T) {
 		if cell.Name != "cell2" {
 			t.Errorf("expected cell2, got %s", cell.Name)
 		}
+		if !reflect.DeepEqual(cell.ServerAddresses, []string{"http://cell2-local:2379"}) {
+			t.Errorf("expected local topo addresses, got %v", cell.ServerAddresses)
+		}
+		if cell.Root != "/multigres/cells/cell2" {
+			t.Errorf("expected local topo root, got %s", cell.Root)
+		}
 	})
 
 	t.Run("idempotent on re-registration", func(t *testing.T) {
@@ -346,12 +371,19 @@ func TestRegisterCellFromSpec(t *testing.T) {
 		ctx := context.Background()
 
 		cellCfg := multigresv1alpha1.CellConfig{Name: "cell1"}
+		localTopo := &multigresv1alpha1.LocalTopoServerSpec{
+			External: &multigresv1alpha1.ExternalTopoServerSpec{
+				Endpoints: []multigresv1alpha1.EndpointUrl{"http://cell1-local:2379"},
+				RootPath:  "/multigres/cells/cell1",
+			},
+		}
 		if err := topo.RegisterCellFromSpec(
 			ctx,
 			store,
 			recorder,
 			owner,
 			cellCfg,
+			localTopo,
 			topoRef,
 		); err != nil {
 			t.Fatalf("first: %v", err)
@@ -362,9 +394,90 @@ func TestRegisterCellFromSpec(t *testing.T) {
 			recorder,
 			owner,
 			cellCfg,
+			localTopo,
 			topoRef,
 		); err != nil {
 			t.Fatalf("second: %v", err)
+		}
+	})
+
+	t.Run("updates stale cell topology on re-registration", func(t *testing.T) {
+		t.Parallel()
+		store := newMemoryStore(t, "cell1")
+		recorder := record.NewFakeRecorder(10)
+		ctx := context.Background()
+
+		if err := store.UpdateCellFields(ctx, "cell1", func(existing *clustermetadatapb.Cell) error {
+			existing.ServerAddresses = []string{"http://stale-cell1-local:2379"}
+			existing.Root = "/stale/cell1"
+			return nil
+		}); err != nil {
+			t.Fatalf("seeding stale cell: %v", err)
+		}
+
+		localTopo := &multigresv1alpha1.LocalTopoServerSpec{
+			External: &multigresv1alpha1.ExternalTopoServerSpec{
+				Endpoints: []multigresv1alpha1.EndpointUrl{
+					"http://cell1-local-a:2379",
+					"http://cell1-local-b:2379",
+				},
+				RootPath: "/multigres/cells/cell1",
+			},
+		}
+		if err := topo.RegisterCellFromSpec(
+			ctx,
+			store,
+			recorder,
+			owner,
+			multigresv1alpha1.CellConfig{Name: "cell1"},
+			localTopo,
+			topoRef,
+		); err != nil {
+			t.Fatalf("re-registration should update stale cell, got: %v", err)
+		}
+
+		cell, err := store.GetCell(ctx, "cell1")
+		if err != nil {
+			t.Fatalf("cell not found: %v", err)
+		}
+		if !reflect.DeepEqual(
+			cell.ServerAddresses,
+			[]string{"http://cell1-local-a:2379", "http://cell1-local-b:2379"},
+		) {
+			t.Errorf("expected local topo addresses, got %v", cell.ServerAddresses)
+		}
+		if cell.Root != "/multigres/cells/cell1" {
+			t.Errorf("expected local topo root, got %s", cell.Root)
+		}
+	})
+
+	t.Run("falls back to global topology when no local topology is configured", func(t *testing.T) {
+		t.Parallel()
+		store := newMemoryStore(t, "cell1")
+		recorder := record.NewFakeRecorder(10)
+
+		err := topo.RegisterCellFromSpec(
+			context.Background(),
+			store,
+			recorder,
+			owner,
+			multigresv1alpha1.CellConfig{Name: "cell2"},
+			nil,
+			topoRef,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cell, err := store.GetCell(context.Background(), "cell2")
+		if err != nil {
+			t.Fatalf("cell not found: %v", err)
+		}
+		if !reflect.DeepEqual(cell.ServerAddresses, []string{"global:2379"}) {
+			t.Errorf("expected global topo address fallback, got %v", cell.ServerAddresses)
+		}
+		if cell.Root != "/multigres/global" {
+			t.Errorf("expected global topo root fallback, got %s", cell.Root)
 		}
 	})
 
@@ -378,7 +491,7 @@ func TestRegisterCellFromSpec(t *testing.T) {
 
 		err := topo.RegisterCellFromSpec(
 			context.Background(), store, record.NewFakeRecorder(10), owner,
-			multigresv1alpha1.CellConfig{Name: "cell1"}, topoRef,
+			multigresv1alpha1.CellConfig{Name: "cell1"}, nil, topoRef,
 		)
 		if err == nil {
 			t.Fatal("expected error, got nil")
@@ -535,7 +648,7 @@ func TestPruneCells(t *testing.T) {
 		for _, c := range []string{"cell1", "cell2"} {
 			if err := topo.RegisterCellFromSpec(
 				ctx, store, recorder, owner,
-				multigresv1alpha1.CellConfig{Name: multigresv1alpha1.CellName(c)}, topoRef,
+				multigresv1alpha1.CellConfig{Name: multigresv1alpha1.CellName(c)}, nil, topoRef,
 			); err != nil {
 				t.Fatalf("registering %s: %v", c, err)
 			}
@@ -562,7 +675,7 @@ func TestPruneCells(t *testing.T) {
 
 		if err := topo.RegisterCellFromSpec(
 			ctx, store, recorder, owner,
-			multigresv1alpha1.CellConfig{Name: "cell1"}, topoRef,
+			multigresv1alpha1.CellConfig{Name: "cell1"}, nil, topoRef,
 		); err != nil {
 			t.Fatalf("registering: %v", err)
 		}


### PR DESCRIPTION
## Description

this pr adds operator-side support for shared topology layouts where Multigres components use a shared global topology server and each Cell points to its own local topology root. The operator now registers global Cell records with the resolved local topology endpoint/root, while keeping cluster level Database records in global topology.

## Main Changes

- Register Cell metadata using the cell’s local topology config when available, falling back to global topology for existing/default behaviour.
- Make Cell registration idempotent by updating stale existing Cell records during reconciliation.
- Resolve cell topology templates/defaults during MultigresCluster topology reconciliation before writing Cell records.
- Add tests for shared topo registration, stale Cell updates, fallback behaviour, and global Database registration.

## Testing

Tests cover direct Cell registration, repeated reconciliation against existing topology records, fallback behaviour when no local topology is configured, and the cluster-level reconciliation path that registers Cells and Databases together.


