### PR TITLE
chore(deps): bump multigres to ef07fa7

### DIFF
--- a/pkg/resource-handler/controller/shard/configmap_test.go
+++ b/pkg/resource-handler/controller/shard/configmap_test.go
@@ -140,7 +140,7 @@ func TestDefaultPgHbaTemplateEmbedded(t *testing.T) {
 		},
 		{
 			desc:        "replication scram-sha-256 rule",
-			mustContain: []string{"host", "replication", "all", "127.0.0.1/32", "scram-sha-256"},
+			mustContain: []string{"host", "replication", "all", "0.0.0.0/0", "scram-sha-256"},
 		},
 	}
 

--- a/pkg/resource-handler/controller/shard/templates/pg_hba_template.conf
+++ b/pkg/resource-handler/controller/shard/templates/pg_hba_template.conf
@@ -28,8 +28,8 @@ local   all             all             scram-sha-256
 # instance shares the same POSTGRES_PASSWORD, so the same pgpass file works
 # for both pgbackrest and replication.
 local   replication     all                                     scram-sha-256
-host    replication     all             127.0.0.1/32            scram-sha-256
-host    replication     all             ::1/128                 scram-sha-256
+host    replication     all             0.0.0.0/0               scram-sha-256
+host    replication     all             ::0/0                   scram-sha-256
 
 # IPv4 local connections:
 host    all             all             127.0.0.1/32            scram-sha-256


### PR DESCRIPTION
hba only allowed loopback addresses, preventing pod-to-pod replication.