### PR TITLE
feat(shard): orphan PVCs instead of deleting them on small shards

### DIFF
--- a/pkg/resource-handler/controller/shard/reconcile_deletion.go
+++ b/pkg/resource-handler/controller/shard/reconcile_deletion.go
@@ -3,6 +3,8 @@ package shard
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/multigres/multigres/go/common/topoclient"
@@ -17,6 +19,7 @@ import (
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/data-handler/drain"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
+	pvcutil "github.com/multigres/multigres-operator/pkg/util/pvc"
 	"github.com/multigres/multigres-operator/pkg/util/status"
 )
 
@@ -25,6 +28,10 @@ const (
 	// in Terminating state before considering it gone. This prevents
 	// shard deletion from blocking indefinitely on a dead kubelet.
 	terminatingTimeout = 60 * time.Second
+
+	// podTerminationRequeueDelay is how long to wait between checks for pods
+	// to finish terminating during Shard deletion, before PVCs are cleaned up.
+	podTerminationRequeueDelay = 2 * time.Second
 )
 
 // handleDeletion performs best-effort cleanup when a Shard is deleted.
@@ -73,12 +80,12 @@ func (r *ShardReconciler) handleDeletion(
 		}
 	}
 
-	// PVCs are handled by Kubernetes GC via conditional ownerRefs set during
-	// normal reconciliation (reconcilePVCOwnerRefs). When PVCDeletionPolicy is
-	// Delete, PVCs have controller ownerRefs and are cascade-deleted with the
-	// Shard. When Retain, PVCs have no ownerRefs and survive deletion.
-
-	// Best-effort pod deletion. Without finalizers, pods are deleted directly.
+	// Delete pods before touching PVCs. A PVC must not be handed to the
+	// multigres-gc CronJob (or deleted in-line) while a pod still references
+	// it: if the pod deletion is stuck (e.g. unhealthy node), GC could delete
+	// the backing volume out from under a pod object Kubernetes still tracks.
+	// We delete every pod, then requeue until they are all actually gone; the
+	// finalizer keeps the Shard CR around until that happens.
 	podList := &corev1.PodList{}
 	if err := r.List(
 		ctx,
@@ -88,17 +95,138 @@ func (r *ShardReconciler) handleDeletion(
 	); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list pods for deletion: %w", err)
 	}
+	blocking := 0
 	for i := range podList.Items {
 		pod := &podList.Items[i]
 		if pod.DeletionTimestamp.IsZero() {
 			if err := r.Delete(ctx, pod); err != nil && !errors.IsNotFound(err) {
 				return ctrl.Result{}, fmt.Errorf("failed to delete pod %s: %w", pod.Name, err)
 			}
+			blocking++
+			continue
+		}
+		// Pod is terminating. Treat it as gone once it has been stuck past
+		// terminatingTimeout (e.g. dead kubelet), so a single unhealthy node
+		// cannot block Shard deletion indefinitely.
+		if time.Since(pod.DeletionTimestamp.Time) < terminatingTimeout {
+			blocking++
+		} else {
+			logger.Info("Pod stuck terminating, proceeding with PVC cleanup",
+				"pod", pod.Name, "terminatingSince", pod.DeletionTimestamp.Time)
+		}
+	}
+	if blocking > 0 {
+		logger.Info(
+			"Waiting for pods to terminate before cleaning up PVCs",
+			"remaining", blocking,
+		)
+		return ctrl.Result{RequeueAfter: podTerminationRequeueDelay}, nil
+	}
+
+	// All pods gone. Clean up PVCs whose policy resolves to Delete. Small
+	// shards (<= pvcOrphanReplicasThreshold replicas) defer the work to
+	// multigres-gc by labelling the PVC with multigres.com/orphan-since=<now>,
+	// larger shards are deleted in-line.
+	if err := r.cleanupShardPVCs(ctx, shard); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Remove the finalizer last so Kubernetes can finish deletion now that the
+	// PVC cleanup has run.
+	if slices.Contains(shard.Finalizers, shardFinalizer) {
+		patch := client.MergeFrom(shard.DeepCopy())
+		shard.Finalizers = slices.DeleteFunc(shard.Finalizers, func(s string) bool {
+			return s == shardFinalizer
+		})
+		if err := r.Patch(ctx, shard, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove shard finalizer: %w", err)
 		}
 	}
 
 	logger.Info("Shard best-effort cleanup complete")
 	return ctrl.Result{}, nil
