### PR TITLE
 feat(topology): support managed local toposervers 

### DIFF
--- a/api/v1alpha1/celltemplate_types.go
+++ b/api/v1alpha1/celltemplate_types.go
@@ -25,7 +25,6 @@ import (
 // ============================================================================
 
 // CellTemplateSpec defines reusable config for Cell components (Gateway, LocalTopo).
-// +kubebuilder:validation:XValidation:rule="!has(self.localTopoServer)",message="local topology servers (localTopoServer) are not yet supported"
 type CellTemplateSpec struct {
 	// MultiGateway configuration.
 	// +optional

--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -281,7 +281,6 @@ type CellOverrides struct {
 }
 
 // CellInlineSpec defines the inline configuration for a Cell.
-// +kubebuilder:validation:XValidation:rule="!has(self.localTopoServer)",message="local topology servers (localTopoServer) are not yet supported"
 type CellInlineSpec struct {
 	// MultiGateway configuration.
 	// +optional

--- a/config/crd/bases/multigres.com_celltemplates.yaml
+++ b/config/crd/bases/multigres.com_celltemplates.yaml
@@ -1280,9 +1280,6 @@ spec:
                     type: array
                 type: object
             type: object
-            x-kubernetes-validations:
-            - message: local topology servers (localTopoServer) are not yet supported
-              rule: '!has(self.localTopoServer)'
         type: object
     served: true
     storage: true

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -2529,10 +2529,6 @@ spec:
                               type: array
                           type: object
                       type: object
-                      x-kubernetes-validations:
-                      - message: local topology servers (localTopoServer) are not
-                          yet supported
-                        rule: '!has(self.localTopoServer)'
                     zoneId:
                       description: |-
                         ZoneID indicates the physical availability zone ID (e.g. use1-az1).

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -190,28 +190,6 @@ func (r *MultigresClusterReconciler) Reconcile(
 	}
 
 	{
-		ctx, childSpan := monitoring.StartChildSpan(ctx, "MultigresCluster.ReconcileTopology")
-		result, err := r.reconcileTopology(ctx, cluster, res)
-		if err != nil {
-			monitoring.RecordSpanError(childSpan, err)
-			childSpan.End()
-			l.Error(err, "Failed to reconcile topology")
-			r.Recorder.Eventf(
-				cluster,
-				"Warning",
-				"FailedApply",
-				"Failed to reconcile topology: %v",
-				err,
-			)
-			return ctrl.Result{}, err
-		}
-		childSpan.End()
-		if result.RequeueAfter > 0 {
-			return result, nil
-		}
-	}
-
-	{
 		ctx, childSpan := monitoring.StartChildSpan(
 			ctx,
 			"MultigresCluster.ReconcileCertificate",
@@ -252,6 +230,28 @@ func (r *MultigresClusterReconciler) Reconcile(
 			return ctrl.Result{}, err
 		}
 		childSpan.End()
+	}
+
+	{
+		ctx, childSpan := monitoring.StartChildSpan(ctx, "MultigresCluster.ReconcileTopology")
+		result, err := r.reconcileTopology(ctx, cluster, res, pendingCells)
+		if err != nil {
+			monitoring.RecordSpanError(childSpan, err)
+			childSpan.End()
+			l.Error(err, "Failed to reconcile topology")
+			r.Recorder.Eventf(
+				cluster,
+				"Warning",
+				"FailedApply",
+				"Failed to reconcile topology: %v",
+				err,
+			)
+			return ctrl.Result{}, err
+		}
+		childSpan.End()
+		if result.RequeueAfter > 0 {
+			return result, nil
+		}
 	}
 
 	{

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
@@ -103,7 +103,13 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 	// Register all cells.
 	for _, cellCfg := range cluster.Spec.Cells {
 		if err := topo.RegisterCellFromSpec(
-			topoCtx, store, r.Recorder, cluster, cellCfg, localTopoSpecs[cellCfg.Name], globalTopoRef,
+			topoCtx,
+			store,
+			r.Recorder,
+			cluster,
+			cellCfg,
+			localTopoSpecs[cellCfg.Name],
+			globalTopoRef,
 			topo.ManagedLocalTopoServerAddress(
 				name.JoinWithConstraints(
 					name.DefaultConstraints, cluster.Name, string(cellCfg.Name)),

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
@@ -3,15 +3,21 @@ package multigrescluster
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/multigres/multigres/go/common/topoclient"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/data-handler/topo"
 	"github.com/multigres/multigres-operator/pkg/resolver"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+	"github.com/multigres/multigres-operator/pkg/util/name"
 )
 
 const (
@@ -29,6 +35,10 @@ const (
 	// TODO: switch to per-entity timeouts when multi-database support lands.
 	// With many cells/databases, later operations could hit the deadline.
 	topoOperationTimeout = 20 * time.Second
+
+	// localTopoServerRequeueDelay is the delay before retrying topology
+	// registration when a managed local TopoServer is not ready yet.
+	localTopoServerRequeueDelay = 5 * time.Second
 )
 
 // reconcileTopology registers cells and databases in the topology server
@@ -38,12 +48,42 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
 	res *resolver.Resolver,
+	preservePendingDeletionCells ...bool,
 ) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+	preservePendingCells := len(preservePendingDeletionCells) > 0 &&
+		preservePendingDeletionCells[0]
 
 	globalTopoRef, err := r.globalTopoRef(ctx, cluster, res)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get global topo ref: %w", err)
+	}
+
+	localTopoSpecs := make(map[multigresv1alpha1.CellName]*multigresv1alpha1.LocalTopoServerSpec,
+		len(cluster.Spec.Cells))
+	for _, cellCfg := range cluster.Spec.Cells {
+		cellCfgForResolution := cellCfg
+		if cellCfgForResolution.CellTemplate == "" &&
+			cluster.Spec.TemplateDefaults.CellTemplate != "" {
+			cellCfgForResolution.CellTemplate = cluster.Spec.TemplateDefaults.CellTemplate
+		}
+		_, _, localTopoSpec, err := res.ResolveCell(ctx, &cellCfgForResolution)
+		if err != nil {
+			r.Recorder.Event(cluster, "Warning", "TemplateMissing", err.Error())
+			return ctrl.Result{}, fmt.Errorf("failed to resolve cell '%s': %w", cellCfg.Name, err)
+		}
+		localTopoSpecs[cellCfg.Name] = localTopoSpec
+		if localTopoSpec != nil && localTopoSpec.Etcd != nil {
+			ready, err := r.managedLocalTopoServerReady(ctx, cluster, cellCfg)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if !ready {
+				logger.V(1).Info("Waiting for managed local TopoServer before registering cell",
+					"cell", cellCfg.Name)
+				return ctrl.Result{RequeueAfter: localTopoServerRequeueDelay}, nil
+			}
+		}
 	}
 
 	store, err := r.openTopoStore(globalTopoRef)
@@ -62,19 +102,13 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 
 	// Register all cells.
 	for _, cellCfg := range cluster.Spec.Cells {
-		cellCfgForResolution := cellCfg
-		if cellCfgForResolution.CellTemplate == "" &&
-			cluster.Spec.TemplateDefaults.CellTemplate != "" {
-			cellCfgForResolution.CellTemplate = cluster.Spec.TemplateDefaults.CellTemplate
-		}
-		_, _, localTopoSpec, err := res.ResolveCell(ctx, &cellCfgForResolution)
-		if err != nil {
-			r.Recorder.Event(cluster, "Warning", "TemplateMissing", err.Error())
-			return ctrl.Result{}, fmt.Errorf("failed to resolve cell '%s': %w", cellCfg.Name, err)
-		}
-
 		if err := topo.RegisterCellFromSpec(
-			topoCtx, store, r.Recorder, cluster, cellCfg, localTopoSpec, globalTopoRef,
+			topoCtx, store, r.Recorder, cluster, cellCfg, localTopoSpecs[cellCfg.Name], globalTopoRef,
+			topo.ManagedLocalTopoServerAddress(
+				name.JoinWithConstraints(
+					name.DefaultConstraints, cluster.Name, string(cellCfg.Name)),
+				cluster.Namespace,
+			),
 		); err != nil {
 			if topo.IsTopoUnavailable(err) {
 				return r.handleTopoUnavailable(cluster, logger)
@@ -120,11 +154,15 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 			return ctrl.Result{}, fmt.Errorf("failed to prune databases: %w", err)
 		}
 
-		specCellNames := make([]string, 0, len(cluster.Spec.Cells))
-		for _, c := range cluster.Spec.Cells {
-			specCellNames = append(specCellNames, string(c.Name))
+		cellNames := specCellNames(cluster)
+		if preservePendingCells {
+			var err error
+			cellNames, err = r.cellNamesToKeepInTopology(ctx, cluster)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 		}
-		if err := topo.PruneCells(topoCtx, store, r.Recorder, cluster, specCellNames); err != nil {
+		if err := topo.PruneCells(topoCtx, store, r.Recorder, cluster, cellNames); err != nil {
 			if topo.IsTopoUnavailable(err) {
 				return r.handleTopoUnavailable(cluster, logger)
 			}
@@ -133,6 +171,85 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func specCellNames(cluster *multigresv1alpha1.MultigresCluster) []string {
+	names := make([]string, 0, len(cluster.Spec.Cells))
+	for _, c := range cluster.Spec.Cells {
+		names = append(names, string(c.Name))
+	}
+	return names
+}
+
+func (r *MultigresClusterReconciler) cellNamesToKeepInTopology(
+	ctx context.Context,
+	cluster *multigresv1alpha1.MultigresCluster,
+) ([]string, error) {
+	names := make(map[string]struct{}, len(cluster.Spec.Cells))
+	for _, c := range cluster.Spec.Cells {
+		names[string(c.Name)] = struct{}{}
+	}
+
+	cells := &multigresv1alpha1.CellList{}
+	if err := r.List(ctx, cells,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels{metadata.LabelMultigresCluster: cluster.Name},
+	); err != nil {
+		return nil, fmt.Errorf("failed to list cells for topology pruning: %w", err)
+	}
+	for i := range cells.Items {
+		cell := &cells.Items[i]
+		if cell.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
+			continue
+		}
+		names[string(cell.Spec.Name)] = struct{}{}
+	}
+
+	out := make([]string, 0, len(names))
+	for n := range names {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func (r *MultigresClusterReconciler) managedLocalTopoServerReady(
+	ctx context.Context,
+	cluster *multigresv1alpha1.MultigresCluster,
+	cellCfg multigresv1alpha1.CellConfig,
+) (bool, error) {
+	cellResourceName := name.JoinWithConstraints(
+		name.DefaultConstraints, cluster.Name, string(cellCfg.Name))
+	cell := &multigresv1alpha1.Cell{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      cellResourceName,
+		Namespace: cluster.Namespace,
+	}, cell); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get Cell %q for managed local TopoServer readiness: %w",
+			cellCfg.Name, err)
+	}
+
+	toposerver := &multigresv1alpha1.TopoServer{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      topo.ManagedLocalTopoServerName(cellResourceName),
+		Namespace: cluster.Namespace,
+	}, toposerver); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get managed local TopoServer for cell %q: %w",
+			cellCfg.Name, err)
+	}
+	controller := metav1.GetControllerOf(toposerver)
+	if controller == nil || controller.UID != cell.UID {
+		return false, nil
+	}
+
+	return toposerver.Status.ObservedGeneration == toposerver.Generation &&
+		toposerver.Status.Phase == multigresv1alpha1.PhaseHealthy, nil
 }
 
 // openTopoStore opens a topology store, using the injected factory for tests

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_test.go
@@ -7,11 +7,15 @@ import (
 
 	"github.com/multigres/multigres/go/common/topoclient"
 	"github.com/multigres/multigres/go/common/topoclient/memorytopo"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/data-handler/topo"
 	"github.com/multigres/multigres-operator/pkg/resolver"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+	"github.com/multigres/multigres-operator/pkg/util/name"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -59,12 +63,16 @@ func TestReconcileTopologySharedTopo(t *testing.T) {
 		},
 	}
 
-	if _, err := reconciler.reconcileTopology(
+	result, err := reconciler.reconcileTopology(
 		context.Background(),
 		cluster,
 		resolver.NewResolver(client, "default"),
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("reconcileTopology() error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("RequeueAfter = %v, want 0", result.RequeueAfter)
 	}
 
 	if openedRef.Address != "http://global-etcd:2379" {
@@ -94,6 +102,341 @@ func TestReconcileTopologySharedTopo(t *testing.T) {
 	}
 }
 
+func TestReconcileTopologyManagedLocalTopo(t *testing.T) {
+	t.Parallel()
+
+	scheme := setupScheme()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{
+					Endpoints: []multigresv1alpha1.EndpointUrl{"http://global-etcd:2379"},
+					RootPath:  "/multigres/global",
+				},
+			},
+			Cells: []multigresv1alpha1.CellConfig{{
+				Name:   "cell1",
+				ZoneID: "use1-az1",
+				Spec: &multigresv1alpha1.CellInlineSpec{
+					LocalTopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+						Etcd: &multigresv1alpha1.EtcdSpec{},
+					},
+				},
+			}},
+		},
+	}
+
+	store := newClusterTopologyMemoryStore(t)
+	k8sCell := expectedManagedLocalCell("cluster", "cell1", "default")
+	ts := healthyManagedLocalTopoServer(k8sCell)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+		WithObjects(cluster, k8sCell, ts).
+		Build()
+	ts.Status.ObservedGeneration = ts.Generation
+	if err := client.Status().Update(context.Background(), ts); err != nil {
+		t.Fatalf("failed to update TopoServer status: %v", err)
+	}
+	reconciler := &MultigresClusterReconciler{
+		Client:   client,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		CreateTopoStore: func(ref multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+			return noCloseStore{Store: store}, nil
+		},
+	}
+	result, err := reconciler.reconcileTopology(
+		context.Background(),
+		cluster,
+		resolver.NewResolver(client, "default"),
+	)
+	if err != nil {
+		t.Fatalf("reconcileTopology() error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("RequeueAfter = %v, want 0", result.RequeueAfter)
+	}
+
+	cell, err := store.GetCell(context.Background(), "cell1")
+	if err != nil {
+		t.Fatalf("cell not found: %v", err)
+	}
+	wantAddress := topo.ManagedLocalTopoServerAddress(
+		name.JoinWithConstraints(name.DefaultConstraints, "cluster", "cell1"),
+		"default",
+	)
+	if !reflect.DeepEqual(cell.ServerAddresses, []string{wantAddress}) {
+		t.Errorf("expected managed local topology service, got %v", cell.ServerAddresses)
+	}
+	if cell.Root != "/multigres/cell1" {
+		t.Errorf("expected default local root, got %q", cell.Root)
+	}
+}
+
+func TestReconcileTopologyWaitsForManagedLocalTopoNotOwnedByCell(t *testing.T) {
+	t.Parallel()
+
+	scheme := setupScheme()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{
+					Endpoints: []multigresv1alpha1.EndpointUrl{"http://global-etcd:2379"},
+					RootPath:  "/multigres/global",
+				},
+			},
+			Cells: []multigresv1alpha1.CellConfig{{
+				Name: "cell1",
+				Spec: &multigresv1alpha1.CellInlineSpec{
+					LocalTopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+						Etcd: &multigresv1alpha1.EtcdSpec{},
+					},
+				},
+			}},
+		},
+	}
+
+	cell := expectedManagedLocalCell("cluster", "cell1", "default")
+	ts := healthyManagedLocalTopoServer(cell)
+	ts.OwnerReferences = nil
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.TopoServer{}).
+		WithObjects(cluster, cell, ts).
+		Build()
+	ts.Status.ObservedGeneration = ts.Generation
+	if err := client.Status().Update(context.Background(), ts); err != nil {
+		t.Fatalf("failed to update TopoServer status: %v", err)
+	}
+	reconciler := &MultigresClusterReconciler{
+		Client:   client,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		CreateTopoStore: func(ref multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+			t.Fatal("topology store should not be opened for an unowned local TopoServer")
+			return nil, nil
+		},
+	}
+
+	result, err := reconciler.reconcileTopology(
+		context.Background(),
+		cluster,
+		resolver.NewResolver(client, "default"),
+	)
+	if err != nil {
+		t.Fatalf("reconcileTopology() error = %v", err)
+	}
+	if result.RequeueAfter != localTopoServerRequeueDelay {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, localTopoServerRequeueDelay)
+	}
+}
+
+func TestReconcileTopologyWaitsForManagedLocalTopo(t *testing.T) {
+	t.Parallel()
+
+	scheme := setupScheme()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{
+					Endpoints: []multigresv1alpha1.EndpointUrl{"http://global-etcd:2379"},
+					RootPath:  "/multigres/global",
+				},
+			},
+			Cells: []multigresv1alpha1.CellConfig{{
+				Name: "cell1",
+				Spec: &multigresv1alpha1.CellInlineSpec{
+					LocalTopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+						Etcd: &multigresv1alpha1.EtcdSpec{},
+					},
+				},
+			}},
+		},
+	}
+
+	store := newClusterTopologyMemoryStore(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	reconciler := &MultigresClusterReconciler{
+		Client:   client,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		CreateTopoStore: func(ref multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+			return noCloseStore{Store: store}, nil
+		},
+	}
+	result, err := reconciler.reconcileTopology(
+		context.Background(),
+		cluster,
+		resolver.NewResolver(client, "default"),
+	)
+	if err != nil {
+		t.Fatalf("reconcileTopology() error = %v", err)
+	}
+	if result.RequeueAfter != localTopoServerRequeueDelay {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, localTopoServerRequeueDelay)
+	}
+	if _, err := store.GetCell(context.Background(), "cell1"); err == nil {
+		t.Fatal("cell should not be registered before managed local TopoServer is ready")
+	}
+}
+
+func TestReconcileTopologyKeepsExistingCellRecordWhileManagedLocalTopoWaits(t *testing.T) {
+	t.Parallel()
+
+	scheme := setupScheme()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{
+					Endpoints: []multigresv1alpha1.EndpointUrl{"http://global-etcd:2379"},
+					RootPath:  "/multigres/global",
+				},
+			},
+			Cells: []multigresv1alpha1.CellConfig{{
+				Name: "cell1",
+				Spec: &multigresv1alpha1.CellInlineSpec{
+					LocalTopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+						Etcd: &multigresv1alpha1.EtcdSpec{},
+					},
+				},
+			}},
+		},
+	}
+
+	store := newClusterTopologyMemoryStore(t)
+	if err := topo.RegisterCellFromSpec(
+		context.Background(),
+		store,
+		record.NewFakeRecorder(10),
+		cluster,
+		multigresv1alpha1.CellConfig{Name: "cell1"},
+		nil,
+		multigresv1alpha1.GlobalTopoServerRef{
+			Address:  "http://global-etcd:2379",
+			RootPath: "/multigres/global",
+		},
+	); err != nil {
+		t.Fatalf("failed to seed existing cell topology: %v", err)
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	reconciler := &MultigresClusterReconciler{
+		Client:   client,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		CreateTopoStore: func(ref multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+			return noCloseStore{Store: store}, nil
+		},
+	}
+
+	result, err := reconciler.reconcileTopology(
+		context.Background(),
+		cluster,
+		resolver.NewResolver(client, "default"),
+	)
+	if err != nil {
+		t.Fatalf("reconcileTopology() error = %v", err)
+	}
+	if result.RequeueAfter != localTopoServerRequeueDelay {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, localTopoServerRequeueDelay)
+	}
+
+	cell, err := store.GetCell(context.Background(), "cell1")
+	if err != nil {
+		t.Fatalf("existing cell record should remain available: %v", err)
+	}
+	if !reflect.DeepEqual(cell.ServerAddresses, []string{"http://global-etcd:2379"}) {
+		t.Errorf("existing cell address = %v, want global topology address", cell.ServerAddresses)
+	}
+	if cell.Root != "/multigres/global" {
+		t.Errorf("existing cell root = %q, want /multigres/global", cell.Root)
+	}
+}
+
+func TestReconcileTopologyKeepsPendingDeletionCellRecord(t *testing.T) {
+	t.Parallel()
+
+	scheme := setupScheme()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{
+					Endpoints: []multigresv1alpha1.EndpointUrl{"http://global-etcd:2379"},
+					RootPath:  "/multigres/global",
+				},
+			},
+			Cells: []multigresv1alpha1.CellConfig{{Name: "cell1"}},
+		},
+	}
+	pendingCell := &multigresv1alpha1.Cell{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-cell2",
+			Namespace: "default",
+			Labels: map[string]string{
+				metadata.LabelMultigresCluster: "cluster",
+			},
+			Annotations: map[string]string{
+				multigresv1alpha1.AnnotationPendingDeletion: "2026-05-21T00:00:00Z",
+			},
+		},
+		Spec: multigresv1alpha1.CellSpec{Name: "cell2"},
+	}
+
+	store := newClusterTopologyMemoryStore(t)
+	for _, cellName := range []multigresv1alpha1.CellName{"cell1", "cell2"} {
+		if err := topo.RegisterCellFromSpec(
+			context.Background(),
+			store,
+			record.NewFakeRecorder(10),
+			cluster,
+			multigresv1alpha1.CellConfig{Name: cellName},
+			nil,
+			multigresv1alpha1.GlobalTopoServerRef{
+				Address:  "http://global-etcd:2379",
+				RootPath: "/multigres/global",
+			},
+		); err != nil {
+			t.Fatalf("failed to seed cell %s topology: %v", cellName, err)
+		}
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, pendingCell).Build()
+	reconciler := &MultigresClusterReconciler{
+		Client:   client,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		CreateTopoStore: func(ref multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+			return noCloseStore{Store: store}, nil
+		},
+	}
+
+	result, err := reconciler.reconcileTopology(
+		context.Background(),
+		cluster,
+		resolver.NewResolver(client, "default"),
+		true,
+	)
+	if err != nil {
+		t.Fatalf("reconcileTopology() error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("RequeueAfter = %v, want 0", result.RequeueAfter)
+	}
+
+	if _, err := store.GetCell(context.Background(), "cell1"); err != nil {
+		t.Fatalf("active cell record should remain: %v", err)
+	}
+	if _, err := store.GetCell(context.Background(), "cell2"); err != nil {
+		t.Fatalf("pending-deletion cell record should remain until deletion completes: %v", err)
+	}
+}
+
 func newClusterTopologyMemoryStore(t *testing.T) topoclient.Store {
 	t.Helper()
 	_, factory := memorytopo.NewServerAndFactory(context.Background())
@@ -110,4 +453,42 @@ type noCloseStore struct {
 
 func (s noCloseStore) Close() error {
 	return nil
+}
+
+func expectedManagedLocalCell(clusterName, cellName, namespace string) *multigresv1alpha1.Cell {
+	return &multigresv1alpha1.Cell{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name.JoinWithConstraints(name.DefaultConstraints, clusterName, cellName),
+			Namespace: namespace,
+			UID:       types.UID(clusterName + "-" + cellName + "-uid"),
+		},
+		Spec: multigresv1alpha1.CellSpec{
+			Name: multigresv1alpha1.CellName(cellName),
+		},
+	}
+}
+
+func healthyManagedLocalTopoServer(cell *multigresv1alpha1.Cell) *multigresv1alpha1.TopoServer {
+	trueValue := true
+	return &multigresv1alpha1.TopoServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      topo.ManagedLocalTopoServerName(cell.Name),
+			Namespace: cell.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         multigresv1alpha1.GroupVersion.String(),
+				Kind:               "Cell",
+				Name:               cell.Name,
+				UID:                cell.UID,
+				Controller:         &trueValue,
+				BlockOwnerDeletion: &trueValue,
+			}},
+		},
+		Spec: multigresv1alpha1.TopoServerSpec{
+			Etcd: &multigresv1alpha1.EtcdSpec{},
+		},
+		Status: multigresv1alpha1.TopoServerStatus{
+			ObservedGeneration: 1,
+			Phase:              multigresv1alpha1.PhaseHealthy,
+		},
+	}
 }

