### PR TITLE
fix: use correct sha for image versions

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -5,25 +5,25 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-ba3ed8e"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-5b9a7c6"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiAdminImage is the default container image for the MultiAdmin component.
-	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-ba3ed8e"
+	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-5b9a7c6"
 
 	// DefaultMultiAdminWebImage is the default container image for the MultiAdminWeb component.
 	DefaultMultiAdminWebImage = "ghcr.io/multigres/multiadmin-web:sha-c2db14c"
 
 	// DefaultMultiOrchImage is the default container image for the MultiOrch component.
-	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-ba3ed8e"
+	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-5b9a7c6"
 
 	// DefaultMultiPoolerImage is the default container image for the MultiPooler component.
-	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-ba3ed8e"
+	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-5b9a7c6"
 
 	// DefaultMultiGatewayImage is the default container image for the MultiGateway component.
-	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-ba3ed8e"
+	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-5b9a7c6"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
 	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"

--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -5,25 +5,25 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-5b9a7c6"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-d2c61f2"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiAdminImage is the default container image for the MultiAdmin component.
-	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-5b9a7c6"
+	DefaultMultiAdminImage = "ghcr.io/multigres/multigres:sha-d2c61f2"
 
 	// DefaultMultiAdminWebImage is the default container image for the MultiAdminWeb component.
 	DefaultMultiAdminWebImage = "ghcr.io/multigres/multiadmin-web:sha-c2db14c"
 
 	// DefaultMultiOrchImage is the default container image for the MultiOrch component.
-	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-5b9a7c6"
+	DefaultMultiOrchImage = "ghcr.io/multigres/multigres:sha-d2c61f2"
 
 	// DefaultMultiPoolerImage is the default container image for the MultiPooler component.
-	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-5b9a7c6"
+	DefaultMultiPoolerImage = "ghcr.io/multigres/multigres:sha-d2c61f2"
 
 	// DefaultMultiGatewayImage is the default container image for the MultiGateway component.
-	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-5b9a7c6"
+	DefaultMultiGatewayImage = "ghcr.io/multigres/multigres:sha-d2c61f2"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
 	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"


### PR DESCRIPTION
* The other sha specified does not point to a valid commit - it should use https://github.com/multigres/multigres/commit/5b9a7c6e32fb5c8224a51622fcb7ccaf0e74ced7 instead which corresponds to https://github.com/multigres/multigres/pkgs/container/multigres/881433391?tag=sha-5b9a7c6