### PR TITLE
fix(shard): make example clusters startable out of the box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ endif
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
+# Defaults to docker when unset
 CONTAINER_TOOL ?= docker
+CONTAINER_TOOL := $(if $(strip $(CONTAINER_TOOL)),$(CONTAINER_TOOL),docker)
 
 # Kind cluster name for local development
 KIND_CLUSTER ?= multigres-operator-dev
@@ -369,6 +371,14 @@ define kind-install-crds
 		KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) apply --server-side -f -
 endef
 
+# Load a single image into every node of the kind cluster.
+define kind-load-image
+	@echo "  Loading $(1)..."
+	@for node in $$($(KIND) get nodes --name $(KIND_CLUSTER)); do \
+		$(CONTAINER_TOOL) save $(1) | $(CONTAINER_TOOL) exec -i $$node ctr -n k8s.io images import -; \
+	done
+endef
+
 ##@ Kind Cluster (Local Development)
 
 .PHONY: kind-up
@@ -386,7 +396,16 @@ kind-up: ## Create a kind cluster for local development
 		echo "Creating kind cluster '$(KIND_CLUSTER)'..."; \
 		$(KIND) create cluster --name $(KIND_CLUSTER) --kubeconfig $(KIND_KUBECONFIG); \
 	fi
+	$(MAKE) kind-label-nodes
 	@echo "==> Cluster ready. Use: export KUBECONFIG=$(KIND_KUBECONFIG)"
+
+# Single-zone topology labels for the dev cluster.
+.PHONY: kind-label-nodes
+kind-label-nodes: ## Label kind nodes with the single-zone topology labels samples select on
+	@echo "==> Labeling nodes with zone us-central1-a / region us-central1..."
+	@KUBECONFIG=$(KIND_KUBECONFIG) $(KUBECTL) label nodes --all --overwrite \
+		topology.k8s.aws/zone-id=us-central1-a \
+		topology.kubernetes.io/region=us-central1
 
 .PHONY: kind-up-topology
 kind-up-topology: ## Create a multi-node kind cluster with topology zone ID labels
@@ -420,7 +439,7 @@ kind-deploy-topology: kind-up-topology manifests kustomize kind-load kind-load-i
 .PHONY: kind-load
 kind-load: container ## Build and load image into kind cluster
 	@echo "==> Loading image $(IMG) into kind cluster..."
-	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER)
+	$(call kind-load-image,$(IMG))
 
 .PHONY: kind-load-images
 kind-load-images: ## Pull latest upstream images and load into kind (incremental, skips unchanged)
@@ -432,7 +451,9 @@ kind-load-images: ## Pull latest upstream images and load into kind (incremental
 	@echo "==> Loading upstream images into kind cluster..."
 	@for img in $(MULTIGRES_IMAGES); do \
 		echo "  Loading $$img..."; \
-		$(KIND) load docker-image $$img --name $(KIND_CLUSTER); \
+		for node in $$($(KIND) get nodes --name $(KIND_CLUSTER)); do \
+			$(CONTAINER_TOOL) save $$img | $(CONTAINER_TOOL) exec -i $$node ctr -n k8s.io images import -; \
+		done; \
 	done
 	@echo "==> All upstream images loaded"
 
@@ -446,7 +467,9 @@ kind-load-observability-images: ## Pull and load observability stack images into
 	@echo "==> Loading observability images into kind cluster..."
 	@for img in $(OBSERVABILITY_IMAGES); do \
 		echo "  Loading $$img..."; \
-		$(KIND) load docker-image $$img --name $(KIND_CLUSTER); \
+		for node in $$($(KIND) get nodes --name $(KIND_CLUSTER)); do \
+			$(CONTAINER_TOOL) save $$img | $(CONTAINER_TOOL) exec -i $$node ctr -n k8s.io images import -; \
+		done; \
 	done
 	@echo "==> All observability images loaded"
 
@@ -522,8 +545,8 @@ kind-portforward: ## Port-forward Grafana (3000), Prometheus (9090), Tempo (3200
 .PHONY: kind-redeploy
 kind-redeploy: container manifests kustomize ## Rebuild image, reload to kind, and redeploy
 	@echo "==> Clearing cached image from kind node..."