--- a/pkg/data-handler/topo/cell.go
+++ b/pkg/data-handler/topo/cell.go
@@ -25,8 +25,12 @@ func RegisterCell(
 
 	cellName := string(cell.Spec.Name)
 
-	cellMetadata := cellMetadataFromTopoRefs(cellName, cell.Spec.TopoServer, cell.Spec.GlobalTopoServer,
-		ManagedLocalTopoServerAddress(cell.Name, cell.Namespace))
+	cellMetadata := cellMetadataFromTopoRefs(
+		cellName,
+		cell.Spec.TopoServer,
+		cell.Spec.GlobalTopoServer,
+		ManagedLocalTopoServerAddress(cell.Name, cell.Namespace),
+	)
 
 	created, err := createOrUpdateCell(ctx, store, cellName, cellMetadata)
 	if err != nil {

--- a/pkg/data-handler/topo/cell.go
+++ b/pkg/data-handler/topo/cell.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/name"
 )
 
 // RegisterCell registers the cell metadata in the global topology.
@@ -24,9 +25,8 @@ func RegisterCell(
 
 	cellName := string(cell.Spec.Name)
 
-	cellMetadata := cellMetadataFromTopoRefs(
-		cellName, cell.Spec.TopoServer, cell.Spec.GlobalTopoServer,
-	)
+	cellMetadata := cellMetadataFromTopoRefs(cellName, cell.Spec.TopoServer, cell.Spec.GlobalTopoServer,
+		ManagedLocalTopoServerAddress(cell.Name, cell.Namespace))
 
 	created, err := createOrUpdateCell(ctx, store, cellName, cellMetadata)
 	if err != nil {
@@ -60,6 +60,7 @@ func cellMetadataFromTopoRefs(
 	cellName string,
 	localTopo *multigresv1alpha1.LocalTopoServerSpec,
 	globalTopo multigresv1alpha1.GlobalTopoServerRef,
+	managedTopoAddress string,
 ) *clustermetadata.Cell {
 	if localTopo != nil && localTopo.External != nil && len(localTopo.External.Endpoints) > 0 {
 		addresses := make([]string, 0, len(localTopo.External.Endpoints))
@@ -70,6 +71,17 @@ func cellMetadataFromTopoRefs(
 			Name:            cellName,
 			ServerAddresses: addresses,
 			Root:            localTopo.External.RootPath,
+		}
+	}
+	if localTopo != nil && localTopo.Etcd != nil && managedTopoAddress != "" {
+		rootPath := localTopo.Etcd.RootPath
+		if rootPath == "" {
+			rootPath = fmt.Sprintf("/multigres/%s", cellName)
+		}
+		return &clustermetadata.Cell{
+			Name:            cellName,
+			ServerAddresses: []string{managedTopoAddress},
+			Root:            rootPath,
 		}
 	}
 
@@ -106,6 +118,18 @@ func createOrUpdateCell(
 		return false, fmt.Errorf("failed to create cell in topology: %w", err)
 	}
 	return true, nil
+}
+
+// ManagedLocalTopoServerName returns the operator-managed local TopoServer name
+// for a Cell resource name.
+func ManagedLocalTopoServerName(cellResourceName string) string {
+	return name.JoinWithConstraints(name.StatefulSetConstraints, cellResourceName, "topo")
+}
+
+// ManagedLocalTopoServerAddress returns the in-cluster client Service address
+// for a managed local TopoServer.
+func ManagedLocalTopoServerAddress(cellResourceName, namespace string) string {
+	return fmt.Sprintf("%s.%s.svc:2379", ManagedLocalTopoServerName(cellResourceName), namespace)
 }
 
 // UnregisterCell removes the cell metadata from the global topology.

--- a/pkg/data-handler/topo/topology.go
+++ b/pkg/data-handler/topo/topology.go
@@ -118,11 +118,17 @@ func RegisterCellFromSpec(
 	cellConfig multigresv1alpha1.CellConfig,
 	localTopo *multigresv1alpha1.LocalTopoServerSpec,
 	topoRef multigresv1alpha1.GlobalTopoServerRef,
+	managedTopoAddress ...string,
 ) error {
 	logger := log.FromContext(ctx)
 	cellName := string(cellConfig.Name)
 
-	cellMetadata := cellMetadataFromTopoRefs(cellName, localTopo, topoRef)
+	managedAddress := ""
+	if len(managedTopoAddress) > 0 {
+		managedAddress = managedTopoAddress[0]
+	}
+
+	cellMetadata := cellMetadataFromTopoRefs(cellName, localTopo, topoRef, managedAddress)
 
 	created, err := createOrUpdateCell(ctx, store, cellName, cellMetadata)
 	if err != nil {

--- a/pkg/data-handler/topo/topology_test.go
+++ b/pkg/data-handler/topo/topology_test.go
@@ -485,6 +485,43 @@ func TestRegisterCellFromSpec(t *testing.T) {
 		}
 	})
 
+	t.Run("uses managed local topology address for etcd local topology", func(t *testing.T) {
+		t.Parallel()
+		store := newMemoryStore(t, "cell1")
+		recorder := record.NewFakeRecorder(10)
+
+		localTopo := &multigresv1alpha1.LocalTopoServerSpec{
+			Etcd: &multigresv1alpha1.EtcdSpec{
+				RootPath: "/multigres/cells/cell2",
+			},
+		}
+		managedAddress := topo.ManagedLocalTopoServerAddress("cluster-cell2", "default")
+		err := topo.RegisterCellFromSpec(
+			context.Background(),
+			store,
+			recorder,
+			owner,
+			multigresv1alpha1.CellConfig{Name: "cell2"},
+			localTopo,
+			topoRef,
+			managedAddress,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		cell, err := store.GetCell(context.Background(), "cell2")
+		if err != nil {
+			t.Fatalf("cell not found: %v", err)
+		}
+		if !reflect.DeepEqual(cell.ServerAddresses, []string{managedAddress}) {
+			t.Errorf("expected managed local topo address, got %v", cell.ServerAddresses)
+		}
+		if cell.Root != "/multigres/cells/cell2" {
+			t.Errorf("expected managed local topo root, got %s", cell.Root)
+		}
+	})
+
 	t.Run("returns error on CreateCell failure", func(t *testing.T) {
 		t.Parallel()
 		store := &mockTopologyStore{

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -317,8 +317,13 @@ func (r *CellReconciler) localTopoServerReady(
 		return false, fmt.Errorf("failed to get local TopoServer: %w", err)
 	}
 	if !isControlledByCell(toposerver, cell) {
-		return false, fmt.Errorf("refusing to use local TopoServer %s/%s not controlled by Cell %s/%s",
-			toposerver.Namespace, toposerver.Name, cell.Namespace, cell.Name)
+		return false, fmt.Errorf(
+			"refusing to use local TopoServer %s/%s not controlled by Cell %s/%s",
+			toposerver.Namespace,
+			toposerver.Name,
+			cell.Namespace,
+			cell.Name,
+		)
 	}
 
 	return toposerver.Status.ObservedGeneration == toposerver.Generation &&
@@ -425,8 +430,13 @@ func (r *CellReconciler) deleteLocalTopoServerIfExists(
 		return false, fmt.Errorf("failed to get local TopoServer: %w", err)
 	}
 	if !isControlledByCell(toposerver, cell) {
-		return false, fmt.Errorf("refusing to delete local TopoServer %s/%s not controlled by Cell %s/%s",
-			toposerver.Namespace, toposerver.Name, cell.Namespace, cell.Name)
+		return false, fmt.Errorf(
+			"refusing to delete local TopoServer %s/%s not controlled by Cell %s/%s",
+			toposerver.Namespace,
+			toposerver.Name,
+			cell.Namespace,
+			cell.Name,
+		)
 	}
 	if !toposerver.DeletionTimestamp.IsZero() {
 		return true, nil

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -31,6 +31,11 @@ const (
 	// Cell is not Healthy. This allows detection of pod-level issues like
 	// CrashLoopBackOff that don't trigger Deployment watch events.
 	statusRecheckDelay = 30 * time.Second
+
+	// localTopoServerRecheckDelay is the interval for rechecking a managed local
+	// TopoServer while waiting to create dependent gateway resources or complete
+	// Cell deletion.
+	localTopoServerRecheckDelay = 5 * time.Second
 )
 
 // CellReconciler reconciles a Cell object.
@@ -69,43 +74,43 @@ func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// If this Cell is pending deletion (from MultigresCluster pruning),
-	// set ReadyForDeletion immediately since Cells are stateless gateways.
+	// wait for any managed local topology server before marking it ready.
 	if cell.Annotations[multigresv1alpha1.AnnotationPendingDeletion] != "" {
-		if !meta.IsStatusConditionTrue(
-			cell.Status.Conditions,
-			multigresv1alpha1.ConditionReadyForDeletion,
-		) {
-			meta.SetStatusCondition(&cell.Status.Conditions, metav1.Condition{
-				Type:               multigresv1alpha1.ConditionReadyForDeletion,
-				Status:             metav1.ConditionTrue,
-				Reason:             "StatelessComponent",
-				Message:            "Cell is stateless; ready for deletion",
-				ObservedGeneration: cell.Generation,
-			})
-			patchObj := &multigresv1alpha1.Cell{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: multigresv1alpha1.GroupVersion.String(),
-					Kind:       "Cell",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      cell.Name,
-					Namespace: cell.Namespace,
-				},
-				Status: cell.Status,
-			}
-			if err := r.Status().Patch(ctx, patchObj, client.Apply,
-				client.FieldOwner("multigres-operator"), client.ForceOwnership); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to set ReadyForDeletion on Cell: %w", err)
-			}
-			r.Recorder.Eventf(cell, "Normal", "ReadyForDeletion",
-				"Cell %s marked ready for deletion", cell.Name)
-		}
-		return ctrl.Result{}, nil
+		return r.handlePendingDeletion(ctx, cell)
 	}
 
 	// If being deleted, let Kubernetes GC handle cleanup
 	if !cell.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, nil
+	}
+
+	// Reconcile managed local TopoServer, when configured.
+	{
+		ctx, childSpan := monitoring.StartChildSpan(ctx, "Cell.ReconcileLocalTopoServer")
+		if err := r.reconcileLocalTopoServer(ctx, cell); err != nil {
+			monitoring.RecordSpanError(childSpan, err)
+			childSpan.End()
+			logger.Error(err, "Failed to reconcile local TopoServer")
+			r.Recorder.Eventf(
+				cell,
+				"Warning",
+				"FailedApply",
+				"Failed to reconcile local TopoServer: %v",
+				err,
+			)
+			return ctrl.Result{}, err
+		}
+		childSpan.End()
+	}
+	if ready, err := r.localTopoServerReady(ctx, cell); err != nil {
+		logger.Error(err, "Failed to check local TopoServer readiness")
+		return ctrl.Result{}, err
+	} else if !ready {
+		logger.V(1).Info("Waiting for local TopoServer before reconciling gateway")
+		if err := r.patchLocalTopoServerWaitingStatus(ctx, cell); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: localTopoServerRecheckDelay}, nil
 	}
 
 	// Reconcile MultiGateway Deployment
@@ -233,6 +238,266 @@ func (r *CellReconciler) reconcileMultiGatewayService(
 		desired.Name,
 	)
 
+	return nil
+}
+
+// reconcileLocalTopoServer creates or updates the managed local TopoServer for a Cell.
+func (r *CellReconciler) reconcileLocalTopoServer(
+	ctx context.Context,
+	cell *multigresv1alpha1.Cell,
+) error {
+	desired, err := BuildLocalTopoServer(cell, r.Scheme)
+	if err != nil {
+		return fmt.Errorf("failed to build local TopoServer: %w", err)
+	}
+	if desired == nil {
+		deleted, err := r.deleteOwnedLocalTopoServerIfExists(ctx, cell)
+		if err != nil {
+			return err
+		}
+		if deleted {
+			r.Recorder.Eventf(cell, "Normal", "Deleted",
+				"Deleted stale local TopoServer %s", BuildLocalTopoServerName(cell))
+		}
+		return nil
+	}
+
+	existing := &multigresv1alpha1.TopoServer{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      desired.Name,
+		Namespace: desired.Namespace,
+	}, existing); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get local TopoServer: %w", err)
+		}
+	} else if !isControlledByCell(existing, cell) {
+		return fmt.Errorf("refusing to manage local TopoServer %s/%s not controlled by Cell %s/%s",
+			existing.Namespace, existing.Name, cell.Namespace, cell.Name)
+	}
+
+	desired.SetGroupVersionKind(multigresv1alpha1.GroupVersion.WithKind("TopoServer"))
+	if err := r.Patch(
+		ctx,
+		desired,
+		client.Apply,
+		client.ForceOwnership,
+		client.FieldOwner("multigres-operator"),
+	); err != nil {
+		return fmt.Errorf("failed to apply local TopoServer: %w", err)
+	}
+
+	r.Recorder.Eventf(
+		cell,
+		"Normal",
+		"Applied",
+		"Applied %s %s",
+		desired.GroupVersionKind().Kind,
+		desired.Name,
+	)
+
+	return nil
+}
+
+func (r *CellReconciler) localTopoServerReady(
+	ctx context.Context,
+	cell *multigresv1alpha1.Cell,
+) (bool, error) {
+	if !hasManagedLocalTopoServer(cell) {
+		return true, nil
+	}
+
+	toposerver := &multigresv1alpha1.TopoServer{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      BuildLocalTopoServerName(cell),
+		Namespace: cell.Namespace,
+	}, toposerver); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get local TopoServer: %w", err)
+	}
+	if !isControlledByCell(toposerver, cell) {
+		return false, fmt.Errorf("refusing to use local TopoServer %s/%s not controlled by Cell %s/%s",
+			toposerver.Namespace, toposerver.Name, cell.Namespace, cell.Name)
+	}
+
+	return toposerver.Status.ObservedGeneration == toposerver.Generation &&
+		toposerver.Status.Phase == multigresv1alpha1.PhaseHealthy, nil
+}
+
+func (r *CellReconciler) handlePendingDeletion(
+	ctx context.Context,
+	cell *multigresv1alpha1.Cell,
+) (ctrl.Result, error) {
+	reason := "StatelessComponent"
+	message := "Cell has no managed local TopoServer; ready for deletion"
+
+	absent, err := r.ensureLocalTopoServerDeleted(ctx, cell)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !absent {
+		if err := r.patchReadyForDeletionCondition(ctx, cell, metav1.Condition{
+			Type:               multigresv1alpha1.ConditionReadyForDeletion,
+			Status:             metav1.ConditionFalse,
+			Reason:             "LocalTopoServerDeleting",
+			Message:            "Waiting for managed local TopoServer deletion",
+			ObservedGeneration: cell.Generation,
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: localTopoServerRecheckDelay}, nil
+	}
+
+	if hasManagedLocalTopoServer(cell) {
+		reason = "LocalTopoServerDeleted"
+		message = "Managed local TopoServer is deleted; ready for deletion"
+	}
+
+	if !meta.IsStatusConditionTrue(
+		cell.Status.Conditions,
+		multigresv1alpha1.ConditionReadyForDeletion,
+	) {
+		if err := r.patchReadyForDeletionCondition(ctx, cell, metav1.Condition{
+			Type:               multigresv1alpha1.ConditionReadyForDeletion,
+			Status:             metav1.ConditionTrue,
+			Reason:             reason,
+			Message:            message,
+			ObservedGeneration: cell.Generation,
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.Recorder.Eventf(cell, "Normal", "ReadyForDeletion",
+			"Cell %s marked ready for deletion", cell.Name)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *CellReconciler) ensureLocalTopoServerDeleted(
+	ctx context.Context,
+	cell *multigresv1alpha1.Cell,
+) (bool, error) {
+	deleted, err := r.deleteLocalTopoServerIfExists(ctx, cell)
+	if err != nil {
+		return false, err
+	}
+	return !deleted, nil
+}
+
+func (r *CellReconciler) deleteOwnedLocalTopoServerIfExists(
+	ctx context.Context,
+	cell *multigresv1alpha1.Cell,
+) (bool, error) {
+	toposerver := &multigresv1alpha1.TopoServer{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      BuildLocalTopoServerName(cell),
+		Namespace: cell.Namespace,
+	}, toposerver); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get local TopoServer: %w", err)
+	}
+	if !isControlledByCell(toposerver, cell) {
+		return false, nil
+	}
+	if !toposerver.DeletionTimestamp.IsZero() {
+		return true, nil
+	}
+	if err := r.Delete(ctx, toposerver); err != nil && !errors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to delete local TopoServer: %w", err)
+	}
+	return true, nil
+}
+
+func (r *CellReconciler) deleteLocalTopoServerIfExists(
+	ctx context.Context,
+	cell *multigresv1alpha1.Cell,
+) (bool, error) {
+	toposerver := &multigresv1alpha1.TopoServer{}
+	if err := r.Get(ctx, client.ObjectKey{
+		Name:      BuildLocalTopoServerName(cell),
+		Namespace: cell.Namespace,
+	}, toposerver); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get local TopoServer: %w", err)
+	}
+	if !isControlledByCell(toposerver, cell) {
+		return false, fmt.Errorf("refusing to delete local TopoServer %s/%s not controlled by Cell %s/%s",
+			toposerver.Namespace, toposerver.Name, cell.Namespace, cell.Name)
+	}
+	if !toposerver.DeletionTimestamp.IsZero() {
+		return true, nil
+	}
+	if err := r.Delete(ctx, toposerver); err != nil && !errors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to delete local TopoServer: %w", err)
+	}
+	return true, nil
+}
+
+func (r *CellReconciler) patchReadyForDeletionCondition(
+	ctx context.Context,
+	cell *multigresv1alpha1.Cell,
+	condition metav1.Condition,
+) error {
+	meta.SetStatusCondition(&cell.Status.Conditions, condition)
+	patchObj := &multigresv1alpha1.Cell{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: multigresv1alpha1.GroupVersion.String(),
+			Kind:       "Cell",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cell.Name,
+			Namespace: cell.Namespace,
+		},
+		Status: cell.Status,
+	}
+	if err := r.Status().Patch(ctx, patchObj, client.Apply,
+		client.FieldOwner("multigres-operator"), client.ForceOwnership); err != nil {
+		return fmt.Errorf("failed to patch ReadyForDeletion on Cell: %w", err)
+	}
+	return nil
+}
+
+func (r *CellReconciler) patchLocalTopoServerWaitingStatus(
+	ctx context.Context,
+	cell *multigresv1alpha1.Cell,
+) error {
+	meta.SetStatusCondition(&cell.Status.Conditions, metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionFalse,
+		Reason:             "LocalTopoServerNotReady",
+		Message:            "Waiting for managed local TopoServer to become ready",
+		ObservedGeneration: cell.Generation,
+	})
+	meta.SetStatusCondition(&cell.Status.Conditions, metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionFalse,
+		Reason:             "LocalTopoServerNotReady",
+		Message:            "Waiting for managed local TopoServer to become ready",
+		ObservedGeneration: cell.Generation,
+	})
+	cell.Status.Phase = multigresv1alpha1.PhaseProgressing
+	cell.Status.Message = "Waiting for managed local TopoServer to become ready"
+	cell.Status.ObservedGeneration = cell.Generation
+
+	patchObj := &multigresv1alpha1.Cell{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: multigresv1alpha1.GroupVersion.String(),
+			Kind:       "Cell",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cell.Name,
+			Namespace: cell.Namespace,
+		},
+		Status: cell.Status,
+	}
+	if err := r.Status().Patch(ctx, patchObj, client.Apply,
+		client.FieldOwner("multigres-operator"), client.ForceOwnership); err != nil {
+		return fmt.Errorf("failed to patch local TopoServer waiting status on Cell: %w", err)
+	}
 	return nil
 }
 
