### PR TITLE
feat: use password files for pool postgres credentials

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -5,25 +5,25 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-9d84da5"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-ba3ed8e"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiAdminImage is the default container image for the MultiAdmin component.
-	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-9d84da5"
+	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-ba3ed8e"
 
 	// DefaultMultiAdminWebImage is the default container image for the MultiAdminWeb component.
 	DefaultMultiAdminWebImage = "ghcr.io/multigres/multiadmin-web:sha-c2db14c"
 
 	// DefaultMultiOrchImage is the default container image for the MultiOrch component.
-	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-9d84da5"
+	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-ba3ed8e"
 
 	// DefaultMultiPoolerImage is the default container image for the MultiPooler component.
-	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-9d84da5"
+	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-ba3ed8e"
 
 	// DefaultMultiGatewayImage is the default container image for the MultiGateway component.
-	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-9d84da5"
+	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-ba3ed8e"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
 	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -65,6 +65,15 @@ const (
 	// PostgresPasswordSecretKey is the key within the Secret that holds the password
 	PostgresPasswordSecretKey = "password"
 
+	// PostgresPasswordVolumeName is the Secret volume containing the postgres password file.
+	PostgresPasswordVolumeName = "postgres-password"
+
+	// PostgresPasswordMountPath is where the postgres password Secret is mounted.
+	PostgresPasswordMountPath = "/etc/postgres-password"
+
+	// PostgresPasswordFilePath is consumed by pgctld and multipooler via POSTGRES_PASSWORD_FILE.
+	PostgresPasswordFilePath = PostgresPasswordMountPath + "/" + PostgresPasswordSecretKey
+
 	// PgBackRestCertVolumeName is the name of the volume for pgBackRest TLS certificates
 	PgBackRestCertVolumeName = "pgbackrest-certs"
 
@@ -116,6 +125,35 @@ func buildPgHbaVolume(shardName string) corev1.Volume {
 	}
 }
 
+func buildPostgresPasswordVolume(shardName string) corev1.Volume {
+	// Keep the Secret world-readable inside the pod because the default pool
+	// pod may not set fsGroup, while containers still run as non-root users.
+	defaultMode := int32(0o444)
+	return corev1.Volume{
+		Name: PostgresPasswordVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  PostgresPasswordSecretName(shardName),
+				DefaultMode: &defaultMode,
+				Items: []corev1.KeyToPath{
+					{
+						Key:  PostgresPasswordSecretKey,
+						Path: PostgresPasswordSecretKey,
+					},
+				},
+			},
+		},
+	}
+}
+
+func postgresPasswordVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      PostgresPasswordVolumeName,
+		MountPath: PostgresPasswordMountPath,
+		ReadOnly:  true,
+	}
+}
+
 // sidecarRestartPolicy is the restart policy for native sidecar containers
 var sidecarRestartPolicy = corev1.ContainerRestartPolicyAlways
 
@@ -123,10 +161,11 @@ var sidecarRestartPolicy = corev1.ContainerRestartPolicyAlways
 // Runs as a native sidecar so it outlives multipooler on pod termination;
 // see docs/development/pod-management-design.md §6 for the full rationale.
 //
-// Uses DefaultPostgresImage (ghcr.io/multigres/pgctld:main) which includes:
+// Uses DefaultPostgresImage which includes:
 //   - PostgreSQL 17
 //   - pgctld binary at /usr/local/bin/pgctld
 //   - pgbackrest for backup/restore operations
