### PR TITLE
chore(release): tighten workflow permissions

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -30,21 +30,24 @@ on:
         type: string
 
 permissions:
-  contents: write
-  packages: write
-  security-events: write
+  contents: read
 
 jobs:
   test-go:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Run tests
         run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
@@ -53,9 +56,15 @@ jobs:
   build-scan-push-container:
     needs: [ test-go ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -102,9 +111,11 @@ jobs:
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
 
       - name: Push to registry (sha)
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}
+          IMAGE_SHA: ${{ github.sha }}
         run: |
-          IMAGE="ghcr.io/${{ github.repository }}"
-          docker push "$IMAGE:${{ github.sha }}"
+          docker push "$IMAGE:$IMAGE_SHA"
 
       # grype requires that the container image be pushed already because
       # the scanner runs in a container with a different local registry
@@ -129,25 +140,33 @@ jobs:
 
       - name: Apply additional tags
         if: ${{ inputs.additional-tags != '' }}
+        env:
+          ADDITIONAL_TAGS: ${{ inputs.additional-tags }}
+          IMAGE: ghcr.io/${{ github.repository }}
+          IMAGE_SHA: ${{ github.sha }}
         run: |
-          IMAGE="ghcr.io/${{ github.repository }}"
-          for TAG in ${{ inputs.additional-tags }}; do
+          for TAG in $ADDITIONAL_TAGS; do
             docker buildx imagetools create \
               --tag "$IMAGE:$TAG" \
-              "$IMAGE:${{ github.sha }}"
+              "$IMAGE:$IMAGE_SHA"
           done
 
   validate-installer:
     needs: [ test-go ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Validate install manifests
         run: make build-installer
@@ -156,17 +175,24 @@ jobs:
     if: ${{ inputs.generate-manifests }}
     needs: [ build-scan-push-container ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Generate install manifests
-        run: make build-installer IMG=${{ inputs.manifest-image-ref }}
+        env:
+          MANIFEST_IMAGE_REF: ${{ inputs.manifest-image-ref }}
+        run: make build-installer IMG="$MANIFEST_IMAGE_REF"
 
       - name: Upload install manifests
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,9 +9,7 @@ on:
       - "**/*.txt"
 
 permissions:
-  contents: write
-  packages: write
-  security-events: write
+  contents: read
 
 jobs:
   build:
@@ -19,6 +17,10 @@ jobs:
     uses: ./.github/workflows/_reusable-build-changed.yaml
 
   run:
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
     uses: ./.github/workflows/build-and-release.yaml
     with:
       push-container-image: true
@@ -43,12 +45,13 @@ jobs:
 
       - name: Create or update current pre-release
         env:
+          COMMIT_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           BODY="## Current Build
 
-          **Commit:** \`${{ github.sha }}\`
+          **Commit:** \`$COMMIT_SHA\`
           **Updated:** \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`
 
           This is a rolling pre-release that tracks the latest successful build from \`main\`.
@@ -57,7 +60,7 @@ jobs:
           ### Quick Install
 
           \`\`\`
-          curl -LO https://github.com/${{ github.repository }}/releases/download/current/install.yaml
+          curl -LO https://github.com/$GH_REPO/releases/download/current/install.yaml
           kubectl apply -f install.yaml
           \`\`\`"
 
@@ -71,7 +74,7 @@ jobs:
             --prerelease \
             --title "Current (latest main)" \
             --notes "$BODY" \
-            --target "${{ github.sha }}" \
+            --target "$COMMIT_SHA" \
             dist/install*.yaml
 
   coverage:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,28 +6,36 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
-  contents: write
-  packages: write
-  security-events: write
+  contents: read
 
 jobs:
   verify-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify tag is on main
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
-            echo "::error::Tag ${{ github.ref_name }} does not point to a commit on the main branch. Delete the tag, ensure the commit is on main, and re-tag."
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag $TAG_NAME does not point to a commit on the main branch. Delete the tag, ensure the commit is on main, and re-tag."
             exit 1
           fi
 
   build:
     needs: verify-tag
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
     uses: ./.github/workflows/build-and-release.yaml
     with:
       push-container-image: true
@@ -45,6 +53,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download install manifests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -56,6 +65,7 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0


### PR DESCRIPTION
## Description

this PR tightens the operator release workflows for GA, following the same release-workflow hardening approach used in https://github.com/multigres/multigres/pull/1029 

## Changes

- Sets release-path workflow defaults to read-only permissions.
- Scopes `contents: write` to jobs that publish GitHub Releases.
- Scopes `packages: write` to the reusable job that publishes container images.
- Moves GitHub context values used by shell `run` blocks through `env`.
- Disables `actions/setup-go` cache use in release/publish workflow paths.
- Keeps pinned actions pinned.

## Behaviour

This keeps the existing operator release behaviour intact: tag triggers, GoReleaser release creation and notes, image publishing, generated install manifests, and the rolling internal `current` release process.