-	docker exec $(KIND_CLUSTER)-control-plane crictl rmi $(IMG) 2>/dev/null || true
-	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER)
+	$(CONTAINER_TOOL) exec $(KIND_CLUSTER)-control-plane crictl rmi $(IMG) 2>/dev/null || true
+	$(call kind-load-image,$(IMG))
 	$(call kind-install-crds)
 	@echo "==> Deploying operator..."
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
@@ -547,7 +570,7 @@ observer-build: ## Build the observer container image
 
 .PHONY: kind-load-observer
 kind-load-observer: observer-build ## Build and load observer image into kind
-	$(KIND) load docker-image $(OBSERVER_IMG) --name $(KIND_CLUSTER)
+	$(call kind-load-image,$(OBSERVER_IMG))
 
 .PHONY: kind-deploy-observer
 kind-deploy-observer: kind-load-observer ## Deploy observer alongside the operator

--- a/config/samples/README.md
+++ b/config/samples/README.md
@@ -129,7 +129,7 @@ This allows you to set "sane defaults" at the Namespace level (Level 3), overrid
 
 ## 5. Pool Replica Requirements
 
-Pools default to `replicasPerCell: 1`. `AT_LEAST_2` requires 2 total poolers; `MULTI_CELL_AT_LEAST_2` requires poolers in 2 cells. For high availability, use at least 3 total poolers so the policy remains achievable while one pooler is unavailable.
+Pools default to `replicasPerCell: 1`, except a pool that spans a single cell defaults to `replicasPerCell: 2` so it meets the default `AT_LEAST_2` durability policy (which needs 2 total poolers) and can elect a primary. `MULTI_CELL_AT_LEAST_2` requires poolers in 2 cells. For high availability, use at least 3 total poolers so the policy remains achievable while one pooler is unavailable.
 
 ---
 

--- a/config/samples/minimal.yaml
+++ b/config/samples/minimal.yaml
@@ -1,3 +1,15 @@
+# Postgres superuser password. The operator reads this Secret (referenced by
+# spec.postgresPasswordSecretRef) to set the postgres password. It must exist
+# in the cluster's namespace. Replace the demo value before any real use.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: multigres-admin-password
+  namespace: default
+type: Opaque
+stringData:
+  password: postgres
+---
 apiVersion: multigres.com/v1alpha1
 kind: MultigresCluster
 metadata:

