### PR TITLE
fix(e2e-test): look for postgres container within initContainers

### DIFF
--- a/pkg/testutil/envtest.go
+++ b/pkg/testutil/envtest.go
@@ -225,8 +225,10 @@ func startManager(t testing.TB, ctx context.Context, mgr manager.Manager) <-chan
 		}
 	}()
 
-	// Wait for cache to sync
-	if !mgr.GetCache().WaitForCacheSync(ctx) {
+	// Wait for cache to sync. WaitForCacheSync returns true immediately when
+	// there are no informers to wait on (e.g. an empty scheme), so also check
+	// the context: a cancelled/expired context means startup did not complete.
+	if !mgr.GetCache().WaitForCacheSync(ctx) || ctx.Err() != nil {
 		t.Fatal("Cache failed to sync")
 	}
 

--- a/test/e2e/fixtures/base.yaml
+++ b/test/e2e/fixtures/base.yaml
@@ -12,6 +12,7 @@ spec:
     whenScaled: Delete
   cells:
     - name: "zone-a"
+      zoneId: us-central1-a
   databases:
     - name: "postgres"
       default: true

--- a/test/e2e/fixtures/log-levels.yaml
+++ b/test/e2e/fixtures/log-levels.yaml
@@ -18,6 +18,7 @@ spec:
     multigateway: "debug"
   cells:
     - name: "zone-a"
+      zoneId: us-central1-a
   databases:
     - name: "postgres"
       default: true

--- a/test/e2e/fixtures/templated.yaml
+++ b/test/e2e/fixtures/templated.yaml
@@ -13,6 +13,7 @@ spec:
   coreTemplateRef: "e2e-core"
   cells:
     - name: "zone-a"
+      zoneId: us-central1-a
       cellTemplateRef: "e2e-cell"
   databases:
     - name: "postgres"

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -129,6 +129,15 @@ func setupCluster(name string) (*Cluster, error) {
 		provider:   p,
 	}
 
+	// Label nodes with cloud topology labels so pods with nodeSelectors
+	// derived from zoneId/region fields can be scheduled in Kind.
+	if err := labelAllNodes(kubecfg, map[string]string{
+		"topology.k8s.aws/zone-id":     "us-central1-a",
+		"topology.kubernetes.io/region": "us-central1",
+	}); err != nil {
+		return nil, fmt.Errorf("label kind nodes: %w", err)
+	}
+
 	// Load images (batch — single CLI call, idempotent).
 	preset := testutil.DefaultOperatorPreset()
 	imgs := append([]string{preset.Image}, testutil.MultigresImages...)
@@ -240,6 +249,22 @@ func lockSetup(name string) (unlock func(), err error) {
 		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 		f.Close()
 	}, nil
+}
+
+// labelAllNodes applies the given labels to all nodes in the cluster.
+// Uses --overwrite so repeated calls are idempotent.
+func labelAllNodes(kubecfg string, labels map[string]string) error {
+	for k, v := range labels {
+		label := fmt.Sprintf("%s=%s", k, v)
+		cmd := exec.Command("kubectl", "--kubeconfig", kubecfg,
+			"label", "nodes", "--all", "--overwrite", label)
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("label nodes %s: %w", label, err)
+		}
+	}
+	return nil
 }
 
 func logf(format string, args ...any) {

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
@@ -115,6 +116,12 @@ func WithCIResources(spec *multigresv1alpha1.MultigresClusterSpec) {
 
 	// Cells → gateway
 	for i := range spec.Cells {
+		// Normalize all zones to the single label present on the Kind node.
+		// Multi-zone samples (e.g. use1-az1/use1-az2) can't schedule on a
+		// single-node Kind cluster; collapsing to one known value lets all
+		// zone-scoped pods land on the same node.
+		spec.Cells[i].ZoneID = "us-central1-a"
+		spec.Cells[i].Region = ""
 		if spec.Cells[i].Spec == nil {
 			spec.Cells[i].Spec = &multigresv1alpha1.CellInlineSpec{}
 		}
@@ -161,6 +168,18 @@ func WithCIResources(spec *multigresv1alpha1.MultigresClusterSpec) {
 				for name, pool := range shard.Spec.Pools {
 					pool.Postgres = CIContainerConfig()
 					pool.Multipooler = CIContainerConfig()
+					// Pin fsGroup so containers get a numeric RunAsUser. The
+					// pgctld/multigres images declare USER postgres (=999), a
+					// non-numeric name kubelet can't verify against
+					// runAsNonRoot without an explicit numeric uid.
+					pool.FSGroup = ptr.To(int64(999))
+					// The default durability policy is AT_LEAST_2, so multiorch
+					// needs >= 2 poolers to elect a primary. Single-replica
+					// pools (e.g. minimal's injected default) stay all-standby
+					// and never serve, so bump them to 2.
+					if pool.ReplicasPerCell == nil || *pool.ReplicasPerCell < 2 {
+						pool.ReplicasPerCell = ptr.To(int32(2))
+					}
 					shard.Spec.Pools[name] = pool
 				}
 			}
@@ -282,6 +301,7 @@ func WaitForStatefulSet(t testing.TB, c client.Client, ns, containerName string)
 }
 
 // WaitForPod waits for at least one Pod with the given container name.
+// Checks both regular containers and init containers (including native sidecars).
 func WaitForPod(t testing.TB, c client.Client, ns, containerName string) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -293,6 +313,11 @@ func WaitForPod(t testing.TB, c client.Client, ns, containerName string) {
 		}
 		for _, pod := range list.Items {
 			for _, cont := range pod.Spec.Containers {
+				if cont.Name == containerName {
+					return true, nil
+				}
+			}
+			for _, cont := range pod.Spec.InitContainers {
 				if cont.Name == containerName {
 					return true, nil
 				}
@@ -417,6 +442,14 @@ func WaitForQueryServing(t testing.TB, c *Cluster, ns, gatewaySvc string) {
 				if cs.Name == "postgres" && cs.Ready {
 					targetPod = pod.Name
 					break
+				}
+			}
+			if targetPod == "" {
+				for _, cs := range pod.Status.InitContainerStatuses {
+					if cs.Name == "postgres" && cs.Ready {
+						targetPod = pod.Name
+						break
+					}
 				}
 			}
 			if targetPod != "" {

--- a/test/e2e/framework/loader.go
+++ b/test/e2e/framework/loader.go
@@ -9,6 +9,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 )
@@ -117,6 +118,10 @@ func MustLoadShardTemplate(repoRelPath, namespace string) *multigresv1alpha1.Sha
 	for name, pool := range tmpl.Spec.Pools {
 		pool.Postgres = CIContainerConfig()
 		pool.Multipooler = CIContainerConfig()
+		// Pin fsGroup so containers get a numeric RunAsUser; the
+		// pgctld/multigres images declare USER postgres (=999), which
+		// kubelet can't verify against runAsNonRoot without a numeric uid.
+		pool.FSGroup = ptr.To(int64(999))
 		tmpl.Spec.Pools[name] = pool
 	}
 	return tmpl


### PR DESCRIPTION
e2e tests have been failing for a while because of several reasons, this is an effort to fix all (or most) of them:

1- Native sidecar lookup
Commit 7330bc6 moved pgctld (the "postgres" container) from `Spec.Containers` to `Spec.InitContainers` as a native sidecar. The E2E helpers only scanned Spec.Containers / Status.ContainerStatuses, so WaitForPod and WaitForQueryServing never found "postgres" and timed out. Both helpers now also scan init containers.

2- Zone-scoped scheduling
Cells carry zoneId/region, which the operator turns into pod nodeSelectors (`topology.k8s.aws/zone-id`, `topology.kubernetes.io/region`). Kind nodes have no such labels, so zone-scoped pods stayed Pending. Label all Kind nodes on cluster setup and normalize fixture/sample zones to a single value so a single-node Kind cluster can schedule them. 

3- Numeric runAsUser for pool containers
Commits 08cedbc / 8d48d47 made container RunAsUser conditional on fsGroup. With no fsGroup, containers got `runAsNonRoot=true` and no numeric uid, kubelet cannot verify the pgctld/multigres images (USER postgres) are non-root and refused to start them (CreateContainerConfigError). Pin fsGroup=999 on CI pools.

4- Cache-sync detection
startManager relied on WaitForCacheSync returning false on a cancelled context, but with an empty scheme it returns true immediately (no informers to wait on), so the "cache sync fails" case never fired `t.Fatal`. Also treat a cancelled/expired context as a sync failure.

5- Durability vs replica count
The default durability policy is AT_LEAST_2, which needs >= 2 poolers for multiorch to elect a primary. The minimal sample's injected default pool has 1 replica, so the lone pod stayed a standby and never served
(`psql: password authentication failed`). Bump single-replica CI pools to 2.

