### PR TITLE
fix(temapltes): fix for pg_hba conf

### DIFF
--- a/pkg/resource-handler/controller/shard/configmap_test.go
+++ b/pkg/resource-handler/controller/shard/configmap_test.go
@@ -140,7 +140,7 @@ func TestDefaultPgHbaTemplateEmbedded(t *testing.T) {
 		},
 		{
 			desc:        "replication scram-sha-256 rule",
-			mustContain: []string{"host", "replication", "all", "127.0.0.1/32", "scram-sha-256"},
+			mustContain: []string{"host", "replication", "all", "0.0.0.0/0", "scram-sha-256"},
 		},
 	}
 

--- a/pkg/resource-handler/controller/shard/templates/pg_hba_template.conf
+++ b/pkg/resource-handler/controller/shard/templates/pg_hba_template.conf
@@ -28,8 +28,8 @@ local   all             all             scram-sha-256
 # instance shares the same POSTGRES_PASSWORD, so the same pgpass file works
 # for both pgbackrest and replication.
 local   replication     all                                     scram-sha-256
-host    replication     all             127.0.0.1/32            scram-sha-256
-host    replication     all             ::1/128                 scram-sha-256
+host    replication     all             0.0.0.0/0               scram-sha-256
+host    replication     all             ::0/0                   scram-sha-256
 
 # IPv4 local connections:
 host    all             all             127.0.0.1/32            scram-sha-256

--- a/pkg/resource-handler/controller/shard/templates/pg_hba_template.conf
+++ b/pkg/resource-handler/controller/shard/templates/pg_hba_template.conf
@@ -15,9 +15,12 @@
 # TYPE  DATABASE        USER            ADDRESS                 METHOD
 
 # "local" is for Unix domain socket connections only.
-# All local connections require SCRAM. Multipooler's admin pool authenticates
-# with POSTGRES_PASSWORD / CONNPOOL_ADMIN_PASSWORD; per-user connections
-# authenticate via SCRAM passthrough.
+# Trust the admin user over the Unix socket so in-pod tooling (and clients
+# that previously relied on socket trust) keep working without a password.
+local   all             {{.User}}       trust
+# All other local connections require SCRAM. Multipooler's admin pool
+# authenticates with POSTGRES_PASSWORD / CONNPOOL_ADMIN_PASSWORD; per-user
+# connections authenticate via SCRAM passthrough.
 local   all             all             scram-sha-256
 
 # Replication connections (localhost only). Standbys authenticate via SCRAM


### PR DESCRIPTION
# Desc
* Prior to: https://github.com/multigres/multigres/pull/976, pooler connected to postgres through the socket with no password. 
* We need this rule, so clusters that don't have those changes will still be able to connect. 