### PR TITLE
feat(gc): run multigres-gc as daily cronjob

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../gc
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - ../webhook

--- a/config/gc/clusterrole.yaml
+++ b/config/gc/clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: multigres-operator
+    app.kubernetes.io/component: gc
+    app.kubernetes.io/managed-by: kustomize
+  name: gc-role
+rules:
+# multigres-gc only needs to list orphaned PVCs and delete them.
+# Scoped cluster-wide because PVCs live in user namespaces.
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - list
+  - delete

--- a/config/gc/clusterrolebinding.yaml
+++ b/config/gc/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: multigres-operator
+    app.kubernetes.io/component: gc
+    app.kubernetes.io/managed-by: kustomize
+  name: gc-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gc-role
+subjects:
+- kind: ServiceAccount
+  name: gc
+  namespace: multigres-operator

--- a/config/gc/cronjob.yaml
+++ b/config/gc/cronjob.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gc
+  namespace: multigres-operator
+  labels:
+    app.kubernetes.io/name: multigres-operator
+    app.kubernetes.io/component: gc
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  # Daily at 02:00 UTC (Off-peak for most regions).
+  schedule: "0 2 * * *"
+  timeZone: Etc/UTC
+  # Forbid prevents overlap if a previous run is still going (it shouldn't, but cheap insurance).
+  concurrencyPolicy: Forbid
+  # If a scheduled run is missed (controller-manager down, cluster paused, etc.), only honour it
+  # within this window. Avoids a thundering catch-up after a long outage.
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      # No retry, next daily run will pick up whatever was missed.
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: multigres-operator
+            app.kubernetes.io/component: gc
+        spec:
+          serviceAccountName: gc
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 30
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+          - name: multigres-gc
+            # Same image as the operator; the Dockerfile bundles both binaries.
+            # Image tag is overridden via kustomize `images` in this kustomization.
+            image: controller:latest
+            command:
+            - /multigres-gc
+            args:
+            - --retention=720h
+            - --zap-log-level=info
+            securityContext:
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - "ALL"
+            resources:
+              limits:
+                cpu: 200m
+                memory: 128Mi
+              requests:
+                cpu: 10m
+                memory: 32Mi

--- a/config/gc/kustomization.yaml
+++ b/config/gc/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: multigres-operator
+
+resources:
+- serviceaccount.yaml
+- clusterrole.yaml
+- clusterrolebinding.yaml
+- cronjob.yaml
+
+images:
+- name: controller
+  newName: ghcr.io/multigres/multigres-operator
+  newTag: latest

--- a/config/gc/serviceaccount.yaml
+++ b/config/gc/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: multigres-operator
+    app.kubernetes.io/component: gc
+    app.kubernetes.io/managed-by: kustomize
+  name: gc
+  namespace: multigres-operator


### PR DESCRIPTION
- Add config/gc kustomize overlay: dedicated ServiceAccount, minimal ClusterRole (persistentvolumeclaims: list, delete) and ClusterRoleBinding, plus a cj that runs multigres-gc daily at 02:00 UTC with the default 720h retention (30 days).
- Use Forbid concurrencyPolicy, startingDeadlineSeconds=300, backoffLimit=0 and ttlSecondsAfterFinished=86400 so missed runs do not pile up and old Jobs are cleaned automatically
- Wire ../gc into config/default/kustomization.yaml so the CronJob is installed alongside the operator