+}
+
+// cleanupShardPVCs handles per-PVC cleanup when a Shard is being deleted.
+// Only PVCs whose effective WhenDeleted policy is Delete are touched.
+func (r *ShardReconciler) cleanupShardPVCs(
+	ctx context.Context,
+	shard *multigresv1alpha1.Shard,
+) error {
+	logger := log.FromContext(ctx)
+
+	selector := map[string]string{
+		metadata.LabelMultigresCluster:    shard.Labels[metadata.LabelMultigresCluster],
+		metadata.LabelMultigresDatabase:   string(shard.Spec.DatabaseName),
+		metadata.LabelMultigresTableGroup: string(shard.Spec.TableGroupName),
+		metadata.LabelMultigresShard:      string(shard.Spec.ShardName),
+	}
+
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(
+		ctx,
+		pvcList,
+		client.InNamespace(shard.Namespace),
+		client.MatchingLabels(selector),
+	); err != nil {
+		return fmt.Errorf("failed to list PVCs for cleanup: %w", err)
+	}
+
+	// Group eligible PVCs by pool+cell so the keep-threshold decision is made
+	// per group (matching replicasPerCell semantics).
+	groups := map[string][]*corev1.PersistentVolumeClaim{}
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+		if !shardPVCShouldBeCleaned(shard, pvc) {
+			continue
+		}
+		key := pvc.Labels[metadata.LabelMultigresPool] + "/" + pvc.Labels[metadata.LabelMultigresCell]
+		groups[key] = append(groups[key], pvc)
+	}
+
+	now := time.Now()
+	for _, group := range groups {
+		// Sort descending by name so the highest-ordinal PVCs are visited first
+		// and become the deleted excess, the lowest are kept as orphans.
+		slices.SortFunc(group, func(a, b *corev1.PersistentVolumeClaim) int {
+			return strings.Compare(b.Name, a.Name)
+		})
+		live := len(group)
+		for _, pvc := range group {
+			_, hasIndex := resolvePodIndex(pvc.Name)
+			if !hasIndex || orphanByRemainingCount(live) {
+				if err := pvcutil.MarkOrphan(ctx, r.Client, pvc, shard.GetUID(), now); err != nil {
+					return fmt.Errorf("failed to mark PVC %s orphan: %w", pvc.Name, err)
+				}
+				logger.Info("Marked PVC orphan on Shard deletion", "pvc", pvc.Name)
+				live--
+				continue
+			}
+			if err := r.Delete(ctx, pvc); err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete PVC %s: %w", pvc.Name, err)
+			}
+			logger.Info("Deleted PVC on Shard deletion", "pvc", pvc.Name)
+			live--
+		}
+	}
+	return nil
+}
+
+// shardPVCShouldBeCleaned returns true when the PVC's effective
+// PVCDeletionPolicy (WhenDeleted) resolves to Delete.
+func shardPVCShouldBeCleaned(
+	shard *multigresv1alpha1.Shard,
+	pvc *corev1.PersistentVolumeClaim,
+) bool {
+	poolName := pvc.Labels[metadata.LabelMultigresPool]
+	if poolName == "" {
+		return ShouldDeleteShardLevelPVCOnRemoval(shard)
+	}
+	poolSpec, ok := shard.Spec.Pools[multigresv1alpha1.PoolName(poolName)]
+	if !ok {
+		return ShouldDeleteShardLevelPVCOnRemoval(shard)
+	}
+	return ShouldDeletePVCOnShardRemoval(shard, poolSpec)
 }
 
 // handlePendingDeletion handles graceful shard deletion. When a shard is marked

--- a/pkg/resource-handler/controller/shard/reconcile_deletion_test.go
+++ b/pkg/resource-handler/controller/shard/reconcile_deletion_test.go
@@ -93,8 +93,8 @@ func TestHandleDeletion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("handleDeletion returned error: %v", err)
 		}
-		if result.RequeueAfter != 0 {
-			t.Error("Expected no requeue during best-effort cleanup")
+		if result.RequeueAfter != podTerminationRequeueDelay {
+			t.Errorf("Expected requeue while pod still terminating, got %v", result.RequeueAfter)
 		}
 
 		// Pod should be deleted
@@ -132,8 +132,11 @@ func TestHandleDeletion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("handleDeletion returned error: %v", err)
 		}
-		if result.RequeueAfter != 0 {
-			t.Error("Expected no requeue for unscheduled pod")
+		if result.RequeueAfter != podTerminationRequeueDelay {
+			t.Errorf(
+				"Expected requeue while unscheduled pod terminating, got %v",
+				result.RequeueAfter,
+			)
 		}
 
 		// Pod should be deleted
@@ -171,8 +174,8 @@ func TestHandleDeletion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("handleDeletion returned error: %v", err)
 		}
-		if result.RequeueAfter != 0 {
-			t.Error("Expected no requeue when drain is complete")
+		if result.RequeueAfter != podTerminationRequeueDelay {
+			t.Errorf("Expected requeue while drained pod terminating, got %v", result.RequeueAfter)
 		}
 
 		// Pod should be deleted
@@ -211,8 +214,8 @@ func TestHandleDeletion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("handleDeletion returned error: %v", err)
 		}