+//   - POSTGRES_PASSWORD_FILE support for file-backed superuser credentials
 func buildPgctldSidecar(
 	shard *multigresv1alpha1.Shard,
 	pool multigresv1alpha1.PoolSpec,
@@ -164,7 +203,7 @@ func buildPgctldSidecar(
 			Value: PgDataPath,
 		},
 		pgUserEnvVar(shard.Spec.PostgresSuperuser),
-		pgPasswordEnvVar(shard.Name),
+		pgPasswordFileEnvVar(),
 	}
 	if shard.Spec.InitdbArgs != "" {
 		env = append(env, corev1.EnvVar{
@@ -201,6 +240,7 @@ func buildPgctldSidecar(
 			MountPath: PgHbaMountPath,
 			ReadOnly:  true,
 		},
+		postgresPasswordVolumeMount(),
 	}
 	if shard.Spec.PostgresConfigRef != nil {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
@@ -404,7 +444,7 @@ func buildMultiPoolerContainer(
 			Value: PgDataPath,
 		},
 		pgUserEnvVar(shard.Spec.PostgresSuperuser),
-		pgPasswordEnvVar(shard.Name),
+		pgPasswordFileEnvVar(),
 	}
 	env = append(env, s3EnvVars(shard.Spec.Backup)...)
 	if otelVars := buildRuntimeOTELEnvVars(shard, "multipooler"); len(otelVars) > 0 {
@@ -425,6 +465,7 @@ func buildMultiPoolerContainer(
 			Name:      SocketDirVolumeName,
 			MountPath: SocketDirMountPath,
 		},
+		postgresPasswordVolumeMount(),
 	}
 	if shard.Spec.Backup != nil {
 		c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
@@ -549,6 +590,7 @@ func buildPoolVolumes(shard *multigresv1alpha1.Shard, cellName string) []corev1.
 		buildSharedBackupVolume(shard, cellName),
 		buildSocketDirVolume(),
 		buildPgHbaVolume(shard.Name),
+		buildPostgresPasswordVolume(shard.Name),
 	}
 	if shard.Spec.PostgresConfigRef != nil {
 		volumes = append(volumes, buildPostgresConfigVolume(shard.Spec.PostgresConfigRef))
@@ -680,19 +722,13 @@ func buildPgBackRestCertVolume(shard *multigresv1alpha1.Shard) *corev1.Volume {
 	}
 }
 
-// pgPasswordEnvVar returns a POSTGRES_PASSWORD env var sourced from the per-shard postgres password Secret.
-// pgctld reads this during initdb to set the superuser password in pg_authid.
-func pgPasswordEnvVar(shardName string) corev1.EnvVar {
+// pgPasswordFileEnvVar returns a POSTGRES_PASSWORD_FILE env var pointing at the mounted
+// per-shard postgres password Secret. pgctld reads this during initdb to set the
+// superuser password in pg_authid, and multipooler uses it for admin connections.
+func pgPasswordFileEnvVar() corev1.EnvVar {
 	return corev1.EnvVar{
-		Name: "POSTGRES_PASSWORD",
-		ValueFrom: &corev1.EnvVarSource{
-			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: PostgresPasswordSecretName(shardName),
-				},
-				Key: PostgresPasswordSecretKey,
-			},
-		},
+		Name:  "POSTGRES_PASSWORD_FILE",
+		Value: PostgresPasswordFilePath,
 	}
 }
 

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -69,6 +69,7 @@ const (
 	PostgresPasswordVolumeName = "postgres-password"
 
 	// PostgresPasswordMountPath is where the postgres password Secret is mounted.
+	//nolint:gosec // Mount path only; the password value is sourced from a Kubernetes Secret.
 	PostgresPasswordMountPath = "/etc/postgres-password"
 
 	// PostgresPasswordFilePath is consumed by pgctld and multipooler via POSTGRES_PASSWORD_FILE.

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -108,7 +108,7 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "PGDATA", Value: PgDataPath},
 					{Name: "POSTGRES_USER", Value: "postgres"},
-					pgPasswordEnvVar("test-shard"),
+					pgPasswordFileEnvVar(),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -123,6 +123,7 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 						Name:      SocketDirVolumeName,
 						MountPath: SocketDirMountPath,
 					},
+					postgresPasswordVolumeMount(),
 				},
 			},
 		},
@@ -214,7 +215,7 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "PGDATA", Value: PgDataPath},
 					{Name: "POSTGRES_USER", Value: "postgres"},
