### PR TITLE
feat(gc): add garbage collector for orphaned multigres resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ COPY . .
 # Build using Go's native cross-compiler (CGO_ENABLED=0).
 # --platform=$BUILDPLATFORM on the FROM makes this stage run on the host arch
 # (amd64) even when targeting arm64, avoiding slow QEMU emulation.
+#
+# We produce two static binaries from the same source tree so the same image
+# can be used as the operator's deployment AND as the CronJob that runs the
+# multigres garbage collector (cmd/multigres-gc).
 RUN CGO_ENABLED=0 \
 	GOOS=${TARGETOS:-linux} \
 	GOARCH=${TARGETARCH} \
@@ -37,6 +41,18 @@ RUN CGO_ENABLED=0 \
 	-a -o manager \
 	cmd/multigres-operator/main.go
 
+RUN CGO_ENABLED=0 \
+	GOOS=${TARGETOS:-linux} \
+	GOARCH=${TARGETARCH} \
+	go build \
+	-ldflags "-s -w -buildid= \
+	-X main.version=${VERSION} \
+	-X main.gitCommit=${GIT_COMMIT} \
+	-X main.buildDate=${BUILD_DATE}" \
+	-trimpath -mod=readonly \
+	-a -o multigres-gc \
+	cmd/multigres-gc/main.go
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
@@ -44,6 +60,7 @@ FROM gcr.io/distroless/static:nonroot
 LABEL org.opencontainers.image.source="https://github.com/multigres/multigres-operator"
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/multigres-gc .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,11 @@ build: manifests generate fmt vet ## Build manager binary with version metadata
 	@echo "==> Building operator binary (version: $(VERSION))"
 	go build -ldflags="$(LDFLAGS)" -o bin/multigres-operator cmd/multigres-operator/main.go
 
+.PHONY: build-multigres-gc
+build-multigres-gc: fmt vet ## Build the multigres garbage-collector binary
+	@echo "==> Building multigres-gc binary (version: $(VERSION))"
+	go build -ldflags="$(LDFLAGS)" -o bin/multigres-gc cmd/multigres-gc/main.go
+
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/multigres-operator/main.go

--- a/cmd/multigres-gc/main.go
+++ b/cmd/multigres-gc/main.go
@@ -1,0 +1,136 @@
+// The multigres-gc command runs a one-shot clean of orphaned multigres resources.
+//
+// It is intended to be invoked from a k8s cronjob, separate from the
+// operator's reconcile loop. New resource types are added by implementing
+// gc.Cleankeeper and registering them in registerCleankeepers().
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/multigres/multigres-operator/pkg/gc"
+	gcpvc "github.com/multigres/multigres-operator/pkg/gc/pvc"
+)
+
+var (
+	// Set via -ldflags at build time.
+	version   = "dev"
+	buildDate = "unknown"
+	gitCommit = "unknown"
+
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("multigres-gc")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+}
+
+func main() {
+	var (
+		retention time.Duration
+		namespace string
+		dryRun    bool
+	)
+
+	flag.DurationVar(&retention, "retention", 30*24*time.Hour,
+		"Minimum age of the orphan label before a resource is deleted "+
+			"(e.g. 720h for 30d). 0 means delete as soon as an object is "+
+			"marked orphan. Negative values are rejected.")
+	flag.StringVar(&namespace, "namespace", "",
+		"Restrict the clean to a single namespace. Empty means all namespaces.")
+	flag.BoolVar(&dryRun, "dry-run", false,
+		"Log what would be deleted without actually deleting.")
+
+	zapOpts := zap.Options{Development: false}
+	zapOpts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
+
+	if retention < 0 {
+		setupLog.Error(
+			fmt.Errorf("invalid retention %s", retention),
+			"--retention must be >= 0 (0 means delete as soon as an object is marked orphan)",
+		)
+		os.Exit(1)
+	}
+
+	setupLog.Info("starting multigres garbage collector",
+		"version", version,
+		"buildDate", buildDate,
+		"gitCommit", gitCommit,
+		"retention", retention.String(),
+		"namespace", namespaceOrAll(namespace),
+		"dry_run", dryRun,
+	)
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		setupLog.Error(err, "failed to load kubernetes config")
+		os.Exit(1)
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "failed to build kubernetes client")
+		os.Exit(1)
+	}
+
+	opts := gc.Options{
+		Retention: retention,
+		Namespace: namespace,
+		DryRun:    dryRun,
+	}
+
+	cleankeepers := registerCleankeepers(c, setupLog, opts)
+	ctx := ctrl.SetupSignalHandler()
+
+	exit := 0
+	for _, ck := range cleankeepers {
+		log := setupLog.WithValues("kind", ck.Kind())
+		res, err := ck.Clean(ctx)
+		if err != nil {
+			log.Error(err, "clean aborted")
+			exit = 1
+			continue
+		}
+		if res.Errors > 0 {
+			log.Info("clean finished with per-object errors", "errors", res.Errors)
+			if exit == 0 {
+				exit = 2
+			}
+		}
+	}
+
+	os.Exit(exit)
+}
+
+// registerCleankeepers returns the list of cleankeepers run on each invocation.
+// Add new resource kinds here.
+func registerCleankeepers(c client.Client, log logr.Logger, opts gc.Options) []gc.Cleankeeper {
+	return []gc.Cleankeeper{
+		gcpvc.New(c, log, opts),
+	}
+}
+
+func namespaceOrAll(ns string) string {
+	if ns == "" {
+		return "<all>"
+	}
+	return ns
+}