-		if result.RequeueAfter != 0 {
-			t.Error("Expected no requeue during best-effort cleanup")
+		if result.RequeueAfter != podTerminationRequeueDelay {
+			t.Errorf("Expected requeue while pod still terminating, got %v", result.RequeueAfter)
 		}
 
 		// Pod should be deleted directly, no drain wait
@@ -254,8 +257,8 @@ func TestHandleDeletion(t *testing.T) {
 		if err != nil {
 			t.Fatalf("handleDeletion returned error: %v", err)
 		}
-		if result.RequeueAfter != 0 {
-			t.Error("Expected no requeue during best-effort cleanup")
+		if result.RequeueAfter != podTerminationRequeueDelay {
+			t.Errorf("Expected requeue while pod still terminating, got %v", result.RequeueAfter)
 		}
 
 		// Pod should be deleted
@@ -294,6 +297,118 @@ func TestHandleDeletion(t *testing.T) {
 		}
 		if result.RequeueAfter != 0 {
 			t.Error("Expected no requeue when no pods exist")
+		}
+	})
+
+	t.Run("PVC orphaned only after pods are gone", func(t *testing.T) {
+		t.Parallel()
+
+		shard := baseShard.DeepCopy()
+		shard.Spec.PVCDeletionPolicy = &multigresv1alpha1.PVCDeletionPolicy{
+			WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
+		}
+		pod := makePod("pod-0", true, "")
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "data-pvc-0",
+				Namespace: "default",
+				Labels:    shardLabels,
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(shard, pod, pvc).
+			WithStatusSubresource(&multigresv1alpha1.Shard{}).
+			Build()
+
+		r := &ShardReconciler{
+			Client:          c,
+			Scheme:          scheme,
+			Recorder:        record.NewFakeRecorder(10),
+			CreateTopoStore: newMemoryTopoFactory(),
+		}
+
+		// First pass: pod still present -> requeue, PVC must NOT be orphaned yet.
+		result, err := r.handleDeletion(context.Background(), shard)
+		if err != nil {
+			t.Fatalf("handleDeletion returned error: %v", err)
+		}
+		if result.RequeueAfter != podTerminationRequeueDelay {
+			t.Errorf("Expected requeue while pod alive, got %v", result.RequeueAfter)
+		}
+		got := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(context.Background(),
+			types.NamespacedName{Name: "data-pvc-0", Namespace: "default"}, got); err != nil {
+			t.Fatalf("failed to get PVC: %v", err)
+		}
+		if _, ok := got.Labels[metadata.LabelOrphan]; ok {
+			t.Error("PVC must not be orphaned while a pod still references it")
+		}
+
+		// Second pass: pod deleted by the first pass -> PVC orphaned now.
+		result, err = r.handleDeletion(context.Background(), shard)
+		if err != nil {
+			t.Fatalf("handleDeletion (2nd pass) returned error: %v", err)
+		}
+		if result.RequeueAfter != 0 {
+			t.Errorf("Expected no requeue once pods are gone, got %v", result.RequeueAfter)
+		}
+		if err := c.Get(context.Background(),
+			types.NamespacedName{Name: "data-pvc-0", Namespace: "default"}, got); err != nil {
+			t.Fatalf("failed to get PVC after cleanup: %v", err)
+		}
+		if _, ok := got.Labels[metadata.LabelOrphan]; !ok {
+			t.Error("PVC should be orphaned once all pods are gone")
+		}
+	})
+
+	t.Run("pod stuck terminating past timeout does not block PVC cleanup", func(t *testing.T) {
+		t.Parallel()
+
+		shard := baseShard.DeepCopy()
+		shard.Spec.PVCDeletionPolicy = &multigresv1alpha1.PVCDeletionPolicy{
+			WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
+		}
+		// Pod stuck Terminating well past terminatingTimeout (dead kubelet).
+		pod := makePod("pod-stuck", true, "")
+		pod.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Add(-2 * terminatingTimeout)}
+		pod.Finalizers = []string{"kubernetes.io/test"} // keep it around despite DeletionTimestamp
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "data-pvc-stuck",
+				Namespace: "default",
+				Labels:    shardLabels,
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(shard, pod, pvc).
+			WithStatusSubresource(&multigresv1alpha1.Shard{}).
+			Build()
+
+		r := &ShardReconciler{
+			Client:          c,
+			Scheme:          scheme,
+			Recorder:        record.NewFakeRecorder(10),
+			CreateTopoStore: newMemoryTopoFactory(),
+		}
+
+		result, err := r.handleDeletion(context.Background(), shard)
+		if err != nil {
+			t.Fatalf("handleDeletion returned error: %v", err)
+		}
+		if result.RequeueAfter != 0 {
+			t.Errorf("Expected no requeue for pod stuck past timeout, got %v", result.RequeueAfter)
+		}
+		got := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(context.Background(),
+			types.NamespacedName{Name: "data-pvc-stuck", Namespace: "default"}, got); err != nil {
+			t.Fatalf("failed to get PVC: %v", err)
+		}
+		if _, ok := got.Labels[metadata.LabelOrphan]; !ok {
+			t.Error("PVC should be orphaned even when a pod is stuck terminating past the timeout")
 		}
 	})
 }

--- a/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
+++ b/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -19,6 +20,7 @@ import (
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/monitoring"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
+	pvcutil "github.com/multigres/multigres-operator/pkg/util/pvc"
 )
 
 // reconcilePoolPods ensures all pods and PVCs for a pool in a specific cell
