### PR TITLE
fix(e2e): include k8s types during e2e tests

### DIFF
--- a/test/e2e/framework/loader.go
+++ b/test/e2e/framework/loader.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
@@ -18,6 +19,7 @@ var decoder runtime.Decoder
 func init() {
 	scheme := runtime.NewScheme()
 	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 	codecFactory := serializer.NewCodecFactory(scheme)
 	decoder = codecFactory.UniversalDeserializer()
 }


### PR DESCRIPTION
In #528 we introduced a Secret object creation during the "minimal" manifest example, that makes the e2e tests to fail as they were not originally including the corev1 types into the schema. This change does just that.