@@ -397,6 +662,7 @@ func (r *CellReconciler) SetupWithManager(mgr ctrl.Manager, opts ...controller.O
 		For(&multigresv1alpha1.Cell{},
 			builder.WithPredicates(projectRefOrGenerationChangedPredicate()),
 		).
+		Owns(&multigresv1alpha1.TopoServer{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		WithOptions(controllerOpts).

--- a/pkg/resource-handler/controller/cell/integration_test.go
+++ b/pkg/resource-handler/controller/cell/integration_test.go
@@ -4,14 +4,18 @@
 package cell_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -665,6 +669,7 @@ func TestCellReconciliation(t *testing.T) {
 			if err := client.Create(ctx, tc.cell); err != nil {
 				t.Fatalf("Failed to create the initial item, %v", err)
 			}
+			markManagedLocalTopoServerHealthy(t, ctx, client, tc.cell)
 
 			// Patch wantResources with hashed names
 			for _, obj := range tc.wantResources {
@@ -718,6 +723,42 @@ func TestCellReconciliation(t *testing.T) {
 }
 
 // Test helpers
+
+func markManagedLocalTopoServerHealthy(
+	t testing.TB,
+	ctx context.Context,
+	k8sClient client.Client,
+	cell *multigresv1alpha1.Cell,
+) {
+	t.Helper()
+	if cell.Spec.TopoServer == nil || cell.Spec.TopoServer.Etcd == nil {
+		return
+	}
+
+	toposerver := &multigresv1alpha1.TopoServer{}
+	key := client.ObjectKey{
+		Namespace: cell.Namespace,
+		Name:      cellcontroller.BuildLocalTopoServerName(cell),
+	}
+	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			if err := k8sClient.Get(ctx, key, toposerver); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		}); err != nil {
+		t.Fatalf("Timed out waiting for managed local TopoServer %s/%s: %v", key.Namespace, key.Name, err)
+	}
+
+	toposerver.Status.Phase = multigresv1alpha1.PhaseHealthy
+	toposerver.Status.ObservedGeneration = toposerver.Generation
+	if err := k8sClient.Status().Update(ctx, toposerver); err != nil {
+		t.Fatalf("Failed to mark managed local TopoServer %s/%s healthy: %v", key.Namespace, key.Name, err)
+	}
+}
 
 // cellLabels returns standard labels for cell resources in tests
 func cellLabels(t testing.TB, instanceName, component, cellName, zoneID string) map[string]string {

--- a/pkg/resource-handler/controller/cell/local_toposerver.go
+++ b/pkg/resource-handler/controller/cell/local_toposerver.go
@@ -1,0 +1,70 @@
+package cell
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/data-handler/topo"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+// BuildLocalTopoServerName returns the managed TopoServer name for a Cell.
+func BuildLocalTopoServerName(cell *multigresv1alpha1.Cell) string {
+	return topo.ManagedLocalTopoServerName(cell.Name)
+}
+
+func hasManagedLocalTopoServer(cell *multigresv1alpha1.Cell) bool {
+	return cell.Spec.TopoServer != nil && cell.Spec.TopoServer.Etcd != nil
+}
+
+func isControlledByCell(obj metav1.Object, cell *multigresv1alpha1.Cell) bool {
+	controller := metav1.GetControllerOf(obj)
+	if controller == nil {
+		return false
+	}
+	if cell.UID != "" {
+		return controller.UID == cell.UID
+	}
+	return controller.APIVersion == multigresv1alpha1.GroupVersion.String() &&
+		controller.Kind == "Cell" &&
+		controller.Name == cell.Name
+}
+
+// BuildLocalTopoServer constructs the desired managed local TopoServer for a Cell.
+// External local topology is user-managed and does not need a child resource.
+func BuildLocalTopoServer(
+	cell *multigresv1alpha1.Cell,
+	scheme *runtime.Scheme,
+) (*multigresv1alpha1.TopoServer, error) {
+	if !hasManagedLocalTopoServer(cell) {
+		return nil, nil
+	}
+
+	etcd := cell.Spec.TopoServer.Etcd.DeepCopy()
+	clusterName := cell.Labels[metadata.LabelMultigresCluster]
+	labels := metadata.BuildStandardLabels(clusterName, "local-topo")
+	metadata.AddClusterLabel(labels, clusterName)
+	metadata.AddCellLabel(labels, cell.Spec.Name)
+
+	ts := &multigresv1alpha1.TopoServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BuildLocalTopoServerName(cell),
+			Namespace: cell.Namespace,
+			Labels:    labels,
+		},
+		Spec: multigresv1alpha1.TopoServerSpec{
+			Etcd:              etcd,
+			PVCDeletionPolicy: etcd.PVCDeletionPolicy,
+		},
+	}
+
+	if err := ctrl.SetControllerReference(cell, ts, scheme); err != nil {
+		return nil, fmt.Errorf("failed to set controller reference: %w", err)
+	}
+
+	return ts, nil
+}

--- a/pkg/resource-handler/controller/cell/local_toposerver_test.go
+++ b/pkg/resource-handler/controller/cell/local_toposerver_test.go
@@ -398,7 +398,9 @@ func TestCellReconcilerPendingDeletionWaitsForManagedLocalTopoServer(t *testing.
 	}
 }
 
-func TestCellReconcilerPendingDeletionDeletesObservedLocalTopoServerWhenSpecNoLongerManaged(t *testing.T) {
+func TestCellReconcilerPendingDeletionDeletesObservedLocalTopoServerWhenSpecNoLongerManaged(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	scheme := cellTestScheme(t)

--- a/pkg/resource-handler/controller/cell/local_toposerver_test.go
+++ b/pkg/resource-handler/controller/cell/local_toposerver_test.go
@@ -1,0 +1,597 @@
+package cell
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+func TestBuildLocalTopoServer(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	if err := multigresv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	cell := &multigresv1alpha1.Cell{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-zone-a",
+			Namespace: "default",
+			Labels: map[string]string{
+				metadata.LabelMultigresCluster: "cluster",
+			},
+		},
+		Spec: multigresv1alpha1.CellSpec{
+			Name: "zone-a",
+			TopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{
+					RootPath: "/multigres/zone-a",
+					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
+					},
+				},
+			},
+		},
+	}
+
+	got, err := BuildLocalTopoServer(cell, scheme)
+	if err != nil {
+		t.Fatalf("BuildLocalTopoServer() error = %v", err)
+	}
+	if got == nil {
+		t.Fatal("BuildLocalTopoServer() = nil, want TopoServer")
+	}
+	if got.Name != BuildLocalTopoServerName(cell) {
+		t.Errorf("name = %q, want %q", got.Name, BuildLocalTopoServerName(cell))
+	}
+	if got.Namespace != "default" {
+		t.Errorf("namespace = %q, want default", got.Namespace)
+	}
+	if got.Labels[metadata.LabelMultigresCluster] != "cluster" {
+		t.Errorf("cluster label = %q, want cluster", got.Labels[metadata.LabelMultigresCluster])
+	}
+	if got.Labels[metadata.LabelMultigresCell] != "zone-a" {
+		t.Errorf("cell label = %q, want zone-a", got.Labels[metadata.LabelMultigresCell])
+	}
+	if got.Spec.Etcd == nil || got.Spec.Etcd.RootPath != "/multigres/zone-a" {
+		t.Fatalf("etcd spec = %#v, want root path /multigres/zone-a", got.Spec.Etcd)
+	}
+	if got.Spec.PVCDeletionPolicy == nil ||
+		got.Spec.PVCDeletionPolicy.WhenDeleted != multigresv1alpha1.DeletePVCRetentionPolicy {
+		t.Fatalf("PVC deletion policy = %#v, want Delete", got.Spec.PVCDeletionPolicy)
+	}
+	if len(got.OwnerReferences) != 1 || got.OwnerReferences[0].Name != cell.Name {
+		t.Fatalf("owner references = %#v, want Cell owner", got.OwnerReferences)
+	}
+}
+
+func TestBuildLocalTopoServerExternalReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	cell := &multigresv1alpha1.Cell{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-zone-a", Namespace: "default"},
+		Spec: multigresv1alpha1.CellSpec{
+			Name: "zone-a",
+			TopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{
+					Endpoints: []multigresv1alpha1.EndpointUrl{"http://local:2379"},
+					RootPath:  "/multigres/zone-a",
+				},
+			},
+		},
+	}
+
+	got, err := BuildLocalTopoServer(cell, runtime.NewScheme())
+	if err != nil {
+		t.Fatalf("BuildLocalTopoServer() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("BuildLocalTopoServer() = %#v, want nil", got)
+	}
+}
+
+func TestBuildLocalTopoServerNameIsSafeForTopoServerChildren(t *testing.T) {
+	t.Parallel()
+
+	cell := &multigresv1alpha1.Cell{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: strings.Repeat("very-long-cell-name-", 20),
+		},
+	}
+
+	got := BuildLocalTopoServerName(cell)
+	if len(got) > 52 {
+		t.Fatalf("managed TopoServer name length = %d, want <= 52: %q", len(got), got)
+	}
+	if len(got+"-headless") > 63 {
+		t.Fatalf("managed TopoServer headless service name length = %d, want <= 63: %q",
+			len(got+"-headless"), got+"-headless")
+	}
+}
+
+func TestCellReconcilerWaitsForManagedLocalTopoServer(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell).
+		Build()
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cell.Name, Namespace: cell.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != localTopoServerRecheckDelay {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, localTopoServerRecheckDelay)
+	}
+
+	toposerver := &multigresv1alpha1.TopoServer{}
+	if err := fakeClient.Get(t.Context(), client.ObjectKey{
+		Name:      BuildLocalTopoServerName(cell),
+		Namespace: cell.Namespace,
+	}, toposerver); err != nil {
+		t.Fatalf("managed TopoServer should exist: %v", err)
+	}
+
+	deployment := &appsv1.Deployment{}
+	err = fakeClient.Get(t.Context(), client.ObjectKey{
+		Name:      "test-cluster-zone-a-multigateway",
+		Namespace: cell.Namespace,
+	}, deployment)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("MultiGateway Deployment get error = %v, want NotFound", err)
+	}
+}
+
+func TestCellReconcilerSetsWaitingStatusForManagedLocalTopoServer(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell).
+		Build()
+	cell.Status.Phase = multigresv1alpha1.PhaseHealthy
+	cell.Status.ObservedGeneration = cell.Generation
+	meta.SetStatusCondition(&cell.Status.Conditions, metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionTrue,
+		Reason:             "MultiGatewayAvailable",
+		ObservedGeneration: cell.Generation,
+	})
+	meta.SetStatusCondition(&cell.Status.Conditions, metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionTrue,
+		Reason:             "MultiGatewayReady",
+		ObservedGeneration: cell.Generation,
+	})
+	if err := fakeClient.Status().Update(t.Context(), cell); err != nil {
+		t.Fatalf("failed to seed Cell status: %v", err)
+	}
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	if _, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cell.Name, Namespace: cell.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	updatedCell := &multigresv1alpha1.Cell{}
+	if err := fakeClient.Get(t.Context(), client.ObjectKey{
+		Name:      cell.Name,
+		Namespace: cell.Namespace,
+	}, updatedCell); err != nil {
+		t.Fatalf("Cell get error = %v", err)
+	}
+	if updatedCell.Status.Phase != multigresv1alpha1.PhaseProgressing {
+		t.Fatalf("Phase = %s, want Progressing", updatedCell.Status.Phase)
+	}
+	for _, conditionType := range []string{"Available", "Ready"} {
+		condition := meta.FindStatusCondition(updatedCell.Status.Conditions, conditionType)
+		if condition == nil {
+			t.Fatalf("%s condition not found", conditionType)
+		}
+		if condition.Status != metav1.ConditionFalse ||
+			condition.Reason != "LocalTopoServerNotReady" {
+			t.Fatalf("%s = %s/%s, want False/LocalTopoServerNotReady",
+				conditionType, condition.Status, condition.Reason)
+		}
+		if condition.ObservedGeneration != updatedCell.Generation {
+			t.Fatalf("%s observedGeneration = %d, want %d",
+				conditionType, condition.ObservedGeneration, updatedCell.Generation)
+		}
+	}
+}
+
+func TestCellReconcilerDeletesStaleManagedLocalTopoServer(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	cell.Spec.TopoServer = &multigresv1alpha1.LocalTopoServerSpec{
+		External: &multigresv1alpha1.ExternalTopoServerSpec{
+			Endpoints: []multigresv1alpha1.EndpointUrl{"http://local-topo:2379"},
+			RootPath:  "/multigres/zone-a",
+		},
+	}
+	toposerver := controlledTopoServer(cell)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell, toposerver).
+		Build()
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	if _, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cell.Name, Namespace: cell.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &multigresv1alpha1.TopoServer{}
+	err := fakeClient.Get(t.Context(), client.ObjectKey{
+		Name:      toposerver.Name,
+		Namespace: toposerver.Namespace,
+	}, got)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("stale local TopoServer get error = %v, want NotFound", err)
+	}
+}
+
+func TestCellReconcilerIgnoresUnownedLocalTopoServerWhenNoManagedTopoDesired(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	cell.Spec.TopoServer = &multigresv1alpha1.LocalTopoServerSpec{
+		External: &multigresv1alpha1.ExternalTopoServerSpec{
+			Endpoints: []multigresv1alpha1.EndpointUrl{"http://local-topo:2379"},
+			RootPath:  "/multigres/zone-a",
+		},
+	}
+	toposerver := controlledTopoServer(cell)
+	toposerver.OwnerReferences = nil
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell, toposerver).
+		Build()
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	if _, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cell.Name, Namespace: cell.Namespace},
+	}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	got := &multigresv1alpha1.TopoServer{}
+	if err := fakeClient.Get(t.Context(), client.ObjectKey{
+		Name:      toposerver.Name,
+		Namespace: toposerver.Namespace,
+	}, got); err != nil {
+		t.Fatalf("unowned local TopoServer should be left alone: %v", err)
+	}
+}
+
+func TestCellReconcilerRefusesManagedLocalTopoServerNameConflict(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	toposerver := controlledTopoServer(cell)
+	toposerver.OwnerReferences = nil
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell, toposerver).
+		Build()
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	_, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cell.Name, Namespace: cell.Namespace},
+	})
+	if err == nil {
+		t.Fatal("Reconcile() error = nil, want name conflict")
+	}
+	if !strings.Contains(err.Error(), "not controlled by Cell") {
+		t.Fatalf("Reconcile() error = %v, want not controlled by Cell", err)
+	}
+}
+
+func TestCellReconcilerPendingDeletionWaitsForManagedLocalTopoServer(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	cell.Annotations = map[string]string{
+		multigresv1alpha1.AnnotationPendingDeletion: "true",
+	}
+	toposerver := controlledTopoServer(cell)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell, toposerver).
+		Build()
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cell.Name, Namespace: cell.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != localTopoServerRecheckDelay {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, localTopoServerRecheckDelay)
+	}
+
+	updatedCell := &multigresv1alpha1.Cell{}
+	if err := fakeClient.Get(t.Context(), client.ObjectKey{
+		Name:      cell.Name,
+		Namespace: cell.Namespace,
+	}, updatedCell); err != nil {
+		t.Fatalf("Cell get error = %v", err)
+	}
+	condition := meta.FindStatusCondition(
+		updatedCell.Status.Conditions,
+		multigresv1alpha1.ConditionReadyForDeletion,
+	)
+	if condition == nil {
+		t.Fatal("ReadyForDeletion condition not found")
+	}
+	if condition.Status != metav1.ConditionFalse || condition.Reason != "LocalTopoServerDeleting" {
+		t.Fatalf("ReadyForDeletion = %s/%s, want False/LocalTopoServerDeleting",
+			condition.Status, condition.Reason)
+	}
+}
+
+func TestCellReconcilerPendingDeletionDeletesObservedLocalTopoServerWhenSpecNoLongerManaged(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	cell.Annotations = map[string]string{
+		multigresv1alpha1.AnnotationPendingDeletion: "true",
+	}
+	cell.Spec.TopoServer = &multigresv1alpha1.LocalTopoServerSpec{
+		External: &multigresv1alpha1.ExternalTopoServerSpec{
+			Endpoints: []multigresv1alpha1.EndpointUrl{"http://local-topo:2379"},
+			RootPath:  "/multigres/zone-a",
+		},
+	}
+	toposerver := controlledTopoServer(cell)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell, toposerver).
+		Build()
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cell.Name, Namespace: cell.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != localTopoServerRecheckDelay {
+		t.Fatalf("RequeueAfter = %v, want %v", result.RequeueAfter, localTopoServerRecheckDelay)
+	}
+
+	got := &multigresv1alpha1.TopoServer{}
+	err = fakeClient.Get(t.Context(), client.ObjectKey{
+		Name:      toposerver.Name,
+		Namespace: toposerver.Namespace,
+	}, got)
+	if !errors.IsNotFound(err) {
+		t.Fatalf("local TopoServer get error = %v, want NotFound", err)
+	}
+}
+
+func TestCellReconcilerLocalTopoServerReadyRequiresObservedGeneration(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	toposerver := controlledTopoServer(cell)
+	toposerver.Generation = 2
+	toposerver.Status.ObservedGeneration = 1
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell, toposerver).
+		Build()
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	ready, err := reconciler.localTopoServerReady(t.Context(), cell)
+	if err != nil {
+		t.Fatalf("localTopoServerReady() error = %v", err)
+	}
+	if ready {
+		t.Fatal("localTopoServerReady() = true, want false for stale observedGeneration")
+	}
+}
+
+func TestCellReconcilerPendingDeletionReadyAfterManagedLocalTopoServerDeleted(t *testing.T) {
+	t.Parallel()
+
+	scheme := cellTestScheme(t)
+	cell := managedLocalTopoCell("test-cell")
+	cell.Annotations = map[string]string{
+		multigresv1alpha1.AnnotationPendingDeletion: "true",
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&multigresv1alpha1.Cell{}).
+		WithObjects(cell).
+		Build()
+
+	reconciler := &CellReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	result, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: cell.Name, Namespace: cell.Namespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Fatalf("RequeueAfter = %v, want 0", result.RequeueAfter)
+	}
+
+	updatedCell := &multigresv1alpha1.Cell{}
+	if err := fakeClient.Get(t.Context(), client.ObjectKey{
+		Name:      cell.Name,
+		Namespace: cell.Namespace,
+	}, updatedCell); err != nil {
+		t.Fatalf("Cell get error = %v", err)
+	}
+	condition := meta.FindStatusCondition(
+		updatedCell.Status.Conditions,
+		multigresv1alpha1.ConditionReadyForDeletion,
+	)
+	if condition == nil {
+		t.Fatal("ReadyForDeletion condition not found")
+	}
+	if condition.Status != metav1.ConditionTrue || condition.Reason != "LocalTopoServerDeleted" {
+		t.Fatalf("ReadyForDeletion = %s/%s, want True/LocalTopoServerDeleted",
+			condition.Status, condition.Reason)
+	}
+}
+
+func cellTestScheme(t testing.TB) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := multigresv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(multigres) error = %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(apps) error = %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core) error = %v", err)
+	}
+	return scheme
+}
+
+func managedLocalTopoCell(name string) *multigresv1alpha1.Cell {
+	return &multigresv1alpha1.Cell{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name + "-uid"),
+			Labels: map[string]string{
+				metadata.LabelMultigresCluster: "test-cluster",
+			},
+		},
+		Spec: multigresv1alpha1.CellSpec{
+			Name: "zone-a",
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+				Address:        "global-topo:2379",
+				RootPath:       "/multigres/global",
+				Implementation: "etcd",
+			},
+			TopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{
+					RootPath: "/multigres/zone-a",
+				},
+			},
+		},
+	}
+}
+
+func controlledTopoServer(cell *multigresv1alpha1.Cell) *multigresv1alpha1.TopoServer {
+	trueValue := true
+	return &multigresv1alpha1.TopoServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              BuildLocalTopoServerName(cell),
+			Namespace:         cell.Namespace,
+			Generation:        1,
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         multigresv1alpha1.GroupVersion.String(),
+					Kind:               "Cell",
+					Name:               cell.Name,
+					UID:                cell.UID,
+					Controller:         &trueValue,
+					BlockOwnerDeletion: &trueValue,
+				},
+			},
+		},
+		Spec: multigresv1alpha1.TopoServerSpec{
+			Etcd: &multigresv1alpha1.EtcdSpec{
+				RootPath: "/multigres/zone-a",
+			},
+		},
+		Status: multigresv1alpha1.TopoServerStatus{
+			ObservedGeneration: 1,
+			Phase:              multigresv1alpha1.PhaseHealthy,
+		},
+	}
+}