--- a/pkg/gc/gc.go
+++ b/pkg/gc/gc.go
@@ -1,0 +1,59 @@
+// Package gc provides the generic garbage-collector framework used by the
+// multigres-gc binary.
+//
+// Each resource type that needs cleaning (PVCs today, more later) implements
+// the Cleankeeper interface in its own sub-package. The binary discovers
+// cleankeepers at startup, invokes Clean on each, and aggregates Results.
+package gc
+
+import (
+	"context"
+	"time"
+)
+
+// Options is the common configuration passed to every Cleankeeper.
+type Options struct {
+	// Retention is the minimum age (now - orphan-since date) before a resource is deleted.
+	Retention time.Duration
+
+	// Namespace restricts the clean to a single namespace. Empty means all.
+	Namespace string
+	DryRun    bool
+
+	// Now allows tests to inject a fixed clock. Defaults to time.Now.
+	Now func() time.Time
+}
+
+// WithDefaults returns a copy of o with required defaults applied.
+func (o Options) WithDefaults() Options {
+	if o.Now == nil {
+		o.Now = time.Now
+	}
+	return o
+}
+
+// Results summarises a single Clean over one resource kind.
+type Results struct {
+	Kind    string
+	Scanned int
+	Deleted int
+	// WouldDelete is the number of objects that would have been deleted in dry-run.
+	WouldDelete int
+	Skipped     int
+	// Malformed is the number of objects whose orphan label could not be parsed.
+	Malformed int
+	Errors    int
+}
+
+// Cleankeeper deletes orphaned resources of one kind.
+//
+// Implementations should be cheap to construct. Clean does all the work.
+// A non-nil error from Clean aborts that resource kind only; main keeps
+// running other Cleankeepers.
+type Cleankeeper interface {
+	// Kind returns the short identifier for the resource type (e.g. "pvc").
+	Kind() string
+
+	// Clean performs one pass and returns its results.
+	Clean(ctx context.Context) (*Results, error)
+}

