### PR TITLE
fix(release): trigger release workflow on RC and prerelease tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
 
 permissions:
   contents: read

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,7 +64,7 @@ curl -sL https://github.com/multigres/multigres-operator/releases/download/vX.Y.
 
 ### Pre-releases
 
-Tags with a pre-release suffix (e.g., `v1.0.0-rc.1`) are automatically marked as pre-releases on GitHub. The pipeline is identical.
+Tags with a semver pre-release suffix (e.g., `v1.0.0-rc.1`, `v1.0.0-beta.2`, `v1.0.0-alpha.3`) trigger the same stable-lane pipeline and are automatically marked as pre-releases on GitHub by GoReleaser. The `latest` and `current` container tags are not moved by pre-release tag pushes, those are only updated on `main` pushes by the current lane.
 
 ## Container image tags on GHCR
 


### PR DESCRIPTION
Add a second tag pattern `v[0-9]+.[0-9]+.[0-9]+-*` so any semver prerelease suffix (`-rc.N`, `-beta.N`, `-alpha.N`, etc.) triggers the same stable lane pipeline. GoReleaser's `prerelease: auto` setting then flags the resulting GitHub Release as a pre-release automatically, and the image is tagged with the full prerelease ref. The `latest` and `current` rolling tags remain untouched because they are only updated by the current lane on `main` pushes.

Also tighten `RELEASE.md` to spell out the accepted prerelease suffixes and clarify the rolling-tag behaviour.