@@ -171,6 +173,22 @@ func (r *ShardReconciler) createMissingResources(
 			}
 			logger.Info("Created missing pool PVC", "pvc", pvcName)
 		} else {
+			// This deterministically-named PVC is desired again. If a prior
+			// scale-down / drain marked it orphan, clear the label so the
+			// multigres-gc cronjob does not delete storage we are putting back
+			// into service.
+			if err := pvcutil.ClearOrphan(
+				ctx,
+				logger,
+				r.Client,
+				existingPVCs[pvcName],
+			); err != nil {
+				return 0, false, fmt.Errorf(
+					"failed to clear orphan label on PVC %s: %w",
+					pvcName,
+					err,
+				)
+			}
 			if err := r.expandPVCIfNeeded(ctx, shard, existingPVCs[pvcName], poolSpec); err != nil {
 				return 0, false, err
 			}
@@ -703,11 +721,12 @@ func (r *ShardReconciler) cleanupDrainedPod(
 ) error {
 	logger := log.FromContext(ctx)
 
-	// DRAINED pods always get their PVC deleted — data is known-bad.
+	// DRAINED pods always get their PVC marked orphan — data is known-bad.
+	// The multigres-gc CronJob deletes the PVC after the retention window.
 	// We check the pod label (not PodRoles) because the data-handler clears
 	// the topology entry during drain before this cleanup point.
 	if pod.Labels[metadata.LabelPodRole] == "DRAINED" {
-		if err := r.deletePodPVC(
+		if err := r.cleanupPodPVC(
 			ctx,
 			shard,
 			pod,
@@ -718,7 +737,7 @@ func (r *ShardReconciler) cleanupDrainedPod(
 		}
 		logger.Info("Drained pod cleanup complete", "pod", pod.Name)
 		r.Recorder.Eventf(shard, "Normal", "DrainCompleted",
-			"Completed drain for DRAINED pod %s — PVC deleted", pod.Name)
+			"Completed drain for DRAINED pod %s — PVC cleanup queued", pod.Name)
 		return nil
 	}
 
@@ -739,7 +758,7 @@ func (r *ShardReconciler) cleanupDrainedPod(
 		if !idxOK {
 			logger.Info("Skipping PVC deletion for pod with unparseable index", "pod", pod.Name)
 		} else if idx >= int(replicas) {
-			if err := r.deletePodPVC(ctx, shard, pod, poolName, "scaled down"); err != nil {
+			if err := r.cleanupPodPVC(ctx, shard, pod, poolName, "scaled down"); err != nil {
 				return err
 			}
 		} else {
@@ -762,8 +781,13 @@ func (r *ShardReconciler) cleanupDrainedPod(
 	return nil
 }
 
-// deletePodPVC fetches and deletes the data PVC for a pod. reason is used for logging.
-func (r *ShardReconciler) deletePodPVC(
+// cleanupPodPVC removes a pod's data PVC from the operator's care. The choice
+// between orphaning (deferred deletion via multigres-gc) and in-line deletion
+// is based on how many sibling PVCs remain in the same pool+cell: if removing
+// this one still leaves >= pvcOrphanReplicasThreshold volumes, it is excess and
+// is deleted, otherwise it is orphaned so the data can be recovered. See
+// orphanByRemainingCount.
+func (r *ShardReconciler) cleanupPodPVC(
 	ctx context.Context,
 	shard *multigresv1alpha1.Shard,
 	pod *corev1.Pod,
@@ -773,7 +797,7 @@ func (r *ShardReconciler) deletePodPVC(
 
 	idx, ok := resolvePodIndex(pod.Name)
 	if !ok {
-		logger.Info("Skipping PVC deletion for pod with unparseable index", "pod", pod.Name)
+		logger.Info("Skipping PVC cleanup for pod with unparseable index", "pod", pod.Name)
 		return nil
 	}
 
@@ -788,16 +812,67 @@ func (r *ShardReconciler) deletePodPVC(
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		logger.Error(err, "Failed to fetch PVC for deletion", "pvc", pvcName)
-		return fmt.Errorf("failed to fetch PVC %s for deletion: %w", pvcName, err)
+		logger.Error(err, "Failed to fetch PVC for cleanup", "pvc", pvcName)
+		return fmt.Errorf("failed to fetch PVC %s for cleanup: %w", pvcName, err)
+	}
+
+	liveCount, err := r.countPoolCellPVCs(ctx, shard, poolName, cellName)
+	if err != nil {
+		return err
+	}
+
+	if orphanByRemainingCount(liveCount) {
+		if err := pvcutil.MarkOrphan(ctx, r.Client, pvc, shard.GetUID(), time.Now()); err != nil {
+			logger.Error(err, "Failed to mark PVC orphan for "+reason+" pod", "pvc", pvcName)
+			return fmt.Errorf("failed to mark PVC %s orphan: %w", pvcName, err)
+		}
+		logger.Info("Marked PVC orphan for "+reason+" pod", "pvc", pvcName, "liveCount", liveCount)
+		return nil
 	}
 
 	if err := r.Delete(ctx, pvc); err != nil && !errors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete PVC for "+reason+" pod", "pvc", pvcName)
 		return fmt.Errorf("failed to delete PVC %s: %w", pvcName, err)
 	}
-	logger.Info("Deleted PVC for "+reason+" pod", "pvc", pvcName)
+	logger.Info("Deleted PVC for "+reason+" pod", "pvc", pvcName, "liveCount", liveCount)
 	return nil
+}
+
+// countPoolCellPVCs returns the number of PVCs currently present for the given
+// pool+cell, used to decide orphan-vs-delete. Already-orphaned PVCs are
+// excluded: they are no longer part of the live serving set, so they must not
+// inflate the count and cause a still-needed volume to be hard-deleted.
+func (r *ShardReconciler) countPoolCellPVCs(
+	ctx context.Context,
+	shard *multigresv1alpha1.Shard,
+	poolName, cellName string,
+) (int, error) {
+	labels := buildPoolLabelsWithCell(shard, poolName, cellName)
+	selector := metadata.GetSelectorLabels(labels)
+
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(
+		ctx,
+		pvcList,
+		client.InNamespace(shard.Namespace),
+		client.MatchingLabels(selector),
+	); err != nil {
+		return 0, fmt.Errorf(
+			"failed to list PVCs for pool %s cell %s: %w",
+			poolName,
+			cellName,
+			err,
+		)
+	}
+
+	count := 0
+	for i := range pvcList.Items {
+		if pvcutil.HasOrphanLabel(&pvcList.Items[i]) {
+			continue
+		}
+		count++
+	}
+	return count, nil
 }
 
 // podNeedsUpdate checks if a pod requires recreation due to spec changes.

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -28,13 +28,38 @@ import (
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/monitoring"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
+	pvcutil "github.com/multigres/multigres-operator/pkg/util/pvc"
 )
 
 const (
 	// topoUnavailableRequeueDelay is the delay before retrying when the topology
 	// server is unavailable during the grace period.
 	topoUnavailableRequeueDelay = 5 * time.Second
+
+	// shardFinalizer gates Shard deletion until the operator has stripped its
+	// ownerRef from associated PVCs and labelled them orphan, so the downstream
+	// multigres-gc cronjob can clean them up instead of k8s cascade-GC
+	// nuking them the moment the Shard CR is deleted.
+	shardFinalizer = "multigres.com/shard-pvc-orphan"
+
+	// pvcOrphanReplicasThreshold is the number of pool pod PVCs that are
+	// kept (orphaned, deferred to the multigres-gc cronjob) rather than deleted
+	// in-line when a pod is scaled down, drained, or the shard is removed.
+	// Keeping a few volumes around lets an accidental scale-down/removal be
+	// rolled back, beyond the threshold the excess is deleted immediately.
+	pvcOrphanReplicasThreshold = 3
 )
+
+// orphanByRemainingCount decides between orphaning and in-line deletion based
+// on how many sibling PVCs currently exist.
+//
+// liveCount includes the PVC being cleaned up. After it is removed, liveCount-1
+// PVCs remain: if that is still >= pvcOrphanReplicasThreshold we have plenty of
+// volumes left, so this one is excess and is hard-deleted, otherwise we keep it
+// as an orphan so the data can be recovered.
+func orphanByRemainingCount(liveCount int) bool {
+	return liveCount-1 < pvcOrphanReplicasThreshold
+}
 
 // ShardReconciler reconciles a Shard object.
 type ShardReconciler struct {
@@ -83,9 +108,17 @@ func (r *ShardReconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 
-	// Best-effort cleanup on deletion — no finalizers are used.
+	// Finalizer gates deletion so PVCs can be detached + labelled orphan
+	// before Kubernetes cascade-GC fires.
 	if !shard.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, shard)
+	}
+	if !slices.Contains(shard.Finalizers, shardFinalizer) {
+		patch := client.MergeFrom(shard.DeepCopy())
+		shard.Finalizers = append(shard.Finalizers, shardFinalizer)
+		if err := r.Patch(ctx, shard, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to add shard finalizer: %w", err)
+		}
 	}
 
 	// Handle graceful deletion via PendingDeletion annotation.
@@ -510,6 +543,12 @@ func (r *ShardReconciler) reconcilePVCOwnerRefs(
 
 	for i := range pvcList.Items {
 		pvc := &pvcList.Items[i]
+
+		// Skip PVCs already marked orphan. Their Shard ownerRef was deliberately
+		// stripped so the multigres-gc cronjob owns the delayed deletion.
+		if pvcutil.HasOrphanLabel(pvc) {
+			continue
+		}
 
 		// Resolve effective policy for this PVC.
 		poolName := pvc.Labels[metadata.LabelMultigresPool]

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -2,6 +2,7 @@ package shard
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1319,10 +1320,35 @@ func TestSetupWithManager(t *testing.T) {
 	})
 }
 
-// TestCleanupDrainedPod_PVCDeletion verifies that cleanupDrainedPod handles
-// PVC deletion correctly for DRAINED replacement pods (idx < replicas),
-// scale-down pods (idx >= replicas), and rolling-update pods under different
+// TestOrphanByRemainingCount verifies that cleanupDrainedPod handles
+// PVC deletion correctly for DRAINED replacement pods (idx < deletion threshold),
+// scale-down pods (idx >= deletion threshold), and rolling-update pods under different
 // PVC deletion policies.
+func TestOrphanByRemainingCount(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		liveCount  int
+		wantOrphan bool
+	}{
+		"scale 4->3 keeps enough -> delete":    {liveCount: 4, wantOrphan: false},
+		"exactly threshold+1 -> delete":        {liveCount: 4, wantOrphan: false},
+		"scale 3->2 below threshold -> orphan": {liveCount: 3, wantOrphan: true},
+		"single PVC -> orphan":                 {liveCount: 1, wantOrphan: true},
+		"large pool -> delete":                 {liveCount: 10, wantOrphan: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := orphanByRemainingCount(tc.liveCount); got != tc.wantOrphan {
+				t.Errorf("orphanByRemainingCount(%d) = %v, want %v",
+					tc.liveCount, got, tc.wantOrphan)
+			}
+		})
+	}
+}
+
 func TestCleanupDrainedPod_PVCDeletion(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = multigresv1alpha1.AddToScheme(scheme)
@@ -1368,11 +1394,14 @@ func TestCleanupDrainedPod_PVCDeletion(t *testing.T) {
 			},
 		}
 	}
+	// makePVC builds a PVC carrying the pool+cell labels so countPoolCellPVCs
+	// finds it when deciding orphan-vs-delete.
 	makePVC := func(n string) *corev1.PersistentVolumeClaim {
 		return &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      n,
 				Namespace: "default",
+				Labels:    buildPoolLabelsWithCell(baseShard, poolName, cellName),
 			},
 		}
 	}
@@ -1385,39 +1414,68 @@ func TestCleanupDrainedPod_PVCDeletion(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		podName  string
-		pvcName  string
-		podRoles map[string]string
-		policy   *multigresv1alpha1.PVCDeletionPolicy
-		wantPVC  bool
+		podName string
+		pvcName string
+		// siblingCount is the number of PVCs present in the pool+cell (including
+		// pvcName). orphanByRemainingCount uses this: siblingCount-1 >= threshold
+		// deletes, otherwise orphans.
+		siblingCount int
+		podRoles     map[string]string
+		policy       *multigresv1alpha1.PVCDeletionPolicy
+		wantPVC      bool
+		wantOrphan   bool
 	}{
-		"DRAINED replacement (idx<replicas) with Delete policy deletes PVC": {
-			podName:  podName0,
-			pvcName:  pvcName0,
-			podRoles: map[string]string{podName0: "DRAINED"},
-			policy:   deletePolicy,
-			wantPVC:  false,
+		"DRAINED small pool (3) -> orphan": {
+			podName:      podName0,
+			pvcName:      pvcName0,
+			siblingCount: 3,
+			podRoles:     map[string]string{podName0: "DRAINED"},
+			policy:       deletePolicy,
+			wantPVC:      true,
+			wantOrphan:   true,
 		},
-		"DRAINED replacement (idx<replicas) with Retain policy deletes PVC": {
-			podName:  podName1,
-			pvcName:  pvcName1,
-			podRoles: map[string]string{podName1: "DRAINED"},
-			policy:   retainPolicy,
-			wantPVC:  false,
+		"DRAINED Retain policy small pool (3) -> orphan": {
+			podName:      podName1,
+			pvcName:      pvcName1,
+			siblingCount: 3,
+			podRoles:     map[string]string{podName1: "DRAINED"},
+			policy:       retainPolicy,
+			wantPVC:      true,
+			wantOrphan:   true,
 		},
-		"non-DRAINED pod (idx<replicas) with Delete policy keeps PVC": {
-			podName:  podName0,
-			pvcName:  pvcName0,
-			podRoles: map[string]string{podName0: "REPLICA"},
-			policy:   deletePolicy,
-			wantPVC:  true,
+		"non-DRAINED idx<replicas Delete policy keeps PVC": {
+			podName:      podName0,
+			pvcName:      pvcName0,
+			siblingCount: 3,
+			podRoles:     map[string]string{podName0: "REPLICA"},
+			policy:       deletePolicy,
+			wantPVC:      true,
+			wantOrphan:   false,
 		},
-		"scale-down (idx>=replicas) with Delete policy deletes PVC": {
-			podName:  podName5,
-			pvcName:  pvcName5,
-			podRoles: map[string]string{},
-			policy:   deletePolicy,
-			wantPVC:  false,
+		"scale-down small pool (3) -> orphan": {
+			podName:      podName5,
+			pvcName:      pvcName5,
+			siblingCount: 3,
+			podRoles:     map[string]string{},
+			policy:       deletePolicy,
+			wantPVC:      true,
+			wantOrphan:   true,
+		},
+		"DRAINED large pool (4, scaling to 3) -> in-line delete": {
+			podName:      podName0,
+			pvcName:      pvcName0,
+			siblingCount: 4,
+			podRoles:     map[string]string{podName0: "DRAINED"},
+			policy:       deletePolicy,
+			wantPVC:      false,
+		},
+		"scale-down large pool (4, scaling to 3) -> in-line delete": {
+			podName:      podName5,
+			pvcName:      pvcName5,
+			siblingCount: 4,
+			podRoles:     map[string]string{},
+			policy:       deletePolicy,
+			wantPVC:      false,
 		},
 	}
 
@@ -1430,11 +1488,17 @@ func TestCleanupDrainedPod_PVCDeletion(t *testing.T) {
 			if tc.podRoles[tc.podName] == "DRAINED" {
 				pod.Labels[metadata.LabelPodRole] = "DRAINED"
 			}
-			pvc := makePVC(tc.pvcName)
+
+			// Create the target PVC plus filler siblings so the pool+cell has
+			// exactly siblingCount PVCs.
+			objs := []client.Object{shard, pod, makePVC(tc.pvcName)}
+			for i := 0; i < tc.siblingCount-1; i++ {
+				objs = append(objs, makePVC(fmt.Sprintf("filler-pvc-%d", i)))
+			}
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(shard, pod, pvc).
+				WithObjects(objs...).
 				Build()
 
 			reconciler := &ShardReconciler{
@@ -1463,12 +1527,19 @@ func TestCleanupDrainedPod_PVCDeletion(t *testing.T) {
 			)
 			pvcExists := getErr == nil
 			if pvcExists != tc.wantPVC {
-				t.Errorf(
+				t.Fatalf(
 					"PVC %s exists = %v, want %v (err=%v)",
-					tc.pvcName,
-					pvcExists,
-					tc.wantPVC,
-					getErr,
+					tc.pvcName, pvcExists, tc.wantPVC, getErr,
+				)
+			}
+			if !pvcExists {
+				return
+			}
+			_, hasOrphanLabel := pvcAfter.Labels[metadata.LabelOrphan]
+			if hasOrphanLabel != tc.wantOrphan {
+				t.Errorf(
+					"PVC %s orphan-since present = %v, want %v",
+					tc.pvcName, hasOrphanLabel, tc.wantOrphan,
 				)
 			}
 
@@ -1878,6 +1949,67 @@ func TestCreateMissingResources(t *testing.T) {
 		)
 		if !errors.IsNotFound(err) {
 			t.Errorf("terminal pod should be deleted, but Get returned: %v", err)
+		}
+	})
+
+	t.Run("reused orphan PVC has orphan-since label cleared", func(t *testing.T) {
+		shard := baseShard.DeepCopy()
+		podName := BuildPoolPodName(shard, poolName, cellName, 0)
+		pvcName := BuildPoolDataPVCName(shard, poolName, cellName, 0)
+
+		// PVC left over from an earlier scale-down: orphan-since stamped, pod gone.
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pvcName,
+				Namespace: "default",
+				Labels: map[string]string{
+					metadata.LabelOrphan:       "2026-05-01T00-00-00Z",
+					metadata.LabelAppManagedBy: metadata.ManagedByMultigres,
+				},
+			},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard, pvc).Build()
+		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+		existingPods := map[string]*corev1.Pod{}
+		existingPVCs := map[string]*corev1.PersistentVolumeClaim{pvcName: pvc}
+
+		_, _, err := r.createMissingResources(
+			context.Background(),
+			shard,
+			poolName,
+			cellName,
+			poolSpec,
+			existingPods,
+			existingPVCs,
+			1,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(
+			context.Background(),
+			types.NamespacedName{Name: pvcName, Namespace: "default"},
+			got,
+		); err != nil {
+			t.Fatalf("PVC must still exist: %v", err)
+		}
+		if _, ok := got.Labels[metadata.LabelOrphan]; ok {
+			t.Errorf(
+				"orphan-since label should be cleared when PVC is reused, still present: %v",
+				got.Labels,
+			)
+		}
+		// pod (re)created on the reused PVC
+		if err := c.Get(
+			context.Background(),
+			types.NamespacedName{Name: podName, Namespace: "default"},
+			&corev1.Pod{},
+		); err != nil {
+			t.Errorf("pod should be created on reused PVC: %v", err)
 		}
 	})
 
@@ -3148,7 +3280,7 @@ func TestCleanupDrainedPod_ErrorPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("error deleting PVC", func(t *testing.T) {
+	t.Run("error orphaning PVC", func(t *testing.T) {
 		shard := baseShard.DeepCopy()
 		podName := BuildPoolPodName(shard, poolName, cellName, 5)
 		pvcName := BuildPoolDataPVCName(shard, poolName, cellName, 5)
@@ -3167,7 +3299,7 @@ func TestCleanupDrainedPod_ErrorPaths(t *testing.T) {
 
 		base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard, pod, pvc).Build()
 		c := testutil.NewFakeClientWithFailures(base, &testutil.FailureConfig{
-			OnDelete: func(obj client.Object) error {
+			OnPatch: func(obj client.Object) error {
 				if _, ok := obj.(*corev1.PersistentVolumeClaim); ok {
 					return testutil.ErrNetworkTimeout
 				}
@@ -3184,11 +3316,11 @@ func TestCleanupDrainedPod_ErrorPaths(t *testing.T) {
 
 		err := r.cleanupDrainedPod(context.Background(), shard, pod, poolName, poolSpec, 3)
 		if err == nil {
-			t.Error("expected error on PVC delete failure")
+			t.Error("expected error on PVC orphan-patch failure")
 		}
 	})
 
-	t.Run("nil PVC deletion policy deletes PVC", func(t *testing.T) {
+	t.Run("nil PVC deletion policy orphans PVC", func(t *testing.T) {
 		shard := baseShard.DeepCopy()
 		podName := BuildPoolPodName(shard, poolName, cellName, 5)
 		pvcName := BuildPoolDataPVCName(shard, poolName, cellName, 5)
@@ -3208,7 +3340,7 @@ func TestCleanupDrainedPod_ErrorPaths(t *testing.T) {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard, pod, pvc).Build()
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
 
-		// nil PVCDeletionPolicy defaults to Delete
+		// nil PVCDeletionPolicy defaults to Delete -> orphans the PVC.
 		err := r.cleanupDrainedPod(
 			context.Background(),
 			shard,
@@ -3221,13 +3353,16 @@ func TestCleanupDrainedPod_ErrorPaths(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		// PVC should be deleted
+		got := &corev1.PersistentVolumeClaim{}
 		if err := c.Get(
 			context.Background(),
 			types.NamespacedName{Name: pvcName, Namespace: "default"},
-			&corev1.PersistentVolumeClaim{},
-		); !errors.IsNotFound(err) {
-			t.Errorf("PVC should be deleted with nil policy, got err: %v", err)
+			got,
+		); err != nil {
+			t.Fatalf("PVC must still exist, got err: %v", err)
+		}
+		if _, ok := got.Labels[metadata.LabelOrphan]; !ok {
+			t.Errorf("PVC %s missing orphan-since label", pvcName)
 		}
 	})
 }
@@ -5465,8 +5600,8 @@ func TestReconcilePoolPods_AdditionalErrorPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("deletePodPVC network error", func(t *testing.T) {
-		// Mock a DRAINED pod so deletePodPVC is called during cleanupDrainedPod
+	t.Run("markPodPVCOrphan network error", func(t *testing.T) {
+		// Mock a DRAINED pod so markPodPVCOrphan is called during cleanupDrainedPod
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      BuildPoolPodName(shard, "main", "z1", 0),
@@ -5499,13 +5634,13 @@ func TestReconcilePoolPods_AdditionalErrorPaths(t *testing.T) {
 			WithObjects(shard, pod, pvc).
 			Build()
 		fails := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
-			OnDelete: testutil.FailOnObjectName(pvcName, testutil.ErrPermissionError),
+			OnPatch: testutil.FailOnObjectName(pvcName, testutil.ErrPermissionError),
 		})
 
 		r := &ShardReconciler{Client: fails, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
 		err := r.cleanupDrainedPod(context.Background(), shard, pod, "main", poolSpec, 1)
-		if err == nil || !strings.Contains(err.Error(), "failed to delete PVC") {
-			t.Fatalf("expected PVC deletion error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "failed to mark PVC") {
+			t.Fatalf("expected PVC orphan-patch error, got %v", err)
 		}
 	})
 }

--- a/pkg/util/pvc/orphan.go
+++ b/pkg/util/pvc/orphan.go
@@ -1,0 +1,104 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-logr/logr"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+// MarkOrphan stamps a PVC with multigres.com/orphan-since=<now in
+// OrphanTimestampFormat> and removes any controller ownerRef whose UID matches
+// ownerUID. The downstream multigres-gc CronJob deletes such PVCs once the
+// configured retention has elapsed.
+//
+// Idempotent: a PVC already carrying the label is left untouched (preserves
+// the original orphan timestamp so retention is computed from when the PVC
+// first became orphan, not from the most recent reconciliation).
+//
+// ownerUID may be the zero value, in that case no ownerRef is stripped. The
+// label patch still runs.
+func MarkOrphan(
+	ctx context.Context,
+	c client.Client,
+	pvc *corev1.PersistentVolumeClaim,
+	ownerUID types.UID,
+	now time.Time,
+) error {
+	if pvc == nil {
+		return fmt.Errorf("MarkOrphan: nil PVC")
+	}
+
+	// Build a JSON-merge patch from a deep copy so we don't mutate the caller's
+	// object until the API call succeeds.
+	base := pvc.DeepCopy()
+	patch := client.MergeFrom(base)
+
+	mutated := false
+
+	if _, ok := pvc.Labels[metadata.LabelOrphan]; !ok {
+		if pvc.Labels == nil {
+			pvc.Labels = map[string]string{}
+		}
+		pvc.Labels[metadata.LabelOrphan] = now.UTC().Format(metadata.OrphanTimestampFormat)
+		mutated = true
+	}
+
+	if ownerUID != "" {
+		filtered := pvc.OwnerReferences[:0:0]
+		for _, ref := range pvc.OwnerReferences {
+			if ref.UID == ownerUID {
+				continue
+			}
+			filtered = append(filtered, ref)
+		}
+		if len(filtered) != len(pvc.OwnerReferences) {
+			pvc.OwnerReferences = filtered
+			mutated = true
+		}
+	}
+
+	if !mutated {
+		return nil
+	}
+
+	return c.Patch(ctx, pvc, patch)
+}
+
+// ClearOrphan removes the multigres.com/orphan-since label from a PVC, marking
+// it live again. We call this before reusing a deterministically-named PVC (e.g.
+// when a scaled-down pool scales back up onto the same PVC) so the multigres-gc
+// CronJob does not delete storage that has been put back into service.
+func ClearOrphan(
+	ctx context.Context,
+	logger logr.Logger,
+	c client.Client,
+	pvc *corev1.PersistentVolumeClaim,
+) error {
+	if pvc == nil {
+		return fmt.Errorf("ClearOrphan: nil PVC")
+	}
+	if _, ok := pvc.Labels[metadata.LabelOrphan]; !ok {
+		return nil
+	}
+
+	patch := client.MergeFrom(pvc.DeepCopy())
+	delete(pvc.Labels, metadata.LabelOrphan)
+	logger.Info("Cleared orphan label on PVC", "pvc", pvc.Name)
+	return c.Patch(ctx, pvc, patch)
+}
+
+// HasOrphanLabel reports whether a PVC has already been marked orphan.
+func HasOrphanLabel(pvc *corev1.PersistentVolumeClaim) bool {
+	if pvc == nil {
+		return false
+	}
+	_, ok := pvc.Labels[metadata.LabelOrphan]
+	return ok
+}

--- a/pkg/util/pvc/orphan_test.go
+++ b/pkg/util/pvc/orphan_test.go
@@ -1,0 +1,137 @@
+package pvc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+const (
+	shardUID types.UID = "shard-uid-1234"
+	otherUID types.UID = "other-uid-9999"
+)
+
+func newPVC(name string, ownerUIDs ...types.UID) *corev1.PersistentVolumeClaim {
+	refs := make([]metav1.OwnerReference, 0, len(ownerUIDs))
+	for _, uid := range ownerUIDs {
+		refs = append(refs, metav1.OwnerReference{UID: uid})
+	}
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       "ns1",
+			OwnerReferences: refs,
+		},
+	}
+}
+
+func newClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(clientgoscheme.Scheme).
+		WithObjects(objs...).
+		Build()
+}
+
+func TestMarkOrphan_AddsLabelAndStripsOwnerRef(t *testing.T) {
+	t.Parallel()
+
+	pvc := newPVC("a", shardUID, otherUID)
+	c := newClient(t, pvc)
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, MarkOrphan(context.Background(), c, pvc, shardUID, now))
+
+	got := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(pvc), got))
+	require.Equal(t, "2026-05-19T12-00-00Z", got.Labels[metadata.LabelOrphan])
+	require.Len(t, got.OwnerReferences, 1)
+	require.Equal(t, otherUID, got.OwnerReferences[0].UID)
+}
+
+func TestMarkOrphan_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	pvc := newPVC("a")
+	pvc.Labels = map[string]string{metadata.LabelOrphan: "2026-05-01T00-00-00Z"}
+	c := newClient(t, pvc)
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, MarkOrphan(context.Background(), c, pvc, "", now))
+
+	got := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(pvc), got))
+	// Existing label preserved — retention is measured from the original event.
+	require.Equal(t, "2026-05-01T00-00-00Z", got.Labels[metadata.LabelOrphan])
+}
+
+func TestMarkOrphan_NoOwnerUIDLeavesRefs(t *testing.T) {
+	t.Parallel()
+
+	pvc := newPVC("a", shardUID)
+	c := newClient(t, pvc)
+
+	require.NoError(t, MarkOrphan(context.Background(), c, pvc, "", time.Now()))
+
+	got := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(pvc), got))
+	require.Len(t, got.OwnerReferences, 1)
+}
+
+func TestClearOrphan_RemovesLabel(t *testing.T) {
+	t.Parallel()
+
+	logger := logr.Discard()
+	pvc := newPVC("a")
+	pvc.Labels = map[string]string{
+		metadata.LabelOrphan:       "2026-05-01T00-00-00Z",
+		metadata.LabelAppManagedBy: metadata.ManagedByMultigres,
+	}
+	c := newClient(t, pvc)
+
+	require.NoError(t, ClearOrphan(context.Background(), logger, c, pvc))
+
+	got := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(pvc), got))
+	_, hasOrphan := got.Labels[metadata.LabelOrphan]
+	require.False(t, hasOrphan)
+	// other labels should remain untouched.
+	require.Equal(t, metadata.ManagedByMultigres, got.Labels[metadata.LabelAppManagedBy])
+}
+
+func TestClearOrphan_NoLabelIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	logger := logr.Discard()
+	pvc := newPVC("a")
+	pvc.Labels = map[string]string{metadata.LabelAppManagedBy: metadata.ManagedByMultigres}
+	c := newClient(t, pvc)
+
+	require.NoError(t, ClearOrphan(context.Background(), logger, c, pvc))
+
+	got := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(pvc), got))
+	require.Equal(t, metadata.ManagedByMultigres, got.Labels[metadata.LabelAppManagedBy])
+}
+
+func TestHasOrphanLabel(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, HasOrphanLabel(nil))
+	require.False(t, HasOrphanLabel(newPVC("a")))
+
+	labeled := newPVC("a")
+	labeled.Labels = map[string]string{metadata.LabelOrphan: "x"}
+	require.True(t, HasOrphanLabel(labeled))
+}