### PR DESCRIPTION
## Description

this PR builds on #493 by adding the operator-managed path for Cell-local TopoServers: while the first PR taught the system how to describe and register local topology, in this one we implement the actual path execution by having the operator create, own, wait for, and safely retire the per-Cell TopoServer that backs it. This lets Multigres keep global topo focused on cross-cell coordination while each Cell can use its own topology backend for Cell-scoped routing state, which is the shape we need for read-local/write-cross-cell behaviour without pushing all local routing state through the global topology server.

## Main Changes

- Enable `localTopoServer` in the API and generated CRDs.
- Add the managed Cell-local `TopoServer` lifecycle: create it from the Cell spec, own it through controller refs, wait for it to become ready, and clean it up during Cell retirement.
- Update global topology registration so Cell records only move to managed local topology once the owned local `TopoServer` is healthy, while preserving existing records during transitions and pending deletion.
- Treat ownership as the source of truth: same-name `TopoServer` objects are not trusted or deleted unless they are controlled by the expected `Cell`.

## Testing

The tests verify that managed local TopoServers are built with safe names and correct ownership, that Cells wait and report waiting status until local topology is ready, and that gateway resources are not created too early.

The cluster-level topology tests verify that global Cell records point at managed local topology only after the owned local TopoServer is healthy, that existing topology records are preserved while waiting, and that pending-deletion Cells are kept in global topology until their deletion lifecycle completes. There is also coverage for ownership conflicts, stale managed children, and switching from managed local topology back to external topology.