-					pgPasswordEnvVar("custom-shard"),
+					pgPasswordFileEnvVar(),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -229,6 +230,7 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 						Name:      SocketDirVolumeName,
 						MountPath: SocketDirMountPath,
 					},
+					postgresPasswordVolumeMount(),
 				},
 			},
 		},
@@ -338,7 +340,7 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "PGDATA", Value: PgDataPath},
 					{Name: "POSTGRES_USER", Value: "postgres"},
-					pgPasswordEnvVar("resource-shard"),
+					pgPasswordFileEnvVar(),
 				},
 				VolumeMounts: []corev1.VolumeMount{
 					{
@@ -353,6 +355,7 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 						Name:      SocketDirVolumeName,
 						MountPath: SocketDirMountPath,
 					},
+					postgresPasswordVolumeMount(),
 				},
 			},
 		},
@@ -463,6 +466,40 @@ func TestPoolContainers_CustomPostgresSuperuser(t *testing.T) {
 		c := buildPostgresExporterContainer(shard, pool)
 		assertEnvVarValue(t, c.Env, "DATA_SOURCE_USER", customSuperuser)
 	})
+}
+
+func TestPoolContainers_PostgresPasswordFile(t *testing.T) {
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-shard"},
+		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:   "testdb",
+			TableGroupName: "default",
+			ShardName:      "0",
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+				Address:  "global-topo:2379",
+				RootPath: "/multigres/global",
+			},
+		},
+	}
+	pool := multigresv1alpha1.PoolSpec{
+		Cells: []multigresv1alpha1.CellName{"zone1"},
+	}
+
+	for name, c := range map[string]corev1.Container{
+		"pgctld":      buildPgctldSidecar(shard, pool),
+		"multipooler": buildMultiPoolerContainer(shard, pool, "primary", "zone1", "p-test-id"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assertEnvVarValue(t, c.Env, "POSTGRES_PASSWORD_FILE", PostgresPasswordFilePath)
+			assertNotContainsEnvVar(t, c.Env, "POSTGRES_PASSWORD")
+			assertReadOnlyVolumeMount(
+				t,
+				c.VolumeMounts,
+				PostgresPasswordVolumeName,
+				PostgresPasswordMountPath,
+			)
+		})
+	}
 }
 
 func TestBuildMultiOrchContainer(t *testing.T) {
@@ -1055,6 +1092,23 @@ func assertContainsVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name s
 	t.Errorf("volume mounts %v does not contain mount %q", mounts, name)
 }
 