--- a/pkg/gc/pvc/pvc.go
+++ b/pkg/gc/pvc/pvc.go
@@ -1,0 +1,153 @@
+// Package pvc implements the gc.Cleankeeper for orphaned PersistentVolumeClaims.
+//
+// A PVC is eligible for garbage collection when it carries both:
+//
+//   - app.kubernetes.io/managed-by = multigres-operator
+//   - multigres.com/orphan-since   = <UTC timestamp, OrphanTimestampFormat>
+//
+// PVCs whose orphan-since timestamp is older than the configured retention are
+// deleted, which (assuming the StorageClass reclaim policy is Delete) also
+// reclaims the underlying backend volume.
+package pvc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/multigres/multigres-operator/pkg/gc"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+// ObjectKind is the short identifier used in logs and Results.
+const ObjectKind = "pvc"
+
+type Cleankeeper struct {
+	c    client.Client
+	log  logr.Logger
+	opts gc.Options
+}
+
+func New(c client.Client, log logr.Logger, opts gc.Options) *Cleankeeper {
+	return &Cleankeeper{
+		c:    c,
+		log:  log.WithValues("cleankeeper", ObjectKind),
+		opts: opts.WithDefaults(),
+	}
+}
+
+func (s *Cleankeeper) Kind() string { return ObjectKind }
+
+func (s *Cleankeeper) Clean(ctx context.Context) (*gc.Results, error) {
+	sel, err := buildSelector()
+	if err != nil {
+		return nil, fmt.Errorf("build label selector: %w", err)
+	}
+
+	var pvcs corev1.PersistentVolumeClaimList
+	listOpts := &client.ListOptions{
+		LabelSelector: sel,
+		Namespace:     s.opts.Namespace,
+	}
+	if err := s.c.List(ctx, &pvcs, listOpts); err != nil {
+		return nil, fmt.Errorf("list PVCs: %w", err)
+	}
+
+	res := &gc.Results{Kind: ObjectKind, Scanned: len(pvcs.Items)}
+	cutoff := s.opts.Now().Add(-s.opts.Retention)
+
+	for i := range pvcs.Items {
+		s.processPVC(ctx, &pvcs.Items[i], cutoff, res)
+	}
+
+	s.log.Info("clean complete",
+		"scanned", res.Scanned,
+		"deleted", res.Deleted,
+		"would_delete", res.WouldDelete,
+		"skipped", res.Skipped,
+		"malformed", res.Malformed,
+		"errors", res.Errors,
+		"dry_run", s.opts.DryRun,
+	)
+	return res, nil
+}
+
+func (s *Cleankeeper) processPVC(
+	ctx context.Context,
+	pvc *corev1.PersistentVolumeClaim,
+	cutoff time.Time,
+	res *gc.Results,
+) {
+	log := s.log.WithValues("namespace", pvc.Namespace, "name", pvc.Name)
+
+	raw, ok := pvc.Labels[metadata.LabelOrphan]
+	if !ok {
+		// Selector guarantees presence; treat as malformed if absent.
+		log.Info("orphan label missing despite selector match")
+		res.Malformed++
+		return
+	}
+
+	orphanedAt, err := time.Parse(metadata.OrphanTimestampFormat, raw)
+	if err != nil {
+		log.Info("malformed orphan label, skipping", "value", raw, "error", err.Error())
+		res.Malformed++
+		return
+	}
+
+	if orphanedAt.After(cutoff) {
+		log.V(1).Info("PVC inside retention window, skipping", "orphaned_at", raw)
+		res.Skipped++
+		return
+	}
+
+	if s.opts.DryRun {
+		log.Info("would delete orphaned PVC", "orphaned_at", raw)
+		res.WouldDelete++
+		return
+	}
+
+	// Use the observed resourceVersion as a precondition so we don't race with
+	// the operator re-adopting a PVC between List and Delete.
+	preconditions := client.Preconditions{
+		ResourceVersion: &pvc.ResourceVersion,
+	}
+	if err := s.c.Delete(ctx, pvc, preconditions); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("PVC already gone, skipping")
+			return
+		}
+		log.Error(err, "failed to delete PVC")
+		res.Errors++
+		return
+	}
+	log.Info("deleted orphaned PVC", "orphaned_at", raw)
+	res.Deleted++
+}
+
+func buildSelector() (labels.Selector, error) {
+	managedReq, err := labels.NewRequirement(
+		metadata.LabelAppManagedBy,
+		selection.Equals,
+		[]string{metadata.ManagedByMultigres},
+	)
+	if err != nil {
+		return nil, err
+	}
+	orphanReq, err := labels.NewRequirement(
+		metadata.LabelOrphan,
+		selection.Exists,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return labels.NewSelector().Add(*managedReq, *orphanReq), nil
+}

--- a/pkg/gc/pvc/pvc_test.go
+++ b/pkg/gc/pvc/pvc_test.go
@@ -1,0 +1,181 @@
+package pvc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/multigres/multigres-operator/pkg/gc"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+const (
+	tsOld    = "2026-01-01T00-00-00Z" // way past retention
+	tsRecent = "2026-05-10T00-00-00Z" // inside retention
+	tsNow    = "2026-05-15T00-00-00Z"
+)
+
+func pvc(name string, lbls map[string]string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns1", Labels: lbls},
+	}
+}
+
+func orphanLabels(ts string) map[string]string {
+	return map[string]string{
+		metadata.LabelAppManagedBy: metadata.ManagedByMultigres,
+		metadata.LabelOrphan:       ts,
+	}
+}
+
+// run builds a fake client + Cleankeeper and invokes Clean. Returns Results.
+func run(
+	t *testing.T,
+	opts gc.Options,
+	interceptors interceptor.Funcs,
+	objs ...client.Object,
+) (*gc.Results, client.Client) {
+	t.Helper()
+	scheme := clientgoscheme.Scheme
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithInterceptorFuncs(interceptors).
+		Build()
+	if opts.Now == nil {
+		opts.Now = parseNow(t, tsNow)
+	}
+	if opts.Retention == 0 {
+		opts.Retention = 30 * 24 * time.Hour
+	}
+	res, err := New(cl, testr.New(t), opts).Clean(context.Background())
+	require.NoError(t, err)
+	return res, cl
+}
+
+func parseNow(t *testing.T, s string) func() time.Time {
+	t.Helper()
+	ts, err := time.Parse(metadata.OrphanTimestampFormat, s)
+	require.NoError(t, err)
+	return func() time.Time { return ts }
+}
+
+func TestClean_DeletesExpiredOnly(t *testing.T) {
+	t.Parallel()
+
+	res, cl := run(
+		t,
+		gc.Options{},
+		interceptor.Funcs{},
+		pvc("old", orphanLabels(tsOld)),       // eligible
+		pvc("recent", orphanLabels(tsRecent)), // inside window
+		pvc("unmanaged", map[string]string{metadata.LabelOrphan: tsOld}),
+		pvc(
+			"unlabeled",
+			map[string]string{metadata.LabelAppManagedBy: metadata.ManagedByMultigres},
+		),
+	)
+
+	require.Equal(t, ObjectKind, res.Kind)
+	require.Equal(t, 2, res.Scanned)
+	require.Equal(t, 1, res.Deleted)
+	require.Equal(t, 1, res.Skipped)
+	require.Zero(t, res.Errors+res.Malformed+res.WouldDelete)
+
+	require.True(t, apierrors.IsNotFound(
+		cl.Get(
+			context.Background(),
+			client.ObjectKey{Namespace: "ns1", Name: "old"},
+			&corev1.PersistentVolumeClaim{},
+		),
+	))
+}
+
+func TestClean_DryRun(t *testing.T) {
+	t.Parallel()
+
+	res, _ := run(t, gc.Options{DryRun: true}, interceptor.Funcs{},
+		pvc("old", orphanLabels(tsOld)),
+	)
+
+	require.Equal(t, 1, res.WouldDelete)
+	require.Zero(t, res.Deleted)
+}
+
+func TestClean_MalformedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	res, _ := run(t, gc.Options{}, interceptor.Funcs{},
+		pvc("bad", orphanLabels("not-a-timestamp")),
+	)
+
+	require.Equal(t, 1, res.Malformed)
+	require.Zero(t, res.Deleted)
+}
+
+func TestClean_NamespaceScope(t *testing.T) {
+	t.Parallel()
+
+	a := pvc("a", orphanLabels(tsOld))
+	b := pvc("b", orphanLabels(tsOld))
+	b.Namespace = "ns2"
+
+	res, _ := run(t, gc.Options{Namespace: "ns1"}, interceptor.Funcs{}, a, b)
+
+	require.Equal(t, 1, res.Scanned)
+	require.Equal(t, 1, res.Deleted)
+}
+
+func TestClean_DeleteErrorCounted(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("api server unavailable")
+	res, _ := run(t, gc.Options{}, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			return boom
+		},
+	}, pvc("old", orphanLabels(tsOld)))
+
+	require.Equal(t, 1, res.Errors)
+	require.Zero(t, res.Deleted)
+}
+
+func TestClean_NotFoundIsNotError(t *testing.T) {
+	t.Parallel()
+
+	res, _ := run(t, gc.Options{}, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			return apierrors.NewNotFound(corev1.Resource("persistentvolumeclaims"), obj.GetName())
+		},
+	}, pvc("old", orphanLabels(tsOld)))
+
+	require.Zero(t, res.Errors)
+}
+
+// Pinpoint regression: a PVC orphaned later in the day must NOT be deleted
+// until a full retention has elapsed from that exact timestamp.
+func TestClean_SameDayPrecision(t *testing.T) {
+	t.Parallel()
+
+	res, _ := run(t, gc.Options{
+		Retention: 30 * 24 * time.Hour,
+		Now:       parseNow(t, "2026-05-15T12-00-00Z"),
+	}, interceptor.Funcs{}, pvc("borderline", orphanLabels("2026-04-15T18-00-00Z")))
+
+	require.Equal(t, 1, res.Skipped)
+	require.Zero(t, res.Deleted)
+}
+
+// Static check that *Cleankeeper satisfies gc.Cleankeeper.
+var _ gc.Cleankeeper = (*Cleankeeper)(nil)

