### PR TITLE
ci(release): gitignore manifests/ so goreleaser dirty check passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ result-*
 # distribution files are added to github releases
 dist/
 
+# install manifests downloaded as a CI artifact during the release workflow;
+# keeps the tree clean so goreleaser's dirty-state check passes
+manifests/
+
 # Go
 cover.out
 *cover.out


### PR DESCRIPTION
The release workflow downloads the install-manifests artifact into a manifests/ directory before running goreleaser. goreleaser's `release --clean` aborts with "git is in a dirty state" because the directory is untracked. Ignoring manifests/ keeps the tree clean.