+func assertReadOnlyVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name, mountPath string) {
+	t.Helper()
+	for _, m := range mounts {
+		if m.Name != name {
+			continue
+		}
+		if m.MountPath != mountPath {
+			t.Errorf("mount %q path = %q, want %q", name, m.MountPath, mountPath)
+		}
+		if !m.ReadOnly {
+			t.Errorf("mount %q should be read-only", name)
+		}
+		return
+	}
+	t.Errorf("volume mounts %v does not contain mount %q", mounts, name)
+}
+
 func assertNotContainsVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name string) {
 	t.Helper()
 	for _, m := range mounts {
@@ -1303,6 +1357,45 @@ func TestMultiPoolerSidecar_PgBackRestCertArgs(t *testing.T) {
 }
 
 func TestBuildPoolVolumes_CertVolumePresence(t *testing.T) {
+	t.Run("postgres password secret volume present", func(t *testing.T) {
+		shard := &multigresv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "test-shard",
+				Labels: map[string]string{"multigres.com/cluster": "test"},
+			},
+			Spec: multigresv1alpha1.ShardSpec{},
+		}
+		volumes := buildPoolVolumes(shard, "zone1")
+		for _, v := range volumes {
+			if v.Name != PostgresPasswordVolumeName {
+				continue
+			}
+			if v.Secret == nil {
+				t.Fatal("postgres password volume should use Secret source")
+			}
+			if v.Secret.SecretName != PostgresPasswordSecretName("test-shard") {
+				t.Errorf(
+					"postgres password SecretName = %q, want %q",
+					v.Secret.SecretName,
+					PostgresPasswordSecretName("test-shard"),
+				)
+			}
+			if v.Secret.DefaultMode == nil || *v.Secret.DefaultMode != 0o444 {
+				t.Errorf("postgres password defaultMode = %v, want 0444", v.Secret.DefaultMode)
+			}
+			if len(v.Secret.Items) != 1 ||
+				v.Secret.Items[0].Key != PostgresPasswordSecretKey ||
+				v.Secret.Items[0].Path != PostgresPasswordSecretKey {
+				t.Errorf(
+					"postgres password Secret items = %+v, want password key projected to password",
+					v.Secret.Items,
+				)
+			}
+			return
+		}
+		t.Fatalf("expected postgres password Secret volume in pool volumes")
+	})
+
 	t.Run("cert volume present when backup configured", func(t *testing.T) {
 		shard := &multigresv1alpha1.Shard{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -263,7 +263,9 @@ func hashContainers(h hash.Hash32, containers []corev1.Container) {
 			_, _ = fmt.Fprintf(h, "res=%s", b)
 		}
 		for _, vm := range c.VolumeMounts {
-			_, _ = fmt.Fprintf(h, "vm=%s:%s", vm.Name, vm.MountPath)
+			if b, err := json.Marshal(vm); err == nil {
+				_, _ = fmt.Fprintf(h, "vm=%s", b)
+			}
 		}
 		if c.SecurityContext != nil {
 			if b, err := json.Marshal(c.SecurityContext); err == nil {

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -192,7 +192,13 @@ func TestBuildPoolPod_Volumes(t *testing.T) {
 		volumeNames[v.Name] = true
 	}
 
-	required := []string{DataVolumeName, "backup-data", "socket-dir", PgHbaVolumeName}
+	required := []string{
+		DataVolumeName,
+		"backup-data",
+		"socket-dir",
+		PgHbaVolumeName,
+		PostgresPasswordVolumeName,
+	}
 	for _, name := range required {
 		if !volumeNames[name] {
 			t.Errorf("missing required volume %q", name)
@@ -211,6 +217,54 @@ func TestBuildPoolPod_Volumes(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestBuildPoolPod_PostgresPasswordFile(t *testing.T) {
+	pod, err := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	passwordVolume := findVolume(pod.Spec.Volumes, PostgresPasswordVolumeName)
+	if passwordVolume == nil {
+		t.Fatalf("missing postgres password volume %q", PostgresPasswordVolumeName)
+	}
+	if passwordVolume.Secret == nil {
+		t.Fatal("postgres password volume should use Secret source")
+	}
+	if passwordVolume.Secret.SecretName != PostgresPasswordSecretName("test-shard") {
+		t.Errorf(
+			"postgres password SecretName = %q, want %q",
+			passwordVolume.Secret.SecretName,
+			PostgresPasswordSecretName("test-shard"),
+		)
+	}
+	if passwordVolume.Secret.DefaultMode == nil || *passwordVolume.Secret.DefaultMode != 0o444 {
+		t.Errorf("postgres password defaultMode = %v, want 0444", passwordVolume.Secret.DefaultMode)
+	}
+
+	postgres := pod.Spec.InitContainers[0]
+	multipooler := pod.Spec.Containers[0]
+	for name, c := range map[string]corev1.Container{
+		"postgres":    postgres,
+		"multipooler": multipooler,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assertEnvVarValue(t, c.Env, "POSTGRES_PASSWORD_FILE", PostgresPasswordFilePath)
+			assertNotContainsEnvVar(t, c.Env, "POSTGRES_PASSWORD")
+			assertReadOnlyVolumeMount(
+				t,
+				c.VolumeMounts,
+				PostgresPasswordVolumeName,
+				PostgresPasswordMountPath,
+			)
+		})
+	}
+
+	exporter := pod.Spec.Containers[1]
+	assertContainsEnvVar(t, exporter.Env, "DATA_SOURCE_PASS")
+	assertNotContainsEnvVar(t, exporter.Env, "POSTGRES_PASSWORD")
+	assertNotContainsEnvVar(t, exporter.Env, "POSTGRES_PASSWORD_FILE")
 }
 
 func TestBuildPoolPod_SecurityContext(t *testing.T) {
@@ -291,6 +345,61 @@ func TestBuildPoolPod_SpecHash(t *testing.T) {
 	if len(hash) != 8 {
 		t.Errorf("spec-hash length = %d, want 8 (FNV-1a 32-bit hex)", len(hash))
 	}
+}
+
+func TestComputeSpecHash_ChangesOnPostgresPasswordFileSpec(t *testing.T) {
+	pod, err := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantHash := ComputeSpecHash(pod)
+
+	t.Run("volume", func(t *testing.T) {
+		oldPod := pod.DeepCopy()
+		oldPod.Spec.Volumes = removeVolume(oldPod.Spec.Volumes, PostgresPasswordVolumeName)
+		if got := ComputeSpecHash(oldPod); got == wantHash {
+			t.Error("spec hash should differ when postgres password volume is removed")
+		}
+	})
+
+	t.Run("pgctld env", func(t *testing.T) {
+		oldPod := pod.DeepCopy()
+		useLegacyPasswordEnv(&oldPod.Spec.InitContainers[0])
+		if got := ComputeSpecHash(oldPod); got == wantHash {
+			t.Error("spec hash should differ when pgctld password env changes")
+		}
+	})
+
+	t.Run("multipooler env", func(t *testing.T) {
+		oldPod := pod.DeepCopy()
+		useLegacyPasswordEnv(&oldPod.Spec.Containers[0])
+		if got := ComputeSpecHash(oldPod); got == wantHash {
+			t.Error("spec hash should differ when multipooler password env changes")
+		}
+	})
+
+	t.Run("volume mount", func(t *testing.T) {
+		oldPod := pod.DeepCopy()
+		oldPod.Spec.Containers[0].VolumeMounts = removeVolumeMount(
+			oldPod.Spec.Containers[0].VolumeMounts,
+			PostgresPasswordVolumeName,
+		)
+		if got := ComputeSpecHash(oldPod); got == wantHash {
+			t.Error("spec hash should differ when postgres password volume mount is removed")
+		}
+	})
+
+	t.Run("volume mount read-only", func(t *testing.T) {
+		changedPod := pod.DeepCopy()
+		for i := range changedPod.Spec.Containers[0].VolumeMounts {
+			if changedPod.Spec.Containers[0].VolumeMounts[i].Name == PostgresPasswordVolumeName {
+				changedPod.Spec.Containers[0].VolumeMounts[i].ReadOnly = false
+			}
+		}
+		if got := ComputeSpecHash(changedPod); got == wantHash {
+			t.Error("spec hash should differ when postgres password volume mount readOnly changes")
+		}
+	})
 }
 
 func TestBuildPoolPod_NoFinalizers(t *testing.T) {
@@ -713,5 +822,57 @@ func TestBuildPoolPod_OmitsPostgresConfigHashWhenAbsent(t *testing.T) {
 
 	if _, ok := pod.Annotations[metadata.AnnotationPostgresConfigHash]; ok {
 		t.Error("postgres config hash annotation should not be present when shard has none")
+	}
+}
+
+func findVolume(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+	return nil
+}
+
+func removeVolume(volumes []corev1.Volume, name string) []corev1.Volume {
+	filtered := make([]corev1.Volume, 0, len(volumes))
+	for _, v := range volumes {
+		if v.Name != name {
+			filtered = append(filtered, v)
+		}
+	}
+	return filtered
+}
+
+func removeVolumeMount(mounts []corev1.VolumeMount, name string) []corev1.VolumeMount {
+	filtered := make([]corev1.VolumeMount, 0, len(mounts))
+	for _, m := range mounts {
+		if m.Name != name {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
+func useLegacyPasswordEnv(container *corev1.Container) {
+	for i, e := range container.Env {
+		if e.Name == "POSTGRES_PASSWORD_FILE" {
+			container.Env[i] = oldPostgresPasswordEnvVar()
+			return
+		}
+	}
+}
+
+func oldPostgresPasswordEnvVar() corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: "POSTGRES_PASSWORD",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: PostgresPasswordSecretName("test-shard"),
+				},
+				Key: PostgresPasswordSecretKey,
+			},
+		},
 	}
 }

--- a/pkg/resource-handler/controller/shard/secret.go
+++ b/pkg/resource-handler/controller/shard/secret.go
@@ -18,8 +18,8 @@ import (
 const DefaultPostgresPassword = "postgres"
 
 // BuildPostgresPasswordSecret creates a Secret containing the PostgreSQL
-// superuser password. Both pgctld (via POSTGRES_PASSWORD env var) and multipooler
-// (via POSTGRES_PASSWORD env var) source credentials from this Secret.
+// superuser password. Pool pods mount this Secret and point pgctld and
+// multipooler at the mounted file via POSTGRES_PASSWORD_FILE.
 func BuildPostgresPasswordSecret(
 	shard *multigresv1alpha1.Shard,
 	scheme *runtime.Scheme,

--- a/pkg/resource-handler/controller/shard/templates/pg_hba_template.conf
+++ b/pkg/resource-handler/controller/shard/templates/pg_hba_template.conf
@@ -16,13 +16,13 @@
 
 # "local" is for Unix domain socket connections only.
 # All local connections require SCRAM. Multipooler's admin pool authenticates
-# with POSTGRES_PASSWORD / CONNPOOL_ADMIN_PASSWORD; per-user connections
+# with the password referenced by POSTGRES_PASSWORD_FILE; per-user connections
 # authenticate via SCRAM passthrough.
 local   all             all             scram-sha-256
 
 # Replication connections (localhost only). Standbys authenticate via SCRAM
 # using a passfile pointed to by primary_conninfo (passfile=...); every
-# instance shares the same POSTGRES_PASSWORD, so the same pgpass file works
+# instance shares the same postgres password, so the same pgpass file works
 # for both pgbackrest and replication.
 local   replication     all                                     scram-sha-256
 host    replication     all             127.0.0.1/32            scram-sha-256


### PR DESCRIPTION
## Description

this PR add the operator-side companion change for upstream Multigres `POSTGRES_PASSWORD_FILE` support. Pool pods now mount the existing per-shard postgres password Secret as a file and pass that file path to pgctld and multipooler, while postgres-exporter continues using its existing SecretKeyRef-based password wiring.

## Main Changes

- Mount the per-shard postgres password Secret into pool pods as a read-only file.
- Switch pgctld and multipooler from `POSTGRES_PASSWORD` to `POSTGRES_PASSWORD_FILE`.
- Keep postgres-exporter on `DATA_SOURCE_PASS`.
- Include the new password volume and mount details in the pool pod spec hash so existing pods roll.
- Bump Multigres runtime image defaults to the upstream SHA containing `POSTGRES_PASSWORD_FILE` support.
- Document the Secret volume file mode choice for non-root pool containers.

## Testing

New tests cover the full pool pod contract for the credential migration: the password Secret is present as a volume, pgctld and multipooler mount it read-only, both containers receive `POSTGRES_PASSWORD_FILE`, and neither receives the legacy `POSTGRES_PASSWORD`. They also verify postgres-exporter remains on its existing `DATA_SOURCE_PASS` SecretKeyRef path.

The spec-hash tests simulate old and drifted pod specs to ensure the new env var, Secret volume, volume mount, and mount read-only bit all contribute to the hash. That gives us coverage that existing pods will roll onto the file-based password wiring.