--- a/pkg/cluster-handler/controller/multigrescluster/integration_resolution_enforcement_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_resolution_enforcement_test.go
@@ -348,9 +348,11 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 						},
 						Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 							"default": {
-								Type:            "readWrite",
-								Cells:           []multigresv1alpha1.CellName{"zone-c"},
-								ReplicasPerCell: ptr.To(resolver.DefaultPoolReplicasPerCell),
+								Type:  "readWrite",
+								Cells: []multigresv1alpha1.CellName{"zone-c"},
+								// Single-cell pool defaults to 2 (the minimum the
+								// AT_LEAST_2 durability policy needs).
+								ReplicasPerCell: ptr.To(int32(2)),
 								Storage:         multigresv1alpha1.StorageSpec{Size: "1Gi"},
 								Postgres: multigresv1alpha1.ContainerConfig{
 									Resources: resolver.DefaultResourcesPostgres(),
@@ -647,9 +649,11 @@ func TestMultigresCluster_TemplateOverrides(t *testing.T) {
 					},
 					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 						"default": {
-							Type:            "readWrite",
-							Cells:           []multigresv1alpha1.CellName{"zone-a"},
-							ReplicasPerCell: ptr.To(resolver.DefaultPoolReplicasPerCell),
+							Type:  "readWrite",
+							Cells: []multigresv1alpha1.CellName{"zone-a"},
+							// Single-cell pool defaults to 2 (the minimum the
+							// AT_LEAST_2 durability policy needs).
+							ReplicasPerCell: ptr.To(int32(2)),
 							Storage:         multigresv1alpha1.StorageSpec{Size: "1Gi"},
 							Postgres: multigresv1alpha1.ContainerConfig{
 								Resources: resolver.DefaultResourcesPostgres(),

--- a/pkg/cluster-handler/controller/multigrescluster/integration_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_test.go
@@ -924,9 +924,10 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 								// FIX: Expect the injected default pool
 								Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 									"default": {
-										Type:            "readWrite",
-										Cells:           []multigresv1alpha1.CellName{"zone-a"},
-										ReplicasPerCell: ptr.To(resolver.DefaultPoolReplicasPerCell),
+										Type:  "readWrite",
+										Cells: []multigresv1alpha1.CellName{"zone-a"},
+										// Single-cell pool defaults to 2 (AT_LEAST_2 minimum).
+										ReplicasPerCell: ptr.To(int32(2)),
 										Storage:         multigresv1alpha1.StorageSpec{Size: resolver.DefaultEtcdStorageSize}, // "1Gi"
 										Postgres: multigresv1alpha1.ContainerConfig{
 											Resources: resolver.DefaultResourcesPostgres(),
@@ -1282,9 +1283,10 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 								// FIX: Expect the injected default pool
 								Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 									"default": {
-										Type:            "readWrite",
-										Cells:           []multigresv1alpha1.CellName{"zone-a"},
-										ReplicasPerCell: ptr.To(resolver.DefaultPoolReplicasPerCell),
+										Type:  "readWrite",
+										Cells: []multigresv1alpha1.CellName{"zone-a"},
+										// Single-cell pool defaults to 2 (AT_LEAST_2 minimum).
+										ReplicasPerCell: ptr.To(int32(2)),
 										Storage:         multigresv1alpha1.StorageSpec{Size: resolver.DefaultEtcdStorageSize}, // "1Gi"
 										Postgres: multigresv1alpha1.ContainerConfig{
 											Resources: resolver.DefaultResourcesPostgres(),

--- a/pkg/resolver/shard.go
+++ b/pkg/resolver/shard.go
@@ -81,6 +81,24 @@ func (r *Resolver) ResolveShard(
 			slices.Sort(p.Cells)
 		}
 
+		// Default replicasPerCell so the pool has at least 2 total poolers,
+		// the minimum the default AT_LEAST_2 durability policy needs to elect
+		// a primary. A multi-cell pool reaches 2 total at 1 per cell; a
+		// single-cell pool needs 2.
+		if p.ReplicasPerCell == nil {
+			effectiveCells := len(p.Cells)
+			if effectiveCells == 0 {
+				effectiveCells = len(opts.AllCellNames)
+			}
+			// A single-cell pool needs 2 replicas in that cell to reach the 2
+			// total poolers AT_LEAST_2 requires. Multi-cell pools reach 2 total
+			// at the per-cell default. effectiveCells == 0 means the cell set
+			// isn't known here (pure template resolution).
+			if effectiveCells == 1 {
+				p.ReplicasPerCell = ptr.To(int32(2))
+			}
+		}
+
 		defaultPoolSpec(&p)
 		pools[name] = p
 	}

--- a/pkg/resolver/validation_test.go
+++ b/pkg/resolver/validation_test.go
@@ -619,6 +619,13 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 							Shards: []multigresv1alpha1.ShardConfig{{
 								Name:          "s0",
 								ShardTemplate: "prod-shard",
+								// Force a single pooler to exercise the
+								// durability warning (default is now 2).
+								Overrides: &multigresv1alpha1.ShardOverrides{
+									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+										"default": {ReplicasPerCell: ptr.To(int32(1))},
+									},
+								},
 							}},
 						}},
 					}},
@@ -713,7 +720,7 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 			},
 			wantNoWarnings: true,
 		},
-		"No Quorum Warning: three cells with omitted replicas default to 1 per cell": {
+		"No Quorum Warning: three cells with omitted replicas (1 per cell, 3 total)": {
 			cluster: &multigresv1alpha1.MultigresCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: "default"},
 				Spec: multigresv1alpha1.MultigresClusterSpec{
@@ -773,7 +780,8 @@ func TestResolver_ValidateClusterLogic(t *testing.T) {
 								Spec: &multigresv1alpha1.ShardInlineSpec{
 									Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 										"main-rw": {
-											Type: "readWrite",
+											Type:            "readWrite",
+											ReplicasPerCell: ptr.To(int32(1)),
 										},
 									},
 								},

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -76,6 +76,8 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 				Resources: corev1.ResourceRequirements{},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot: ptr.To(true),
+					RunAsUser:    ptr.To(DefaultPostgresUID),
+					RunAsGroup:   ptr.To(DefaultPostgresUID),
 				},
 				StartupProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
@@ -183,6 +185,8 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 				Resources: corev1.ResourceRequirements{},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot: ptr.To(true),
+					RunAsUser:    ptr.To(DefaultPostgresUID),
+					RunAsGroup:   ptr.To(DefaultPostgresUID),
 				},
 				StartupProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