### PR DESCRIPTION
Until now the shard controller relied on k8s cascade-GC (via a controller ownerRef on each PVC) and directly triggered delete calls to clean up data volumes when a pod was drained, scaled down, or the whole Shard was removed. 

## Changes
Hand the cleanup to multigres-gc instead, so PVCs stick around long enough for an operator to roll back a shard deletion:

  - Add pkg/util/pvc.MarkOrphan, which strips a given ownerRef from a PVC and stamps it with multigres.com/orphan-since=<UTC now>. Idempotent: an existing orphan-since label is preserved so the retention window starts at the first orphan event, not at every reconcile.

  - Gate Shard deletion on a new finalizer (multigres.com/shard-pvc-orphan). Without it, cascade-GC fires the instant the Shard's DeletionTimestamp is set and we have no chance to detach the PVCs first.

  - Rename deletePodPVC -> cleanupPodPVC and replace the in-line delete with MarkOrphan for drained pods and scale-down events.

  - Replace handleDeletion's reliance on ownerRef cascade with a new cleanupShardPVCs step that enumerates Shard-scoped PVCs (via the cluster/database/tablegroup/shard label set) and orphans those whose effective PVCDeletionPolicy resolves to Delete.

Large shards skip the orphan path. Once shard.Spec.Replicas exceeds pvcOrphanReplicasThreshold (3) the operator deletes the PVC in-line at both cleanup sites, for those workloads keeping every per-replica volume around for the retention window would be too expensive. nil Replicas (Shard CRs created before the field existed) default to the small-shard path.