### PR TITLE
fix(release): resolve goreleaser dist conflict

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: install-manifests
-          path: dist
+          path: manifests
 
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -71,6 +71,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
-          args: release
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,7 @@ release:
     owner: multigres
     name: multigres-operator
   extra_files:
-    - glob: dist/install*.yaml
+    - glob: manifests/install*.yaml
   prerelease: auto
   footer: |
     ---


### PR DESCRIPTION
GoReleaser failed with "dist is not empty, remove it before running goreleaser or use the --clean flag" because the release job downloaded install manifests into dist/ before invoking goreleaser.

Download manifests into manifests/ instead, point the release extra_files glob at manifests/install*.yaml, and add --clean so goreleaser starts from a clean dist/. The manifests live outside dist/ so --clean does not delete them.