@@ -308,6 +312,8 @@ func TestBuildMultiPoolerContainer(t *testing.T) {
 				},
 				SecurityContext: &corev1.SecurityContext{
 					RunAsNonRoot: ptr.To(true),
+					RunAsUser:    ptr.To(DefaultPostgresUID),
+					RunAsGroup:   ptr.To(DefaultPostgresUID),
 				},
 				StartupProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
@@ -409,6 +415,8 @@ func TestBuildPostgresExporterContainer(t *testing.T) {
 		},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsNonRoot: ptr.To(true),
+			RunAsUser:    ptr.To(DefaultPostgresUID),
+			RunAsGroup:   ptr.To(DefaultPostgresUID),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/pkg/resource-handler/controller/shard/pool_pod.go
+++ b/pkg/resource-handler/controller/shard/pool_pod.go
@@ -144,18 +144,28 @@ func buildPoolPodSecurityContext(poolSpec multigresv1alpha1.PoolSpec) *corev1.Po
 	}
 }
 
-// buildContainerSecurityContext returns a non-root SecurityContext. When fsGroup
-// is set, RunAsUser and RunAsGroup are pinned to that value so all containers
-// in the pod share the same filesystem identity on shared volumes.
+// DefaultPostgresUID is the postgres user's UID/GID in the pgctld/multigres
+// container images. Pool containers share the postgres data directory, so they
+// run as this identity unless a pool overrides it via fsGroup.
+const DefaultPostgresUID int64 = 999
+
+// buildContainerSecurityContext returns a non-root SecurityContext with a
+// numeric RunAsUser/RunAsGroup. A numeric uid is required: without it, kubelet
+// cannot verify runAsNonRoot against images whose USER is a name (the
+// pgctld/multigres images declare `USER postgres`) and refuses to start the
+// container with CreateContainerConfigError. fsGroup, when set, overrides the
+// default so all containers share the caller's chosen filesystem identity on
+// shared volumes.
 func buildContainerSecurityContext(fsGroup *int64) *corev1.SecurityContext {
-	sc := &corev1.SecurityContext{
-		RunAsNonRoot: ptr.To(true),
-	}
+	uid := DefaultPostgresUID
 	if fsGroup != nil {
-		sc.RunAsUser = fsGroup
-		sc.RunAsGroup = fsGroup
+		uid = *fsGroup
 	}
-	return sc
+	return &corev1.SecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		RunAsUser:    ptr.To(uid),
+		RunAsGroup:   ptr.To(uid),
+	}
 }
 
 // buildHeadlessServiceName constructs the headless service name for DNS