--- a/pkg/util/metadata/labels.go
+++ b/pkg/util/metadata/labels.go
@@ -125,6 +125,14 @@ const (
 	// Used as the durable signal for DRAINED PVC cleanup, since PodRoles may be
 	// cleared by the data-handler during drain before cleanup runs.
 	LabelPodRole = "multigres.com/role"
+
+	// LabelOrphan marks a resource as orphaned (no longer referenced by an owner)
+	// and eligible for garbage collection. Value is the UTC timestamp when the
+	// resource became orphaned, formatted as OrphanTimestampFormat.
+	LabelOrphan = "multigres.com/orphan-since"
+
+	// OrphanTimestampFormat is the layout used for LabelOrphan values (RFC 3339).
+	OrphanTimestampFormat = "2006-01-02T15-04-05Z"
 )
 
 const (


### PR DESCRIPTION
- Introduce pkg/gc with a pluggable Cleankeeper interface so additional resource kinds can be added with minimal effort.
- Add pkg/gc/pvc Cleankeeper that deletes PVCs labeled `app.kubernetes.io/managed-by=multigres-operator` and `multigres.com/orphan-since=<YYYY-MM-DD>` once past the configured retention window (default 30d), with a resourceVersion precondition to avoid racing with operator re-adoption.
- Add `cmd/multigres-gc`, a standalone one-shot binary intended to be invoked from a cronjob (to be added in a follow-up PR).
- Build multigres-gc alongside manager in the Dockerfile and expose a build-multigres-gc Makefile target.
- Add multigres.com/orphan-since label and OrphanDateFormat constants in `pkg/util/metadata`.