--- a/pkg/resource-handler/controller/shard/pool_pod_test.go
+++ b/pkg/resource-handler/controller/shard/pool_pod_test.go
@@ -363,11 +363,13 @@ func TestBuildPoolPod_SecurityContextWithFSGroup(t *testing.T) {
 }
 
 func TestBuildContainerSecurityContext(t *testing.T) {
-	t.Run("nil fsGroup", func(t *testing.T) {
+	t.Run("nil fsGroup defaults to postgres UID", func(t *testing.T) {
 		sc := buildContainerSecurityContext(nil)
 		assert.True(t, *sc.RunAsNonRoot)
-		assert.Nil(t, sc.RunAsUser)
-		assert.Nil(t, sc.RunAsGroup)
+		// A numeric uid is required so kubelet can verify runAsNonRoot against
+		// the pgctld/multigres images whose USER is the name "postgres".
+		assert.Equal(t, DefaultPostgresUID, *sc.RunAsUser)
+		assert.Equal(t, DefaultPostgresUID, *sc.RunAsGroup)
 	})
 
 	t.Run("with fsGroup", func(t *testing.T) {

--- a/pkg/webhook/handlers/defaulter_test.go
+++ b/pkg/webhook/handlers/defaulter_test.go
@@ -140,9 +140,10 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 														Type: "readWrite",
 														// Cells should be nil to avoid sticky defaults
 														Cells: nil,
-														ReplicasPerCell: ptr.To(
-															resolver.DefaultPoolReplicasPerCell,
-														),
+														// Single-cell cluster: defaults to 2 so the
+														// pool reaches the 2 total poolers AT_LEAST_2
+														// needs.
+														ReplicasPerCell: ptr.To(int32(2)),
 														Storage: multigresv1alpha1.StorageSpec{
 															Size: "1Gi",
 														},

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
@@ -168,18 +167,10 @@ func WithCIResources(spec *multigresv1alpha1.MultigresClusterSpec) {
 				for name, pool := range shard.Spec.Pools {
 					pool.Postgres = CIContainerConfig()
 					pool.Multipooler = CIContainerConfig()
-					// Pin fsGroup so containers get a numeric RunAsUser. The
-					// pgctld/multigres images declare USER postgres (=999), a
-					// non-numeric name kubelet can't verify against
-					// runAsNonRoot without an explicit numeric uid.
-					pool.FSGroup = ptr.To(int64(999))
-					// The default durability policy is AT_LEAST_2, so multiorch
-					// needs >= 2 poolers to elect a primary. Single-replica
-					// pools (e.g. minimal's injected default) stay all-standby
-					// and never serve, so bump them to 2.
-					if pool.ReplicasPerCell == nil || *pool.ReplicasPerCell < 2 {
-						pool.ReplicasPerCell = ptr.To(int32(2))
-					}
+					// Note: no fsGroup or replicasPerCell overrides here on
+					// purpose. The operator defaults containers to a numeric
+					// uid and single-cell pools to 2 replicas, so e2e exercises
+					// those defaults directly and catches regressions.
 					shard.Spec.Pools[name] = pool
 				}
 			}

--- a/test/e2e/framework/loader.go
+++ b/test/e2e/framework/loader.go
@@ -9,7 +9,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/utils/ptr"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 )
@@ -114,14 +113,11 @@ func MustLoadShardTemplate(repoRelPath, namespace string) *multigresv1alpha1.Sha
 	if tmpl.Spec.MultiOrch != nil {
 		tmpl.Spec.MultiOrch.Resources = CIResources()
 	}
-	// CI resources on each pool.
+	// CI resources on each pool. No fsGroup override: the operator defaults
+	// pool containers to a numeric uid, so e2e exercises that default.
 	for name, pool := range tmpl.Spec.Pools {
 		pool.Postgres = CIContainerConfig()
 		pool.Multipooler = CIContainerConfig()
-		// Pin fsGroup so containers get a numeric RunAsUser; the
-		// pgctld/multigres images declare USER postgres (=999), which
-		// kubelet can't verify against runAsNonRoot without a numeric uid.
-		pool.FSGroup = ptr.To(int64(999))
 		tmpl.Spec.Pools[name] = pool
 	}
 	return tmpl


### PR DESCRIPTION
Currently some example manifests used for dev do not scale up, this was surfaced while [repairing the E2E suite](https://github.com/multigres/multigres-operator/pull/524) (where they were worked around in the test harness rather than fixed).

## Changes: 
1. Numeric `RunAsUser` for pool containers: `buildContainerSecurityContext` set `runAsNonRoot=true` but only set a numeric `RunAsUser`/`RunAsGroup` when the pool specified fsGroup. With no fsGroup (the default), the pgctld/multigres images declare `USER postgres` (a name, not a uid), so kubelet cannot verify the container is non-root and refuses to start it with `CreateContainerConfigError`. Pods never leave Pending.
Always set a numeric uid, defaulting to DefaultPostgresUID (999, the postgres user in those images) and still honoring fsGroup as an override. Restores the pre-refactor behavior for the default path.

2. Single-cell pools default to 2 replicas: The default durability policy `AT_LEAST_2` needs 2 poolers *in total* (across all cells) before multiorch can elect a primary. A pool that spans one cell with the per-cell default of 1 yields a single pooler, so it stays an unpromotable standby and never serves (it will hit `psql: password authentication failed`).
When replicasPerCell is omitted, default it to 2 only for a single-cell pool, multi-cell pools already reach 2 total at 1 per cell. The decision uses the effective cell count (the pool's own cells, or all cluster cells when not yet materialized) so it is correct on the dynamic webhook-defaulter path too. DefaultPoolReplicas PerCell stays 1.

Dev clusters workflow fixes:
1. Modify the Makefile kind workflow to pipe `docker save` into `ctr import` without --all-platforms to import just the host platform that is present, and avoid `kind load docker-image`, which runs `ctr import --all-platforms --digests`. With Docker's containerd image store the local image is a multi-platform OCI index, but `docker save` only emits the host platform's blobs, so the import fails with "content digest <sha> not found".

2. Add a `kind-label-nodes` target to the Makefile to label the kind nodes with the single-zone topology labels samples select on.