### PR TITLE
refactor(tablegroup): make shard reconciliation observed-state truthful

### DIFF
--- a/pkg/cluster-handler/controller/tablegroup/integration_consistency_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/integration_consistency_test.go
@@ -1,0 +1,456 @@
+//go:build integration
+// +build integration
+
+package tablegroup_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/cluster-handler/controller/tablegroup"
+	"github.com/multigres/multigres-operator/pkg/testutil"
+	nameutil "github.com/multigres/multigres-operator/pkg/util/name"
+)
+
+// TestTableGroup_ConsistencyConvergence runs the controller against a real
+// apiserver and cache (envtest) and asserts it converges to the correct terminal
+// state (children, status, ObservedGeneration) without resourceVersion conflicts
+// or status flapping, including across add/remove scenarios. A fake client can't
+// model cache lag or conflicts, so this is the envtest counterpart to the unit
+// tests.
+func TestTableGroup_ConsistencyConvergence(t *testing.T) {
+	t.Parallel()
+
+	globalTopo := multigresv1alpha1.GlobalTopoServerRef{
+		Address:        "etcd-client:2379",
+		RootPath:       "/multigres/global",
+		Implementation: "etcd",
+	}
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	mgr := testutil.SetUpEnvtestManager(t, scheme,
+		testutil.WithCRDPaths("../../../../config/crd/bases"),
+	)
+
+	if err := (&tablegroup.TableGroupReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("tablegroup-controller"),
+	}).SetupWithManager(mgr, controller.Options{SkipNameValidation: ptr.To(true)}); err != nil {
+		t.Fatalf("Failed to set up controller: %v", err)
+	}
+
+	watcher := testutil.NewResourceWatcher(t, t.Context(), mgr,
+		testutil.WithCmpOpts(testutil.IgnoreMetaRuntimeFields()),
+		testutil.WithExtraResource(
+			&multigresv1alpha1.TableGroup{},
+			&multigresv1alpha1.Shard{},
+		),
+		testutil.WithTimeout(15*time.Second),
+	)
+
+	k8sClient := mgr.GetClient()
+	ctx := t.Context()
+
+	const (
+		clusterName = "consistency-cluster"
+		dbName      = "db1"
+		tgName      = "tg1"
+		namespace   = "default"
+	)
+
+	shardSpec := func(name, cell string) multigresv1alpha1.ShardResolvedSpec {
+		return multigresv1alpha1.ShardResolvedSpec{
+			Name: name,
+			MultiOrch: multigresv1alpha1.MultiOrchSpec{
+				StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
+				Cells:         []multigresv1alpha1.CellName{multigresv1alpha1.CellName(cell)},
+			},
+			Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"primary": {
+					Type:            "readWrite",
+					ReplicasPerCell: ptr.To(int32(1)),
+					Cells:           []multigresv1alpha1.CellName{multigresv1alpha1.CellName(cell)},
+				},
+			},
+		}
+	}
+
+	childName := func(shard string) string {
+		return nameutil.JoinWithConstraints(
+			nameutil.DefaultConstraints, clusterName, dbName, tgName, shard,
+		)
+	}
+
+	tg := &multigresv1alpha1.TableGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tg-consistency",
+			Namespace: namespace,
+			Labels:    map[string]string{"multigres.com/cluster": clusterName},
+		},
+		Spec: multigresv1alpha1.TableGroupSpec{
+			DatabaseName:     dbName,
+			TableGroupName:   tgName,
+			GlobalTopoServer: globalTopo,
+			Images: multigresv1alpha1.ShardImages{
+				MultiOrch:   "orch:latest",
+				MultiPooler: "pooler:latest",
+				Postgres:    "postgres:15",
+			},
+			Shards: []multigresv1alpha1.ShardResolvedSpec{
+				shardSpec("s1", "zone-a"),
+				shardSpec("s2", "zone-b"),
+				shardSpec("s3", "zone-c"),
+			},
+		},
+	}
+	setTestPostgresPasswordSecretRef(tg)
+
+	// The initial three-shard spec establishes a healthy terminal baseline under
+	// a real apiserver and cache before the test introduces an add/remove change.
+	if err := k8sClient.Create(ctx, tg); err != nil {
+		t.Fatalf("Failed to create TableGroup: %v", err)
+	}
+
+	waitForChildShards(t, ctx, k8sClient, namespace, clusterName, dbName, tgName,
+		[]string{childName("s1"), childName("s2"), childName("s3")})
+
+	// TableGroup readiness depends on child status, not child existence alone.
+	// The test drives the Shard status the way the Shard controller would.
+	for _, shard := range []string{"s1", "s2", "s3"} {
+		driveShardHealthy(t, ctx, k8sClient, childName(shard), namespace)
+	}
+
+	healthy := waitForTableGroup(t, ctx, k8sClient,
+		client.ObjectKeyFromObject(tg), 15*time.Second,
+		func(g *multigresv1alpha1.TableGroup) bool {
+			return g.Status.Phase == multigresv1alpha1.PhaseHealthy &&
+				g.Status.ReadyShards == 3 &&
+				g.Status.TotalShards == 3 &&
+				g.Status.ObservedGeneration == g.Generation &&
+				isConditionTrue(g.Status.Conditions, "Available")
+		},
+	)
+
+	// A reconciled terminal state should remain quiet across repeated watches:
+	// no status flapping, stale generations, or cache-conflict churn.
+	stableGen := healthy.Status.ObservedGeneration
+	assertTableGroupStaysStable(t, ctx, k8sClient, client.ObjectKeyFromObject(tg),
+		2*time.Second, func(g *multigresv1alpha1.TableGroup) bool {
+			return g.Status.Phase == multigresv1alpha1.PhaseHealthy &&
+				g.Status.ObservedGeneration == stableGen
+		})
+
+	// The add/remove update forces the controller to create one desired child,
+	// retire one orphan through PendingDeletion, and keep status truthful while
+	// both old and new children may briefly exist.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &multigresv1alpha1.TableGroup{}
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tg), latest); err != nil {
+			return err
+		}
+		latest.Spec.Shards = []multigresv1alpha1.ShardResolvedSpec{
+			shardSpec("s1", "zone-a"),
+			shardSpec("s2", "zone-b"),
+			shardSpec("s4", "zone-d"),
+		}
+		return k8sClient.Update(ctx, latest)
+	}); err != nil {
+		t.Fatalf("Failed to update TableGroup spec: %v", err)
+	}
+
+	// The old child can still exist while it drains, so the useful assertion here
+	// is that the new desired child appears, not that the child set is already
+	// exact.
+	waitForShardExists(t, ctx, k8sClient, childName("s4"), namespace)
+
+	// The orphan remains visible until it acknowledges PendingDeletion. That
+	// retained object is what lets the child controller drain before deletion.
+	s3Name := childName("s3")
+	waitForShardAnnotation(t, ctx, k8sClient, s3Name, namespace,
+		multigresv1alpha1.AnnotationPendingDeletion)
+
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &multigresv1alpha1.Shard{}
+		if err := k8sClient.Get(
+			ctx,
+			client.ObjectKey{Name: s3Name, Namespace: namespace},
+			latest,
+		); err != nil {
+			return err
+		}
+		cond := metav1.Condition{
+			Type:               multigresv1alpha1.ConditionReadyForDeletion,
+			Status:             metav1.ConditionTrue,
+			Reason:             "DrainComplete",
+			Message:            "Simulated by integration test",
+			LastTransitionTime: metav1.Now(),
+		}
+		latest.Status.Conditions = append(latest.Status.Conditions, cond)
+		return k8sClient.Status().Update(ctx, latest)
+	}); err != nil {
+		t.Fatalf("Failed to set ReadyForDeletion on orphan shard: %v", err)
+	}
+
+	if err := watcher.WaitForDeletion(&multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{Name: s3Name, Namespace: namespace},
+	}); err != nil {
+		t.Fatalf("Orphan shard s3 was not pruned: %v", err)
+	}
+
+	// Once the replacement child reports Healthy, the parent should converge to a
+	// stable terminal status for the new generation.
+	for _, shard := range []string{"s1", "s2", "s4"} {
+		driveShardHealthy(t, ctx, k8sClient, childName(shard), namespace)
+	}
+
+	reconverged := waitForTableGroup(t, ctx, k8sClient,
+		client.ObjectKeyFromObject(tg), 15*time.Second,
+		func(g *multigresv1alpha1.TableGroup) bool {
+			return g.Status.Phase == multigresv1alpha1.PhaseHealthy &&
+				g.Status.ReadyShards == 3 &&
+				g.Status.TotalShards == 3 &&
+				g.Status.ObservedGeneration == g.Generation &&
+				isConditionTrue(g.Status.Conditions, "Available")
+		},
+	)
+
+	finalGen := reconverged.Status.ObservedGeneration
+	assertTableGroupStaysStable(t, ctx, k8sClient, client.ObjectKeyFromObject(tg),
+		2*time.Second, func(g *multigresv1alpha1.TableGroup) bool {
+			return g.Status.Phase == multigresv1alpha1.PhaseHealthy &&
+				g.Status.ObservedGeneration == finalGen
+		})
+}
+
+// waitForChildShards polls until exactly the expected child Shard names exist
+// for the given cluster/database/tablegroup labels (the same single label
+// selector the controller reads with).
+func waitForChildShards(
+	t testing.TB,
+	ctx context.Context,
+	k8sClient client.Client,
+	namespace, cluster, db, tg string,
+	wantNames []string,
+) {
+	t.Helper()
+
+	want := make(map[string]bool, len(wantNames))
+	for _, n := range wantNames {
+		want[n] = true
+	}
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		list := &multigresv1alpha1.ShardList{}
+		if err := k8sClient.List(ctx, list,
+			client.InNamespace(namespace),
+			client.MatchingLabels{
+				"multigres.com/cluster":    cluster,
+				"multigres.com/database":   db,
+				"multigres.com/tablegroup": tg,
+			},
+		); err == nil {
+			got := make(map[string]bool, len(list.Items))
+			for i := range list.Items {
+				got[list.Items[i].Name] = true
+			}
+			if mapsEqual(want, got) {
+				return
+			}
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for child shards %v", wantNames)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// driveShardHealthy simulates the Shard controller reporting a Healthy phase with
+// ObservedGeneration matching the spec generation, which is the condition the
+// TableGroup controller requires to count a child as ready.
+func driveShardHealthy(
+	t testing.TB,
+	ctx context.Context,
+	k8sClient client.Client,
+	name, namespace string,
+) {
+	t.Helper()
+
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &multigresv1alpha1.Shard{}
+		if err := k8sClient.Get(
+			ctx,
+			client.ObjectKey{Name: name, Namespace: namespace},
+			latest,
+		); err != nil {
+			return err
+		}
+		latest.Status.Phase = multigresv1alpha1.PhaseHealthy
+		latest.Status.Message = "Ready"
+		latest.Status.ObservedGeneration = latest.Generation
+		return k8sClient.Status().Update(ctx, latest)
+	}); err != nil {
+		t.Fatalf("Failed to drive shard %s healthy: %v", name, err)
+	}
+}
+
+// waitForShardExists polls until the named Shard exists.
+func waitForShardExists(
+	t testing.TB,
+	ctx context.Context,
+	k8sClient client.Client,
+	name, namespace string,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		s := &multigresv1alpha1.Shard{}
+		if err := k8sClient.Get(
+			ctx,
+			client.ObjectKey{Name: name, Namespace: namespace},
+			s,
+		); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for shard %s to exist", name)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// waitForShardAnnotation polls until the named Shard carries a non-empty value
+// for the given annotation key.
+func waitForShardAnnotation(
+	t testing.TB,
+	ctx context.Context,
+	k8sClient client.Client,
+	name, namespace, annotation string,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		s := &multigresv1alpha1.Shard{}
+		if err := k8sClient.Get(
+			ctx,
+			client.ObjectKey{Name: name, Namespace: namespace},
+			s,
+		); err == nil {
+			if s.Annotations[annotation] != "" {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for shard %s annotation %q", name, annotation)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// waitForTableGroup polls until the TableGroup satisfies the predicate, returning
+// the matching object. It fails the test on timeout.
+func waitForTableGroup(
+	t testing.TB,
+	ctx context.Context,
+	k8sClient client.Client,
+	key client.ObjectKey,
+	timeout time.Duration,
+	predicate func(*multigresv1alpha1.TableGroup) bool,
+) *multigresv1alpha1.TableGroup {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var last multigresv1alpha1.TableGroup
+	for {
+		g := &multigresv1alpha1.TableGroup{}
+		if err := k8sClient.Get(ctx, key, g); err == nil {
+			last = *g
+			if predicate(g) {
+				return g
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf(
+				"timed out waiting for TableGroup to converge; last observed phase=%q ready=%d total=%d observedGen=%d gen=%d",
+				last.Status.Phase,
+				last.Status.ReadyShards,
+				last.Status.TotalShards,
+				last.Status.ObservedGeneration,
+				last.Generation,
+			)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// assertTableGroupStaysStable verifies the TableGroup continues to satisfy the
+// predicate across a settle window, guarding against status flapping under a
+// real cache.
+func assertTableGroupStaysStable(
+	t testing.TB,
+	ctx context.Context,
+	k8sClient client.Client,
+	key client.ObjectKey,
+	window time.Duration,
+	predicate func(*multigresv1alpha1.TableGroup) bool,
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(window)
+	for {
+		g := &multigresv1alpha1.TableGroup{}
+		if err := k8sClient.Get(ctx, key, g); err != nil {
+			t.Fatalf("Failed to get TableGroup during stability check: %v", err)
+		}
+		if !predicate(g) {
+			t.Fatalf(
+				"TableGroup left its stable terminal state: phase=%q observedGen=%d gen=%d",
+				g.Status.Phase, g.Status.ObservedGeneration, g.Generation,
+			)
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func isConditionTrue(conditions []metav1.Condition, condType string) bool {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return conditions[i].Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func mapsEqual(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/cluster-handler/controller/tablegroup/integration_lifecycle_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/integration_lifecycle_test.go
@@ -26,18 +26,18 @@ import (
 func TestTableGroup_Lifecycle(t *testing.T) {
 	t.Parallel()
 
-	// Common test data
 	globalTopo := multigresv1alpha1.GlobalTopoServerRef{
 		Address:        "etcd-client:2379",
 		RootPath:       "/multigres/global",
 		Implementation: "etcd",
 	}
 
-	// Setup Helper
 	setup := func(t *testing.T) (client.Client, *testutil.ResourceWatcher) {
 		t.Helper()
 
-		// Create the Scheme and register types manually
+		// These tests need the real apiserver/cache behaviour from envtest because
+		// the lifecycle under test depends on watches, status updates, and
+		// optimistic concurrency rather than just object shape.
 		scheme := runtime.NewScheme()
 		_ = multigresv1alpha1.AddToScheme(scheme)
 		_ = appsv1.AddToScheme(scheme)
@@ -47,7 +47,6 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 			testutil.WithCRDPaths("../../../../config/crd/bases"),
 		)
 
-		// Start Controller
 		if err := (&tablegroup.TableGroupReconciler{
 			Client:   mgr.GetClient(),
 			Scheme:   mgr.GetScheme(),
@@ -87,29 +86,46 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 				},
 				Shards: []multigresv1alpha1.ShardResolvedSpec{
 					{
-						Name:      "keep-me",
-						MultiOrch: multigresv1alpha1.MultiOrchSpec{StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))}},
-						Pools:     map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
+						Name: "keep-me",
+						MultiOrch: multigresv1alpha1.MultiOrchSpec{
+							StatelessSpec: multigresv1alpha1.StatelessSpec{
+								Replicas: ptr.To(int32(1)),
+							},
+						},
+						Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
 					},
 					{
-						Name:      "delete-me",
-						MultiOrch: multigresv1alpha1.MultiOrchSpec{StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))}},
-						Pools:     map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
+						Name: "delete-me",
+						MultiOrch: multigresv1alpha1.MultiOrchSpec{
+							StatelessSpec: multigresv1alpha1.StatelessSpec{
+								Replicas: ptr.To(int32(1)),
+							},
+						},
+						Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
 					},
 				},
 			},
 		}
 
-		// 1. Create Initial State
+		// Begin with two desired children so removing one from the spec later has
+		// to go through the same graceful-deletion path used in production.
 		setTestPostgresPasswordSecretRef(tg)
 		if err := k8sClient.Create(ctx, tg); err != nil {
 			t.Fatal(err)
 		}
 
-		// Wait for both shards
+		// The expected Shards describe the child specs TableGroup owns. Metadata
+		// and status are intentionally ignored because those are filled by the
+		// apiserver and by child controllers.
 		shard1 := &multigresv1alpha1.Shard{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      nameutil.JoinWithConstraints(nameutil.DefaultConstraints, clusterName, "db1", "tg1", "keep-me"),
+				Name: nameutil.JoinWithConstraints(
+					nameutil.DefaultConstraints,
+					clusterName,
+					"db1",
+					"tg1",
+					"keep-me",
+				),
 				Namespace: "default",
 			},
 			Spec: multigresv1alpha1.ShardSpec{
@@ -122,14 +138,22 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 					MultiPooler: "pooler:latest",
 					Postgres:    "postgres:15",
 				},
-				MultiOrch: multigresv1alpha1.MultiOrchSpec{StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))}},
-				Pools:     map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
-				Replicas:  ptr.To(int32(0)),
+				MultiOrch: multigresv1alpha1.MultiOrchSpec{
+					StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
+				},
+				Pools:    map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
+				Replicas: ptr.To(int32(0)),
 			},
 		}
 		shard2 := &multigresv1alpha1.Shard{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      nameutil.JoinWithConstraints(nameutil.DefaultConstraints, clusterName, "db1", "tg1", "delete-me"),
+				Name: nameutil.JoinWithConstraints(
+					nameutil.DefaultConstraints,
+					clusterName,
+					"db1",
+					"tg1",
+					"delete-me",
+				),
 				Namespace: "default",
 			},
 			Spec: multigresv1alpha1.ShardSpec{
@@ -142,33 +166,37 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 					MultiPooler: "pooler:latest",
 					Postgres:    "postgres:15",
 				},
-				MultiOrch: multigresv1alpha1.MultiOrchSpec{StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))}},
-				Pools:     map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
-				Replicas:  ptr.To(int32(0)),
+				MultiOrch: multigresv1alpha1.MultiOrchSpec{
+					StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
+				},
+				Pools:    map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
+				Replicas: ptr.To(int32(0)),
 			},
 		}
 		setTestShardPostgresPasswordSecretRef(shard1)
 		setTestShardPostgresPasswordSecretRef(shard2)
 
-		// Using WaitForMatch with CompareSpecOnly to avoid needing full metadata/status matching
+		// Compare only spec fields because the controller owns metadata and status.
 		watcher.SetCmpOpts(testutil.CompareSpecOnly()...)
 		if err := watcher.WaitForMatch(shard1, shard2); err != nil {
 			t.Fatalf("Failed to create initial shards: %v", err)
 		}
 
-		// 2. Update TG to remove "delete-me"
-		// FIX: Use RetryOnConflict to handle background controller updates (e.g. status/finalizers)
-		// causing ResourceVersion mismatches.
+		// Removing a child from the desired spec should not delete the Shard
+		// immediately. The parent first asks the child to drain by preserving the
+		// object and adding PendingDeletion.
+		// Retry because the controller may update status or finalizers concurrently.
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			// Always fetch the latest version inside the retry loop
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tg), tg); err != nil {
 				return err
 			}
 			tg.Spec.Shards = []multigresv1alpha1.ShardResolvedSpec{
 				{
-					Name:      "keep-me",
-					MultiOrch: multigresv1alpha1.MultiOrchSpec{StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))}},
-					Pools:     map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
+					Name: "keep-me",
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
 				},
 			}
 			return k8sClient.Update(ctx, tg)
@@ -176,15 +204,25 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// 3. Wait for PendingDeletion annotation (set by the TableGroup controller).
-		// The shard controller is not running in this test, so we simulate its
-		// role by manually setting the ReadyForDeletion condition below.
-		deleteMeName := nameutil.JoinWithConstraints(nameutil.DefaultConstraints, clusterName, "db1", "tg1", "delete-me")
+		// The shard controller is not running in this test. Once the parent has
+		// asked for a drain, the test simulates the child controller's
+		// ReadyForDeletion acknowledgement.
+		deleteMeName := nameutil.JoinWithConstraints(
+			nameutil.DefaultConstraints,
+			clusterName,
+			"db1",
+			"tg1",
+			"delete-me",
+		)
 		var deleteMe multigresv1alpha1.Shard
 		waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer waitCancel()
 		for {
-			if err := k8sClient.Get(waitCtx, client.ObjectKey{Name: deleteMeName, Namespace: "default"}, &deleteMe); err == nil {
+			if err := k8sClient.Get(
+				waitCtx,
+				client.ObjectKey{Name: deleteMeName, Namespace: "default"},
+				&deleteMe,
+			); err == nil {
 				if deleteMe.Annotations[multigresv1alpha1.AnnotationPendingDeletion] != "" {
 					break
 				}
@@ -196,10 +234,13 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 			}
 		}
 
-		// 4. Simulate the shard controller: set ReadyForDeletion condition.
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			latest := &multigresv1alpha1.Shard{}
-			if err := k8sClient.Get(ctx, client.ObjectKey{Name: deleteMeName, Namespace: "default"}, latest); err != nil {
+			if err := k8sClient.Get(
+				ctx,
+				client.ObjectKey{Name: deleteMeName, Namespace: "default"},
+				latest,
+			); err != nil {
 				return err
 			}
 			latest.Status.Conditions = append(latest.Status.Conditions, metav1.Condition{
@@ -214,7 +255,7 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 			t.Fatalf("Failed to set ReadyForDeletion condition: %v", err)
 		}
 
-		// 5. Verify the shard is deleted by the TableGroup controller.
+		// Deletion is only valid after the child has acknowledged the drain.
 		if err := watcher.WaitForDeletion(shard2); err != nil {
 			t.Errorf("Shard 'delete-me' was not pruned: %v", err)
 		}
@@ -246,7 +287,9 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 					{
 						Name: "s1",
 						MultiOrch: multigresv1alpha1.MultiOrchSpec{
-							StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
+							StatelessSpec: multigresv1alpha1.StatelessSpec{
+								Replicas: ptr.To(int32(1)),
+							},
 						},
 						Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
 					},
@@ -254,19 +297,27 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 			},
 		}
 
+		// This case treats TableGroup as the source of truth for child spec. A
+		// direct edit to the Shard should be corrected back to the parent-owned
+		// desired shape.
 		setTestPostgresPasswordSecretRef(tg)
 
 		if err := k8sClient.Create(ctx, tg); err != nil {
 			t.Fatal(err)
 		}
 
-		// Use SpecOnly comparison to simplify the object construction
+		// Compare only spec fields because the controller owns metadata and status.
 		watcher.SetCmpOpts(testutil.CompareSpecOnly()...)
 
-		// 1. Wait for Shard (Initial Good State)
 		goodShard := &multigresv1alpha1.Shard{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      nameutil.JoinWithConstraints(nameutil.DefaultConstraints, clusterName, "db1", "tg1", "s1"),
+				Name: nameutil.JoinWithConstraints(
+					nameutil.DefaultConstraints,
+					clusterName,
+					"db1",
+					"tg1",
+					"s1",
+				),
 				Namespace: "default",
 			},
 			Spec: multigresv1alpha1.ShardSpec{
@@ -291,22 +342,25 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 			t.Fatalf("Initial shard creation failed: %v", err)
 		}
 
-		// 2. Tamper with Shard (Scale up manually)
+		// Mutate the child directly, as an out-of-band actor might. The retry is
+		// for resourceVersion conflicts with the controller's own writes.
 		latestShard := &multigresv1alpha1.Shard{}
-		// FIX: Use RetryOnConflict for tamper update as well, just in case
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(goodShard), latestShard); err != nil {
+			if err := k8sClient.Get(
+				ctx,
+				client.ObjectKeyFromObject(goodShard),
+				latestShard,
+			); err != nil {
 				return err
 			}
-			latestShard.Spec.MultiOrch.Replicas = ptr.To(int32(99)) // Tamper
+			latestShard.Spec.MultiOrch.Replicas = ptr.To(int32(99))
 			return k8sClient.Update(ctx, latestShard)
 		}); err != nil {
 			t.Fatal(err)
 		}
 
-		// 3. Verify Reversion (Back to Good State)
-		// We removed the waiting for "Bad" state because the controller can be faster than the watcher.
-		// If Update() succeeded, the tamper occurred. We now verify the controller enforces the desired state.
+		// Assert the desired spec again rather than trying to observe the bad
+		// intermediate state; the controller may repair it before the watch sees it.
 		if err := watcher.WaitForMatch(goodShard); err != nil {
 			t.Errorf("Controller failed to revert manual shard change: %v", err)
 		}

--- a/pkg/cluster-handler/controller/tablegroup/integration_lifecycle_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/integration_lifecycle_test.go
@@ -63,7 +63,7 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 		return mgr.GetClient(), watcher
 	}
 
-	t.Run("Pruning (Orphan Deletion)", func(t *testing.T) {
+	t.Run("Pruning and Same-Name Replacement", func(t *testing.T) {
 		t.Parallel()
 		k8sClient, watcher := setup(t)
 		ctx := t.Context()
@@ -234,6 +234,64 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 			}
 		}
 
+		oldDeleteMeUID := string(deleteMe.UID)
+		if got := deleteMe.Spec.MultiOrch.StatelessSpec.Replicas; got == nil || *got != 1 {
+			t.Fatalf("Initial delete-me replicas = %v, want 1", got)
+		}
+
+		// Re-adding the same logical shard while the old object is draining must
+		// not resurrect or update that object. Cleanup remains the active
+		// lifecycle until the child reports ReadyForDeletion and is deleted.
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tg), tg); err != nil {
+				return err
+			}
+			tg.Spec.Shards = []multigresv1alpha1.ShardResolvedSpec{
+				{
+					Name: "keep-me",
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
+				},
+				{
+					Name: "delete-me",
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(2))},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{},
+				},
+			}
+			return k8sClient.Update(ctx, tg)
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		waitForTableGroup(t, ctx, k8sClient, client.ObjectKeyFromObject(tg),
+			15*time.Second, func(g *multigresv1alpha1.TableGroup) bool {
+				return g.Status.Phase == multigresv1alpha1.PhaseProgressing &&
+					g.Status.ObservedGeneration == g.Generation &&
+					g.Status.Message == "Waiting for shard cleanup to finish"
+			})
+
+		if err := k8sClient.Get(
+			ctx,
+			client.ObjectKey{Name: deleteMeName, Namespace: "default"},
+			&deleteMe,
+		); err != nil {
+			t.Fatalf("Failed to get draining shard after re-add: %v", err)
+		}
+		if got := string(deleteMe.UID); got != oldDeleteMeUID {
+			t.Fatalf("Draining shard was replaced before cleanup: got UID %s, want %s",
+				got, oldDeleteMeUID)
+		}
+		if deleteMe.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
+			t.Fatal("Draining shard lost PendingDeletion after same-name re-add")
+		}
+		if got := deleteMe.Spec.MultiOrch.StatelessSpec.Replicas; got == nil || *got != 1 {
+			t.Fatalf("Draining shard was updated during cleanup: replicas = %v, want 1", got)
+		}
+
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			latest := &multigresv1alpha1.Shard{}
 			if err := k8sClient.Get(
@@ -259,6 +317,39 @@ func TestTableGroup_Lifecycle(t *testing.T) {
 		if err := watcher.WaitForDeletion(shard2); err != nil {
 			t.Errorf("Shard 'delete-me' was not pruned: %v", err)
 		}
+
+		waitCtx, waitCancel = context.WithTimeout(ctx, 15*time.Second)
+		defer waitCancel()
+		for {
+			latest := &multigresv1alpha1.Shard{}
+			if err := k8sClient.Get(
+				waitCtx,
+				client.ObjectKey{Name: deleteMeName, Namespace: "default"},
+				latest,
+			); err == nil &&
+				string(latest.UID) != oldDeleteMeUID &&
+				latest.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
+				if got := latest.Spec.MultiOrch.StatelessSpec.Replicas; got == nil || *got != 2 {
+					t.Fatalf("Replacement shard replicas = %v, want 2", got)
+				}
+				break
+			}
+			select {
+			case <-waitCtx.Done():
+				t.Fatalf("Shard 'delete-me' replacement was not created: %v", waitCtx.Err())
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+
+		driveShardHealthy(t, ctx, k8sClient, shard1.Name, "default")
+		driveShardHealthy(t, ctx, k8sClient, deleteMeName, "default")
+		waitForTableGroup(t, ctx, k8sClient, client.ObjectKeyFromObject(tg),
+			15*time.Second, func(g *multigresv1alpha1.TableGroup) bool {
+				return g.Status.Phase == multigresv1alpha1.PhaseHealthy &&
+					g.Status.ReadyShards == 2 &&
+					g.Status.TotalShards == 2 &&
+					g.Status.ObservedGeneration == g.Generation
+			})
 	})
 
 	t.Run("Enforcement (Revert Manual Changes)", func(t *testing.T) {

--- a/pkg/cluster-handler/controller/tablegroup/integration_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/integration_test.go
@@ -63,7 +63,6 @@ func TestSetupWithManager_Failure(t *testing.T) {
 		),
 	)
 
-	// Setup should fail because TableGroup is not in scheme
 	if err := (&tablegroup.TableGroupReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
@@ -135,8 +134,10 @@ func TestTableGroupReconciliation(t *testing.T) {
 						{
 							Name: "s1",
 							MultiOrch: multigresv1alpha1.MultiOrchSpec{
-								StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
-								Cells:         []multigresv1alpha1.CellName{"zone-a"},
+								StatelessSpec: multigresv1alpha1.StatelessSpec{
+									Replicas: ptr.To(int32(1)),
+								},
+								Cells: []multigresv1alpha1.CellName{"zone-a"},
 							},
 							Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 								"primary": {
@@ -149,8 +150,10 @@ func TestTableGroupReconciliation(t *testing.T) {
 						{
 							Name: "s2",
 							MultiOrch: multigresv1alpha1.MultiOrchSpec{
-								StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
-								Cells:         []multigresv1alpha1.CellName{"zone-b"},
+								StatelessSpec: multigresv1alpha1.StatelessSpec{
+									Replicas: ptr.To(int32(1)),
+								},
+								Cells: []multigresv1alpha1.CellName{"zone-b"},
 							},
 							Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 								"primary": {
@@ -164,7 +167,6 @@ func TestTableGroupReconciliation(t *testing.T) {
 				},
 			},
 			wantResources: []client.Object{
-				// Shard 1
 				&multigresv1alpha1.Shard{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "tg-test-simple-s1",
@@ -187,8 +189,10 @@ func TestTableGroupReconciliation(t *testing.T) {
 							Implementation: "etcd",
 						},
 						MultiOrch: multigresv1alpha1.MultiOrchSpec{
-							StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
-							Cells:         []multigresv1alpha1.CellName{"zone-a"},
+							StatelessSpec: multigresv1alpha1.StatelessSpec{
+								Replicas: ptr.To(int32(1)),
+							},
+							Cells: []multigresv1alpha1.CellName{"zone-a"},
 						},
 						Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 							"primary": {
@@ -200,7 +204,6 @@ func TestTableGroupReconciliation(t *testing.T) {
 						Replicas: ptr.To(int32(1)),
 					},
 				},
-				// Shard 2
 				&multigresv1alpha1.Shard{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "tg-test-simple-s2",
@@ -223,8 +226,10 @@ func TestTableGroupReconciliation(t *testing.T) {
 							Implementation: "etcd",
 						},
 						MultiOrch: multigresv1alpha1.MultiOrchSpec{
-							StatelessSpec: multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))},
-							Cells:         []multigresv1alpha1.CellName{"zone-b"},
+							StatelessSpec: multigresv1alpha1.StatelessSpec{
+								Replicas: ptr.To(int32(1)),
+							},
+							Cells: []multigresv1alpha1.CellName{"zone-b"},
 						},
 						Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
 							"primary": {
@@ -245,14 +250,12 @@ func TestTableGroupReconciliation(t *testing.T) {
 			t.Parallel()
 			ctx := t.Context()
 
-			// 1. Setup Envtest and Manager
 			mgr := testutil.SetUpEnvtestManager(t, scheme,
 				testutil.WithCRDPaths(
 					filepath.Join("../../../../", "config", "crd", "bases"),
 				),
 			)
 
-			// 2. Setup Watcher
 			watcher := testutil.NewResourceWatcher(t, ctx, mgr,
 				testutil.WithCmpOpts(
 					testutil.IgnoreMetaRuntimeFields(),
@@ -265,7 +268,6 @@ func TestTableGroupReconciliation(t *testing.T) {
 			)
 			k8sClient := mgr.GetClient()
 
-			// 3. Setup and Start Controller
 			reconciler := &tablegroup.TableGroupReconciler{
 				Client:   mgr.GetClient(),
 				Scheme:   mgr.GetScheme(),
@@ -278,13 +280,12 @@ func TestTableGroupReconciliation(t *testing.T) {
 				t.Fatalf("Failed to create controller, %v", err)
 			}
 
-			// 4. Create the Input
 			setTestPostgresPasswordSecretRef(tc.tableGroup)
 			if err := k8sClient.Create(ctx, tc.tableGroup); err != nil {
 				t.Fatalf("Failed to create the initial tablegroup, %v", err)
 			}
 
-			// Patch wantResources with hashed names
+			// Expected Shard names use the same name constraints as the controller.
 			for _, obj := range tc.wantResources {
 				if shard, ok := obj.(*multigresv1alpha1.Shard); ok {
 					clusterName := tc.tableGroup.Labels["multigres.com/cluster"]
@@ -300,15 +301,12 @@ func TestTableGroupReconciliation(t *testing.T) {
 				}
 			}
 
-			// 5. Assert Logic
 			if err := watcher.WaitForMatch(tc.wantResources...); err != nil {
 				t.Errorf("Resources mismatch:\n%v", err)
 			}
 		})
 	}
 }
-
-// Helpers
 
 func shardLabels(clusterName, db, tg, shard string) map[string]string {
 	labels := metadata.BuildStandardLabels(clusterName, "shard")

--- a/pkg/cluster-handler/controller/tablegroup/reconcile_shards.go
+++ b/pkg/cluster-handler/controller/tablegroup/reconcile_shards.go
@@ -1,0 +1,148 @@
+package tablegroup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+// stepListChildShards reads the children once for the normal reconcile path.
+// Later steps apply desired children and prune orphans against this same
+// snapshot, preserving each child's observed .Status for status aggregation.
+func stepListChildShards(ctx context.Context, rc *reconcileContext) (stepResult, error) {
+	observed := &multigresv1alpha1.ShardList{}
+	if err := rc.r.List(ctx, observed, childShardSelector(rc.tg)...); err != nil {
+		return stepResult{}, newStepError(
+			fmt.Errorf("failed to list shards for pruning: %w", err),
+			"Warning",
+			"CleanUpError",
+			fmt.Sprintf("Failed to list shards for pruning: %v", err),
+		)
+	}
+
+	rc.observedShards = observed
+	return continueStep(), nil
+}
+
+// stepApplyDesiredShards applies each desired Shard and records the names and
+// generations produced by the apiserver. Later status aggregation uses those
+// generations to avoid treating a just-updated child as ready before the child
+// controller observes its new spec.
+func stepApplyDesiredShards(ctx context.Context, rc *reconcileContext) (stepResult, error) {
+	rc.activeShardNames = make(map[string]bool, len(rc.tg.Spec.Shards))
+	rc.appliedGeneration = make(map[string]int64, len(rc.tg.Spec.Shards))
+	for i := range rc.tg.Spec.Shards {
+		shardSpec := rc.tg.Spec.Shards[i]
+		desired, err := BuildShard(rc.tg, &shardSpec, rc.r.Scheme)
+		if err != nil {
+			return stepResult{}, newStepError(
+				fmt.Errorf("failed to build shard: %w", err),
+				"Warning",
+				"FailedApply",
+				fmt.Sprintf("Failed to build shard %s: %v", shardSpec.Name, err),
+			)
+		}
+
+		// Track the name BuildShard produced, not a manually computed one.
+		rc.activeShardNames[desired.Name] = true
+
+		desired.SetGroupVersionKind(multigresv1alpha1.GroupVersion.WithKind("Shard"))
+		if err := rc.r.Patch(
+			ctx,
+			desired,
+			client.Apply,
+			client.ForceOwnership,
+			client.FieldOwner("multigres-operator"),
+		); err != nil {
+			return stepResult{}, newStepError(
+				fmt.Errorf("failed to apply shard: %w", err),
+				"Warning",
+				"FailedApply",
+				fmt.Sprintf("Failed to apply shard %s: %v", desired.Name, err),
+			)
+		}
+
+		// Record the generation the apply settled on. If this apply changed the
+		// child's spec the server bumps it past the child's observed generation,
+		// which stepComputeStatus uses to avoid reporting a just-changed child as
+		// ready before its own controller has reconciled.
+		rc.appliedGeneration[desired.Name] = desired.Generation
+
+		rc.r.Recorder.Eventf(rc.tg, "Normal", "Applied", "Applied Shard %s", desired.Name)
+	}
+
+	return continueStep(), nil
+}
+
+// stepReconcileUndesired retires observed children that are no longer desired.
+// Orphans are not deleted on sight: the parent first marks PendingDeletion, waits
+// for the Shard controller to report ReadyForDeletion, and only then deletes.
+// The desired objects built above are never written back into rc.observedShards,
+// so status continues to use the children's observed status.
+func stepReconcileUndesired(ctx context.Context, rc *reconcileContext) (stepResult, error) {
+	l := log.FromContext(ctx)
+
+	for i := range rc.observedShards.Items {
+		s := &rc.observedShards.Items[i]
+		if rc.activeShardNames[s.Name] {
+			continue
+		}
+
+		// The annotation is the handoff to the Shard controller: keep the child
+		// object around, but ask it to drain before the parent deletes it.
+		if s.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
+			if err := rc.r.setShardPendingDeletion(ctx, s); err != nil {
+				return stepResult{}, newStepError(
+					fmt.Errorf("failed to set PendingDeletion on shard '%s': %w", s.Name, err),
+					"Warning",
+					"CleanUpError",
+					fmt.Sprintf("Failed to set PendingDeletion on shard %s: %v", s.Name, err),
+				)
+			}
+			rc.r.Recorder.Eventf(rc.tg, "Normal", "PendingDeletion",
+				"Marked Shard %s for graceful deletion", s.Name)
+			rc.pendingDeletion = true
+			continue
+		}
+
+		// Until the child reports ReadyForDeletion, parent status must remain
+		// Progressing and the orphan must stay in place.
+		if !meta.IsStatusConditionTrue(
+			s.Status.Conditions,
+			multigresv1alpha1.ConditionReadyForDeletion,
+		) {
+			l.V(1).Info("Shard pending deletion, waiting for drain", "shard", s.Name)
+			rc.pendingDeletion = true
+			continue
+		}
+
+		// The Shard has drained, so it is safe to delete.
+		if err := rc.r.Delete(ctx, s); err != nil && !apierrors.IsNotFound(err) {
+			return stepResult{}, newStepError(
+				fmt.Errorf("failed to delete orphan shard '%s': %w", s.Name, err),
+				"Warning",
+				"CleanUpError",
+				fmt.Sprintf("Failed to delete orphan shard %s: %v", s.Name, err),
+			)
+		} else if err == nil {
+			rc.r.Recorder.Eventf(rc.tg, "Normal", "Deleted", "Deleted orphaned Shard %s", s.Name)
+		}
+	}
+
+	return continueStep(), nil
+}
+
+func stepRequeueIfPending(_ context.Context, rc *reconcileContext) (stepResult, error) {
+	if rc.pendingDeletion {
+		return doneStep(ctrl.Result{RequeueAfter: 5 * time.Second}), nil
+	}
+	return continueStep(), nil
+}

--- a/pkg/cluster-handler/controller/tablegroup/reconcile_shards.go
+++ b/pkg/cluster-handler/controller/tablegroup/reconcile_shards.go
@@ -32,10 +32,9 @@ func stepListChildShards(ctx context.Context, rc *reconcileContext) (stepResult,
 	return continueStep(), nil
 }
 
-// stepApplyDesiredShards applies each desired Shard and records the names and
-// generations produced by the apiserver. Later status aggregation uses those
-// generations to avoid treating a just-updated child as ready before the child
-// controller observes its new spec.
+// stepApplyDesiredShards applies each desired Shard that is not already being
+// cleaned up. If the same name still carries PendingDeletion or is terminating,
+// the old child must leave before a replacement is created.
 func stepApplyDesiredShards(ctx context.Context, rc *reconcileContext) (stepResult, error) {
 	rc.activeShardNames = make(map[string]bool, len(rc.tg.Spec.Shards))
 	rc.appliedGeneration = make(map[string]int64, len(rc.tg.Spec.Shards))
@@ -49,6 +48,11 @@ func stepApplyDesiredShards(ctx context.Context, rc *reconcileContext) (stepResu
 				"FailedApply",
 				fmt.Sprintf("Failed to build shard %s: %v", shardSpec.Name, err),
 			)
+		}
+
+		if observedCleanupInProgress(rc.observedShards, desired.Name) {
+			rc.pendingDeletion = true
+			continue
 		}
 
 		// Track the name BuildShard produced, not a manually computed one.
@@ -82,17 +86,35 @@ func stepApplyDesiredShards(ctx context.Context, rc *reconcileContext) (stepResu
 	return continueStep(), nil
 }
 
-// stepReconcileUndesired retires observed children that are no longer desired.
-// Orphans are not deleted on sight: the parent first marks PendingDeletion, waits
-// for the Shard controller to report ReadyForDeletion, and only then deletes.
-// The desired objects built above are never written back into rc.observedShards,
-// so status continues to use the children's observed status.
+func observedCleanupInProgress(shards *multigresv1alpha1.ShardList, name string) bool {
+	if shards == nil {
+		return false
+	}
+	for i := range shards.Items {
+		s := &shards.Items[i]
+		if s.Name == name {
+			return s.Annotations[multigresv1alpha1.AnnotationPendingDeletion] != "" ||
+				s.DeletionTimestamp != nil
+		}
+	}
+	return false
+}
+
+// stepReconcileUndesired advances cleanup for observed children that were not
+// applied this reconcile. Children drain through PendingDeletion and
+// ReadyForDeletion before deletion; same-name replacements wait here too.
 func stepReconcileUndesired(ctx context.Context, rc *reconcileContext) (stepResult, error) {
 	l := log.FromContext(ctx)
 
 	for i := range rc.observedShards.Items {
 		s := &rc.observedShards.Items[i]
 		if rc.activeShardNames[s.Name] {
+			continue
+		}
+
+		if s.DeletionTimestamp != nil {
+			l.V(1).Info("Shard already terminating, waiting for deletion", "shard", s.Name)
+			rc.pendingDeletion = true
 			continue
 		}
 
@@ -127,13 +149,14 @@ func stepReconcileUndesired(ctx context.Context, rc *reconcileContext) (stepResu
 		// The Shard has drained, so it is safe to delete.
 		if err := rc.r.Delete(ctx, s); err != nil && !apierrors.IsNotFound(err) {
 			return stepResult{}, newStepError(
-				fmt.Errorf("failed to delete orphan shard '%s': %w", s.Name, err),
+				fmt.Errorf("failed to delete shard '%s' after cleanup: %w", s.Name, err),
 				"Warning",
 				"CleanUpError",
-				fmt.Sprintf("Failed to delete orphan shard %s: %v", s.Name, err),
+				fmt.Sprintf("Failed to delete shard %s after cleanup: %v", s.Name, err),
 			)
 		} else if err == nil {
-			rc.r.Recorder.Eventf(rc.tg, "Normal", "Deleted", "Deleted orphaned Shard %s", s.Name)
+			rc.r.Recorder.Eventf(rc.tg, "Normal", "Deleted",
+				"Deleted Shard %s after cleanup", s.Name)
 		}
 	}
 

--- a/pkg/cluster-handler/controller/tablegroup/reconcile_shards_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/reconcile_shards_test.go
@@ -1,0 +1,256 @@
+package tablegroup
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/name"
+)
+
+// TestShardStepsPrune covers the retained PendingDeletion handshake for child
+// Shards no longer in the spec. It verifies pruning annotates once, waits for
+// ReadyForDeletion, deletes only after drain, and skips desired children.
+func TestShardStepsPrune(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	baseTG, _, namespace, clusterName, dbName, tgLabelName := setupFixtures(t)
+
+	shardName := name.JoinWithConstraints(
+		name.DefaultConstraints,
+		clusterName,
+		dbName,
+		tgLabelName,
+		"shard-0",
+	)
+
+	childShardLabels := map[string]string{
+		"multigres.com/cluster":    clusterName,
+		"multigres.com/database":   dbName,
+		"multigres.com/tablegroup": tgLabelName,
+	}
+
+	// annotation stamped by a prior reconcile; must be preserved, not re-stamped.
+	const oldAnnotation = "2026-01-01T00:00:00Z"
+
+	// child builds a no-longer-desired child Shard. withAnnotation seeds the
+	// PendingDeletion annotation; ready additionally sets ReadyForDeletion.
+	child := func(withAnnotation, ready bool) *multigresv1alpha1.Shard {
+		s := &multigresv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shardName,
+				Namespace: namespace,
+				Labels:    childShardLabels,
+			},
+			Spec: multigresv1alpha1.ShardSpec{ShardName: "shard-0"},
+		}
+		if withAnnotation {
+			s.Annotations = map[string]string{
+				multigresv1alpha1.AnnotationPendingDeletion: oldAnnotation,
+			}
+		}
+		if ready {
+			meta.SetStatusCondition(&s.Status.Conditions, metav1.Condition{
+				Type:    multigresv1alpha1.ConditionReadyForDeletion,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Drained",
+				Message: "All pods drained",
+			})
+		}
+		return s
+	}
+
+	tests := map[string]struct {
+		child                  *multigresv1alpha1.Shard
+		stillDesired           bool // when true the spec keeps shard-0 so pruning must skip it
+		wantPatches            int64
+		wantDeletes            int64
+		wantPending            bool
+		wantDeleted            bool
+		wantEvent              string
+		wantAnnotation         string // exact PendingDeletion value expected when child survives
+		wantAnnotationNonEmpty bool   // when set, only require a (freshly stamped) non-empty value
+	}{
+		// With no annotation yet, pruning annotates the child, marks it pending,
+		// and emits an event without deleting.
+		"orphan without annotation gets annotated and pends": {
+			child:                  child(false, false),
+			wantPatches:            1,
+			wantDeletes:            0,
+			wantPending:            true,
+			wantDeleted:            false,
+			wantEvent:              "Normal PendingDeletion",
+			wantAnnotationNonEmpty: true,
+		},
+		// Already annotated but not ready, so it stays pending without re-stamping
+		// or deleting.
+		"orphan annotated but not ready stays pending, not double-driven": {
+			child:          child(true, false),
+			wantPatches:    0,
+			wantDeletes:    0,
+			wantPending:    true,
+			wantDeleted:    false,
+			wantAnnotation: oldAnnotation,
+		},
+		// Annotated and drained, so it's deleted once without re-stamping.
+		"orphan annotated and ReadyForDeletion is deleted": {
+			child:       child(true, true),
+			wantPatches: 0,
+			wantDeletes: 1,
+			wantPending: false,
+			wantDeleted: true,
+		},
+		// A child that's still desired is applied but never pruned: the apply is
+		// the single Patch, pruning leaves it untouched with no PendingDeletion.
+		"desired child is applied and skipped by pruning": {
+			child:          child(false, false),
+			stillDesired:   true,
+			wantPatches:    1,
+			wantDeletes:    0,
+			wantPending:    false,
+			wantDeleted:    false,
+			wantAnnotation: "",
+		},
+	}
+
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			var shardPatchCount atomic.Int64
+			var shardDeleteCount atomic.Int64
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tc.child).
+				WithStatusSubresource(
+					&multigresv1alpha1.TableGroup{},
+					&multigresv1alpha1.Shard{},
+				).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(
+						ctx context.Context,
+						cli client.WithWatch,
+						obj client.Object,
+						patch client.Patch,
+						opts ...client.PatchOption,
+					) error {
+						if _, ok := obj.(*multigresv1alpha1.Shard); ok {
+							shardPatchCount.Add(1)
+						}
+						return cli.Patch(ctx, obj, patch, opts...)
+					},
+					Delete: func(
+						ctx context.Context,
+						cli client.WithWatch,
+						obj client.Object,
+						opts ...client.DeleteOption,
+					) error {
+						if _, ok := obj.(*multigresv1alpha1.Shard); ok {
+							shardDeleteCount.Add(1)
+						}
+						return cli.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			recorder := record.NewFakeRecorder(100)
+			reconciler := &TableGroupReconciler{
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: recorder,
+			}
+
+			tg := baseTG.DeepCopy()
+			if !tc.stillDesired {
+				// Drop the desired shard so the seeded child becomes an orphan.
+				tg.Spec.Shards = []multigresv1alpha1.ShardResolvedSpec{}
+			}
+
+			rc := &reconcileContext{
+				r:  reconciler,
+				tg: tg,
+			}
+			for _, s := range []step{
+				stepListChildShards,
+				stepApplyDesiredShards,
+				stepReconcileUndesired,
+			} {
+				if _, err := s(t.Context(), rc); err != nil {
+					t.Fatalf("shard step returned error: %v", err)
+				}
+			}
+
+			if got := shardPatchCount.Load(); got != tc.wantPatches {
+				t.Errorf("Patch count mismatch: got %d, want %d", got, tc.wantPatches)
+			}
+			if got := shardDeleteCount.Load(); got != tc.wantDeletes {
+				t.Errorf("Delete count mismatch: got %d, want %d", got, tc.wantDeletes)
+			}
+			if rc.pendingDeletion != tc.wantPending {
+				t.Errorf("pending mismatch: got %t, want %t", rc.pendingDeletion, tc.wantPending)
+			}
+
+			if tc.wantEvent != "" {
+				close(recorder.Events)
+				found := false
+				for evt := range recorder.Events {
+					if strings.Contains(evt, tc.wantEvent) {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("expected an event containing %q", tc.wantEvent)
+				}
+			}
+
+			fetched := &multigresv1alpha1.Shard{}
+			getErr := c.Get(
+				t.Context(),
+				types.NamespacedName{Name: shardName, Namespace: namespace},
+				fetched,
+			)
+
+			if tc.wantDeleted {
+				if !errors.IsNotFound(getErr) {
+					t.Errorf(
+						"expected child Shard to be deleted, but it still exists (err: %v)",
+						getErr,
+					)
+				}
+				return
+			}
+
+			if getErr != nil {
+				t.Fatalf("expected child Shard to still exist: %v", getErr)
+			}
+			got := fetched.Annotations[multigresv1alpha1.AnnotationPendingDeletion]
+			if tc.wantAnnotationNonEmpty {
+				if got == "" {
+					t.Error("expected a freshly stamped PendingDeletion annotation, got empty")
+				}
+			} else if got != tc.wantAnnotation {
+				t.Errorf(
+					"PendingDeletion annotation mismatch: got %q, want %q",
+					got,
+					tc.wantAnnotation,
+				)
+			}
+		})
+	}
+}

--- a/pkg/cluster-handler/controller/tablegroup/reconcile_shards_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/reconcile_shards_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -74,6 +75,15 @@ func TestShardStepsPrune(t *testing.T) {
 		}
 		return s
 	}
+	terminatingChild := func() *multigresv1alpha1.Shard {
+		s := child(false, false)
+		now := metav1.Now()
+		s.DeletionTimestamp = &now
+		// Test fixture only: keep the fake object visible after DeletionTimestamp
+		// so the controller observes a Kubernetes object mid-termination.
+		s.Finalizers = []string{"test.finalizer"}
+		return s
+	}
 
 	tests := map[string]struct {
 		child                  *multigresv1alpha1.Shard
@@ -82,6 +92,7 @@ func TestShardStepsPrune(t *testing.T) {
 		wantDeletes            int64
 		wantPending            bool
 		wantDeleted            bool
+		wantActive             bool
 		wantEvent              string
 		wantAnnotation         string // exact PendingDeletion value expected when child survives
 		wantAnnotationNonEmpty bool   // when set, only require a (freshly stamped) non-empty value
@@ -124,7 +135,51 @@ func TestShardStepsPrune(t *testing.T) {
 			wantDeletes:    0,
 			wantPending:    false,
 			wantDeleted:    false,
+			wantActive:     true,
 			wantAnnotation: "",
+		},
+		// If the same name becomes desired again while the old child is still
+		// draining, the controller waits instead of applying over deletion state.
+		"desired child already pending deletion waits for replacement": {
+			child:          child(true, false),
+			stillDesired:   true,
+			wantPatches:    0,
+			wantDeletes:    0,
+			wantPending:    true,
+			wantDeleted:    false,
+			wantAnnotation: oldAnnotation,
+		},
+		// A desired child that Kubernetes is already deleting also cannot be
+		// updated or counted as active; the replacement waits for a clean object.
+		"desired child already terminating waits for replacement": {
+			child:          terminatingChild(),
+			stillDesired:   true,
+			wantPatches:    0,
+			wantDeletes:    0,
+			wantPending:    true,
+			wantDeleted:    false,
+			wantAnnotation: "",
+		},
+		// If an orphan is already terminating, pruning should wait for the
+		// apiserver deletion instead of trying to stamp the cleanup annotation.
+		"orphan already terminating waits without restamping": {
+			child:          terminatingChild(),
+			wantPatches:    0,
+			wantDeletes:    0,
+			wantPending:    true,
+			wantDeleted:    false,
+			wantAnnotation: "",
+		},
+		// Once the old child reports ready, it is deleted and the next reconcile
+		// can create the desired replacement from a clean object lifecycle.
+		"desired child ready for deletion is removed before replacement": {
+			child:        child(true, true),
+			stillDesired: true,
+			wantPatches:  0,
+			wantDeletes:  1,
+			wantPending:  true,
+			wantDeleted:  true,
+			wantEvent:    "Normal Deleted",
 		},
 	}
 
@@ -204,6 +259,20 @@ func TestShardStepsPrune(t *testing.T) {
 			}
 			if rc.pendingDeletion != tc.wantPending {
 				t.Errorf("pending mismatch: got %t, want %t", rc.pendingDeletion, tc.wantPending)
+			}
+			if got := rc.activeShardNames[shardName]; got != tc.wantActive {
+				t.Errorf("active child mismatch: got %t, want %t", got, tc.wantActive)
+			}
+			res, err := stepRequeueIfPending(t.Context(), rc)
+			if err != nil {
+				t.Fatalf("stepRequeueIfPending returned error: %v", err)
+			}
+			if tc.wantPending {
+				if !res.done || res.result.RequeueAfter != 5*time.Second {
+					t.Errorf("requeue mismatch: got %+v, want 5s requeue", res.result)
+				}
+			} else if res.done {
+				t.Errorf("unexpected requeue result: %+v", res.result)
 			}
 
 			if tc.wantEvent != "" {

--- a/pkg/cluster-handler/controller/tablegroup/status.go
+++ b/pkg/cluster-handler/controller/tablegroup/status.go
@@ -1,0 +1,159 @@
+package tablegroup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+// stepComputeStatus derives TableGroup status from desired children whose
+// observed status has caught up to the generation applied in this reconcile.
+// Pending cleanup forces Progressing so stale child status cannot report ready.
+func stepComputeStatus(_ context.Context, rc *reconcileContext) (stepResult, error) {
+	observed := rc.observedShards
+	if observed == nil {
+		observed = &multigresv1alpha1.ShardList{}
+	}
+
+	total := int32(len(rc.tg.Spec.Shards)) //nolint:gosec // bounded by K8s object size limits
+	ready := int32(0)
+
+	var anyDegraded bool
+
+	for i := range observed.Items {
+		s := &observed.Items[i]
+
+		// Orphans being pruned (or already deleted this pass) are no longer
+		// desired, so they must not influence the parent's status.
+		if !rc.activeShardNames[s.Name] {
+			continue
+		}
+
+		// Count the child only after it has observed the generation applied above.
+		if s.Status.ObservedGeneration != rc.appliedGeneration[s.Name] {
+			continue
+		}
+
+		switch s.Status.Phase {
+		case multigresv1alpha1.PhaseHealthy:
+			ready++
+		case multigresv1alpha1.PhaseDegraded:
+			anyDegraded = true
+		default:
+			// Initializing, Progressing, and Unknown all count as progressing.
+		}
+	}
+
+	rc.tg.Status.TotalShards = total
+	rc.tg.Status.ReadyShards = ready
+
+	switch {
+	case anyDegraded:
+		rc.tg.Status.Phase = multigresv1alpha1.PhaseDegraded
+		rc.tg.Status.Message = "At least one shard is degraded"
+	case rc.pendingDeletion:
+		rc.tg.Status.Phase = multigresv1alpha1.PhaseProgressing
+		rc.tg.Status.Message = "Waiting for removed shards to drain"
+	case total == 0:
+		rc.tg.Status.Phase = multigresv1alpha1.PhaseInitializing
+		rc.tg.Status.Message = "No Shards"
+	case ready == total:
+		rc.tg.Status.Phase = multigresv1alpha1.PhaseHealthy
+		rc.tg.Status.Message = "Ready"
+	default:
+		rc.tg.Status.Phase = multigresv1alpha1.PhaseProgressing
+		rc.tg.Status.Message = fmt.Sprintf("%d/%d shards ready", ready, total)
+	}
+
+	condStatus := metav1.ConditionFalse
+	condMessage := fmt.Sprintf("%d/%d shards ready", ready, total)
+	condReason := "ShardsNotReady"
+
+	switch rc.tg.Status.Phase {
+	case multigresv1alpha1.PhaseHealthy:
+		condStatus = metav1.ConditionTrue
+		condReason = "ShardsReady"
+	case multigresv1alpha1.PhaseDegraded:
+		condReason = "ShardDegraded"
+		condMessage = rc.tg.Status.Message
+	}
+	if total == 0 && !rc.pendingDeletion {
+		condStatus = metav1.ConditionTrue
+		condReason = "NoShards"
+		condMessage = rc.tg.Status.Message
+	}
+	if rc.pendingDeletion && rc.tg.Status.Phase == multigresv1alpha1.PhaseProgressing {
+		condReason = "CleanupPending"
+		condMessage = rc.tg.Status.Message
+	}
+
+	// Let meta.SetStatusCondition manage LastTransitionTime.
+	meta.SetStatusCondition(&rc.tg.Status.Conditions, metav1.Condition{
+		Type:               "Available",
+		Status:             condStatus,
+		Reason:             condReason,
+		Message:            condMessage,
+		ObservedGeneration: rc.tg.Generation,
+	})
+
+	rc.tg.Status.ObservedGeneration = rc.tg.Generation
+
+	return continueStep(), nil
+}
+
+// stepPatchStatus patches the computed status and emits lifecycle events.
+func stepPatchStatus(ctx context.Context, rc *reconcileContext) (stepResult, error) {
+	l := log.FromContext(ctx)
+
+	patchObj := &multigresv1alpha1.TableGroup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: multigresv1alpha1.GroupVersion.String(),
+			Kind:       "TableGroup",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rc.tg.Name,
+			Namespace: rc.tg.Namespace,
+		},
+		Status: rc.tg.Status,
+	}
+
+	if rc.oldPhase != rc.tg.Status.Phase {
+		rc.r.Recorder.Eventf(
+			rc.tg,
+			"Normal",
+			"PhaseChange",
+			"Transitioned from '%s' to '%s'",
+			rc.oldPhase,
+			rc.tg.Status.Phase,
+		)
+	}
+
+	// Server-Side Apply makes unchanged status patches no-ops.
+	if err := rc.r.Status().Patch(
+		ctx,
+		patchObj,
+		client.Apply,
+		client.FieldOwner("multigres-operator"),
+		client.ForceOwnership,
+	); err != nil {
+		return stepResult{}, newStepError(
+			fmt.Errorf("failed to patch status: %w", err),
+			"Warning",
+			"StatusError",
+			fmt.Sprintf("Failed to patch status: %v", err),
+		)
+	}
+
+	l.V(1).Info("reconcile complete", "duration", time.Since(rc.start).String())
+	if !rc.pendingDeletion {
+		rc.r.Recorder.Event(rc.tg, "Normal", "Synced", "Successfully reconciled TableGroup")
+	}
+	return continueStep(), nil
+}

--- a/pkg/cluster-handler/controller/tablegroup/status.go
+++ b/pkg/cluster-handler/controller/tablegroup/status.go
@@ -60,7 +60,7 @@ func stepComputeStatus(_ context.Context, rc *reconcileContext) (stepResult, err
 		rc.tg.Status.Message = "At least one shard is degraded"
 	case rc.pendingDeletion:
 		rc.tg.Status.Phase = multigresv1alpha1.PhaseProgressing
-		rc.tg.Status.Message = "Waiting for removed shards to drain"
+		rc.tg.Status.Message = "Waiting for shard cleanup to finish"
 	case total == 0:
 		rc.tg.Status.Phase = multigresv1alpha1.PhaseInitializing
 		rc.tg.Status.Message = "No Shards"

--- a/pkg/cluster-handler/controller/tablegroup/status_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/status_test.go
@@ -1,0 +1,451 @@
+package tablegroup
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+// TestStepComputeStatus pins the status aggregation branches. Status must come
+// from observed child status, while TotalShards comes from the desired spec.
+func TestStepComputeStatus(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	const (
+		tgName    = "test-tg"
+		namespace = "default"
+	)
+
+	tests := map[string]struct {
+		desiredShards int
+		children      []multigresv1alpha1.Shard
+		wantPhase     multigresv1alpha1.Phase
+		wantTotal     int32
+		wantReady     int32
+		wantMessage   string
+		wantAvailable metav1.ConditionStatus
+		wantReason    string
+		wantCondMsg   string
+	}{
+		// A healthy child whose ObservedGeneration matches counts as ready.
+		"healthy steady state": {
+			desiredShards: 1,
+			children: []multigresv1alpha1.Shard{
+				{
+					ObjectMeta: metav1.ObjectMeta{Generation: 1},
+					Status: multigresv1alpha1.ShardStatus{
+						Phase:              multigresv1alpha1.PhaseHealthy,
+						ObservedGeneration: 1,
+					},
+				},
+			},
+			wantPhase:     multigresv1alpha1.PhaseHealthy,
+			wantTotal:     1,
+			wantReady:     1,
+			wantMessage:   "Ready",
+			wantAvailable: metav1.ConditionTrue,
+			wantReason:    "ShardsReady",
+			wantCondMsg:   "1/1 shards ready",
+		},
+		// A healthy child with a stale ObservedGeneration isn't ready, so the group
+		// is Progressing.
+		"child observedGeneration stale": {
+			desiredShards: 1,
+			children: []multigresv1alpha1.Shard{
+				{
+					ObjectMeta: metav1.ObjectMeta{Generation: 2},
+					Status: multigresv1alpha1.ShardStatus{
+						Phase:              multigresv1alpha1.PhaseHealthy,
+						ObservedGeneration: 1,
+					},
+				},
+			},
+			wantPhase:     multigresv1alpha1.PhaseProgressing,
+			wantTotal:     1,
+			wantReady:     0,
+			wantMessage:   "0/1 shards ready",
+			wantAvailable: metav1.ConditionFalse,
+			wantReason:    "ShardsNotReady",
+			wantCondMsg:   "0/1 shards ready",
+		},
+		// A degraded child makes the whole group Degraded.
+		"degraded child": {
+			desiredShards: 1,
+			children: []multigresv1alpha1.Shard{
+				{
+					ObjectMeta: metav1.ObjectMeta{Generation: 1},
+					Status: multigresv1alpha1.ShardStatus{
+						Phase:              multigresv1alpha1.PhaseDegraded,
+						ObservedGeneration: 1,
+					},
+				},
+			},
+			wantPhase:     multigresv1alpha1.PhaseDegraded,
+			wantTotal:     1,
+			wantReady:     0,
+			wantMessage:   "At least one shard is degraded",
+			wantAvailable: metav1.ConditionFalse,
+			wantReason:    "ShardDegraded",
+			wantCondMsg:   "At least one shard is degraded",
+		},
+		// Two desired but only one healthy, so the group is Progressing.
+		"partial ready": {
+			desiredShards: 2,
+			children: []multigresv1alpha1.Shard{
+				{
+					ObjectMeta: metav1.ObjectMeta{Generation: 1},
+					Status: multigresv1alpha1.ShardStatus{
+						Phase:              multigresv1alpha1.PhaseHealthy,
+						ObservedGeneration: 1,
+					},
+				},
+			},
+			wantPhase:     multigresv1alpha1.PhaseProgressing,
+			wantTotal:     2,
+			wantReady:     1,
+			wantMessage:   "1/2 shards ready",
+			wantAvailable: metav1.ConditionFalse,
+			wantReason:    "ShardsNotReady",
+			wantCondMsg:   "1/2 shards ready",
+		},
+		// With no shards the group is vacuously Available and Initializing.
+		"zero desired": {
+			desiredShards: 0,
+			children:      nil,
+			wantPhase:     multigresv1alpha1.PhaseInitializing,
+			wantTotal:     0,
+			wantReady:     0,
+			wantMessage:   "No Shards",
+			wantAvailable: metav1.ConditionTrue,
+			wantReason:    "NoShards",
+			wantCondMsg:   "No Shards",
+		},
+	}
+
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			tg := &multigresv1alpha1.TableGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       tgName,
+					Namespace:  namespace,
+					Generation: 1,
+				},
+				Spec: multigresv1alpha1.TableGroupSpec{
+					Shards: make([]multigresv1alpha1.ShardResolvedSpec, tc.desiredShards),
+				},
+			}
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tg).
+				WithStatusSubresource(&multigresv1alpha1.TableGroup{}).
+				Build()
+
+			reconciler := &TableGroupReconciler{
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(100),
+			}
+
+			observed := &multigresv1alpha1.ShardList{Items: tc.children}
+
+			// Name each observed child and mark it desired and applied at its own
+			// generation, which is the steady-state setup these cases describe.
+			// The orphan and spec-change cases are covered by dedicated tests
+			// below that set these inputs differently.
+			active := make(map[string]bool, len(observed.Items))
+			appliedGen := make(map[string]int64, len(observed.Items))
+			for i := range observed.Items {
+				childName := fmt.Sprintf("shard-%d", i)
+				observed.Items[i].Name = childName
+				active[childName] = true
+				appliedGen[childName] = observed.Items[i].Generation
+			}
+
+			rc := &reconcileContext{
+				r:                 reconciler,
+				tg:                tg,
+				observedShards:    observed,
+				activeShardNames:  active,
+				appliedGeneration: appliedGen,
+				start:             time.Now(),
+				oldPhase:          tg.Status.Phase,
+			}
+			if _, err := stepComputeStatus(t.Context(), rc); err != nil {
+				t.Fatalf("stepComputeStatus returned error: %v", err)
+			}
+			res, err := stepPatchStatus(t.Context(), rc)
+			if err != nil {
+				t.Fatalf("stepPatchStatus returned error: %v", err)
+			}
+			// A successful status update never requeues on its own.
+			if res.result.RequeueAfter != 0 {
+				t.Errorf("expected no requeue, got %+v", res.result)
+			}
+
+			updated := &multigresv1alpha1.TableGroup{}
+			if err := c.Get(
+				t.Context(),
+				types.NamespacedName{Name: tgName, Namespace: namespace},
+				updated,
+			); err != nil {
+				t.Fatalf("failed to get tablegroup: %v", err)
+			}
+
+			if got := updated.Status.Phase; got != tc.wantPhase {
+				t.Errorf("Phase mismatch: got %q, want %q", got, tc.wantPhase)
+			}
+			if got := updated.Status.TotalShards; got != tc.wantTotal {
+				t.Errorf("TotalShards mismatch: got %d, want %d", got, tc.wantTotal)
+			}
+			if got := updated.Status.ReadyShards; got != tc.wantReady {
+				t.Errorf("ReadyShards mismatch: got %d, want %d", got, tc.wantReady)
+			}
+			if got := updated.Status.Message; got != tc.wantMessage {
+				t.Errorf("Message mismatch: got %q, want %q", got, tc.wantMessage)
+			}
+
+			cond := meta.FindStatusCondition(updated.Status.Conditions, "Available")
+			if cond == nil {
+				t.Fatal("expected an Available condition to be set")
+			}
+			if cond.Status != tc.wantAvailable {
+				t.Errorf(
+					"Available condition status mismatch: got %q, want %q",
+					cond.Status,
+					tc.wantAvailable,
+				)
+			}
+			if cond.Reason != tc.wantReason {
+				t.Errorf(
+					"Available condition reason mismatch: got %q, want %q",
+					cond.Reason,
+					tc.wantReason,
+				)
+			}
+			if cond.Message != tc.wantCondMsg {
+				t.Errorf(
+					"Available condition message mismatch: got %q, want %q",
+					cond.Message,
+					tc.wantCondMsg,
+				)
+			}
+			if cond.ObservedGeneration != tg.Generation {
+				t.Errorf(
+					"Available condition observedGeneration mismatch: got %d, want %d",
+					cond.ObservedGeneration,
+					tg.Generation,
+				)
+			}
+		})
+	}
+}
+
+// TestStepComputeStatus_IgnoresUndesiredOrphans verifies that pruned orphans do
+// not drive parent status, even if the observed snapshot still has stale child
+// status.
+func TestStepComputeStatus_IgnoresUndesiredOrphans(t *testing.T) {
+	t.Parallel()
+
+	tg := &multigresv1alpha1.TableGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "tg", Namespace: "default", Generation: 1},
+		Spec: multigresv1alpha1.TableGroupSpec{
+			Shards: make([]multigresv1alpha1.ShardResolvedSpec, 1),
+		},
+	}
+
+	observed := &multigresv1alpha1.ShardList{Items: []multigresv1alpha1.Shard{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "desired", Generation: 1},
+			Status: multigresv1alpha1.ShardStatus{
+				Phase:              multigresv1alpha1.PhaseHealthy,
+				ObservedGeneration: 1,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "orphan", Generation: 1},
+			Status: multigresv1alpha1.ShardStatus{
+				Phase:              multigresv1alpha1.PhaseDegraded,
+				ObservedGeneration: 1,
+			},
+		},
+	}}
+
+	rc := &reconcileContext{
+		tg:                tg,
+		observedShards:    observed,
+		activeShardNames:  map[string]bool{"desired": true},
+		appliedGeneration: map[string]int64{"desired": 1},
+	}
+
+	if _, err := stepComputeStatus(t.Context(), rc); err != nil {
+		t.Fatalf("stepComputeStatus returned error: %v", err)
+	}
+
+	if got := tg.Status.Phase; got != multigresv1alpha1.PhaseHealthy {
+		t.Errorf(
+			"Phase mismatch: got %q, want %q (orphan must not count)",
+			got,
+			multigresv1alpha1.PhaseHealthy,
+		)
+	}
+	if got := tg.Status.ReadyShards; got != 1 {
+		t.Errorf("ReadyShards mismatch: got %d, want 1", got)
+	}
+	if got := tg.Status.TotalShards; got != 1 {
+		t.Errorf("TotalShards mismatch: got %d, want 1", got)
+	}
+}
+
+// TestStepComputeStatus_PendingDeletionPreventsHealthy verifies that pending
+// cleanup keeps the parent Progressing even when all desired children are ready.
+func TestStepComputeStatus_PendingDeletionPreventsHealthy(t *testing.T) {
+	t.Parallel()
+
+	tg := &multigresv1alpha1.TableGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "tg", Namespace: "default", Generation: 2},
+		Spec: multigresv1alpha1.TableGroupSpec{
+			Shards: make([]multigresv1alpha1.ShardResolvedSpec, 1),
+		},
+	}
+
+	observed := &multigresv1alpha1.ShardList{Items: []multigresv1alpha1.Shard{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "desired", Generation: 1},
+			Status: multigresv1alpha1.ShardStatus{
+				Phase:              multigresv1alpha1.PhaseHealthy,
+				ObservedGeneration: 1,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "orphan", Generation: 1},
+			Status: multigresv1alpha1.ShardStatus{
+				Phase:              multigresv1alpha1.PhaseHealthy,
+				ObservedGeneration: 1,
+			},
+		},
+	}}
+
+	rc := &reconcileContext{
+		tg:                tg,
+		observedShards:    observed,
+		activeShardNames:  map[string]bool{"desired": true},
+		appliedGeneration: map[string]int64{"desired": 1},
+		pendingDeletion:   true,
+	}
+
+	if _, err := stepComputeStatus(t.Context(), rc); err != nil {
+		t.Fatalf("stepComputeStatus returned error: %v", err)
+	}
+
+	if got := tg.Status.Phase; got != multigresv1alpha1.PhaseProgressing {
+		t.Errorf("Phase mismatch: got %q, want %q", got, multigresv1alpha1.PhaseProgressing)
+	}
+	if got, want := tg.Status.Message, "Waiting for removed shards to drain"; got != want {
+		t.Errorf("Message mismatch: got %q, want %q", got, want)
+	}
+	if got := tg.Status.ReadyShards; got != 1 {
+		t.Errorf("ReadyShards mismatch: got %d, want 1", got)
+	}
+
+	cond := meta.FindStatusCondition(tg.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatal("expected an Available condition to be set")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Available status mismatch: got %q, want %q", cond.Status, metav1.ConditionFalse)
+	}
+	if cond.Reason != "CleanupPending" {
+		t.Errorf("Available reason mismatch: got %q, want CleanupPending", cond.Reason)
+	}
+	if cond.ObservedGeneration != tg.Generation {
+		t.Errorf(
+			"Available observedGeneration mismatch: got %d, want %d",
+			cond.ObservedGeneration,
+			tg.Generation,
+		)
+	}
+}
+
+// TestStepComputeStatus_IgnoresChildUntilSpecChangeObserved verifies that a
+// just-changed child is not ready until its observed generation catches up.
+func TestStepComputeStatus_IgnoresChildUntilSpecChangeObserved(t *testing.T) {
+	t.Parallel()
+
+	newTG := func() *multigresv1alpha1.TableGroup {
+		return &multigresv1alpha1.TableGroup{
+			ObjectMeta: metav1.ObjectMeta{Name: "tg", Namespace: "default", Generation: 1},
+			Spec: multigresv1alpha1.TableGroupSpec{
+				Shards: make([]multigresv1alpha1.ShardResolvedSpec, 1),
+			},
+		}
+	}
+	observed := func() *multigresv1alpha1.ShardList {
+		return &multigresv1alpha1.ShardList{Items: []multigresv1alpha1.Shard{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "desired", Generation: 1},
+				Status: multigresv1alpha1.ShardStatus{
+					Phase:              multigresv1alpha1.PhaseHealthy,
+					ObservedGeneration: 1,
+				},
+			},
+		}}
+	}
+
+	// This reconcile applied generation 2, so the child's observed generation 1
+	// is stale and it must not be counted as ready.
+	changed := &reconcileContext{
+		tg:                newTG(),
+		observedShards:    observed(),
+		activeShardNames:  map[string]bool{"desired": true},
+		appliedGeneration: map[string]int64{"desired": 2},
+	}
+	if _, err := stepComputeStatus(t.Context(), changed); err != nil {
+		t.Fatalf("stepComputeStatus returned error: %v", err)
+	}
+	if got := changed.tg.Status.Phase; got != multigresv1alpha1.PhaseProgressing {
+		t.Errorf(
+			"Phase mismatch after spec change: got %q, want %q",
+			got,
+			multigresv1alpha1.PhaseProgressing,
+		)
+	}
+	if got := changed.tg.Status.ReadyShards; got != 0 {
+		t.Errorf("ReadyShards mismatch after spec change: got %d, want 0", got)
+	}
+
+	// Once applied and observed generations match, the child counts as ready.
+	caughtUp := &reconcileContext{
+		tg:                newTG(),
+		observedShards:    observed(),
+		activeShardNames:  map[string]bool{"desired": true},
+		appliedGeneration: map[string]int64{"desired": 1},
+	}
+	if _, err := stepComputeStatus(t.Context(), caughtUp); err != nil {
+		t.Fatalf("stepComputeStatus returned error: %v", err)
+	}
+	if got := caughtUp.tg.Status.Phase; got != multigresv1alpha1.PhaseHealthy {
+		t.Errorf(
+			"Phase mismatch once observed: got %q, want %q",
+			got,
+			multigresv1alpha1.PhaseHealthy,
+		)
+	}
+	if got := caughtUp.tg.Status.ReadyShards; got != 1 {
+		t.Errorf("ReadyShards mismatch once observed: got %d, want 1", got)
+	}
+}

--- a/pkg/cluster-handler/controller/tablegroup/status_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/status_test.go
@@ -355,7 +355,7 @@ func TestStepComputeStatus_PendingDeletionPreventsHealthy(t *testing.T) {
 	if got := tg.Status.Phase; got != multigresv1alpha1.PhaseProgressing {
 		t.Errorf("Phase mismatch: got %q, want %q", got, multigresv1alpha1.PhaseProgressing)
 	}
-	if got, want := tg.Status.Message, "Waiting for removed shards to drain"; got != want {
+	if got, want := tg.Status.Message, "Waiting for shard cleanup to finish"; got != want {
 		t.Errorf("Message mismatch: got %q, want %q", got, want)
 	}
 	if got := tg.Status.ReadyShards; got != 1 {

--- a/pkg/cluster-handler/controller/tablegroup/steps.go
+++ b/pkg/cluster-handler/controller/tablegroup/steps.go
@@ -1,0 +1,124 @@
+package tablegroup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+// step models one named phase of the TableGroup reconcile loop. A step either
+// continues to the next phase or returns the reconcile result to use.
+type step func(context.Context, *reconcileContext) (stepResult, error)
+
+type stepResult struct {
+	done   bool
+	result ctrl.Result
+}
+
+type reconcileContext struct {
+	r *TableGroupReconciler
+
+	req   ctrl.Request
+	start time.Time
+
+	tg             *multigresv1alpha1.TableGroup
+	observedShards *multigresv1alpha1.ShardList
+	// activeShardNames holds the names of the desired child Shards applied this
+	// reconcile. Only these contribute to status; orphans being pruned do not.
+	activeShardNames map[string]bool
+	// appliedGeneration is the child generation produced by apply. Status counts
+	// a child only after the child has observed that generation.
+	appliedGeneration map[string]int64
+	oldPhase          multigresv1alpha1.Phase
+	pendingDeletion   bool
+}
+
+type stepError struct {
+	err       error
+	eventType string
+	reason    string
+	msg       string
+}
+
+func (e *stepError) Error() string {
+	return e.err.Error()
+}
+
+func (e *stepError) Unwrap() error {
+	return e.err
+}
+
+func newStepError(err error, eventType, reason, msg string) *stepError {
+	return &stepError{
+		err:       err,
+		eventType: eventType,
+		reason:    reason,
+		msg:       msg,
+	}
+}
+
+func continueStep() stepResult {
+	return stepResult{}
+}
+
+func doneStep(result ctrl.Result) stepResult {
+	return stepResult{
+		done:   true,
+		result: result,
+	}
+}
+
+func (r *TableGroupReconciler) runSteps(
+	ctx context.Context,
+	rc *reconcileContext,
+	steps []step,
+) (ctrl.Result, error) {
+	for _, s := range steps {
+		res, err := s(ctx, rc)
+		if err != nil {
+			return res.result, err
+		}
+		if res.done {
+			return res.result, nil
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func stepFetchTableGroup(ctx context.Context, rc *reconcileContext) (stepResult, error) {
+	tg := &multigresv1alpha1.TableGroup{}
+	if err := rc.r.Get(ctx, rc.req.NamespacedName, tg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return doneStep(ctrl.Result{}), nil
+		}
+		return stepResult{}, fmt.Errorf("failed to get TableGroup: %w", err)
+	}
+
+	rc.tg = tg
+	rc.oldPhase = tg.Status.Phase
+	return continueStep(), nil
+}
+
+func stepHandlePendingDeletion(ctx context.Context, rc *reconcileContext) (stepResult, error) {
+	if rc.tg.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
+		return continueStep(), nil
+	}
+
+	result, err := rc.r.handlePendingDeletion(ctx, rc.tg)
+	if err != nil {
+		return stepResult{}, err
+	}
+	return doneStep(result), nil
+}
+
+func stepShortCircuitDeletion(_ context.Context, rc *reconcileContext) (stepResult, error) {
+	if rc.tg.GetDeletionTimestamp() != nil {
+		return doneStep(ctrl.Result{}), nil
+	}
+	return continueStep(), nil
+}

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -2,10 +2,10 @@ package tablegroup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,287 +54,62 @@ func (r *TableGroupReconciler) Reconcile(
 	l := log.FromContext(ctx)
 	l.V(1).Info("reconcile started")
 
-	tg := &multigresv1alpha1.TableGroup{}
-	err := r.Get(ctx, req.NamespacedName, tg)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		monitoring.RecordSpanError(span, err)
-		return ctrl.Result{}, fmt.Errorf("failed to get TableGroup: %w", err)
+	rc := &reconcileContext{
+		r:     r,
+		req:   req,
+		start: start,
 	}
 
-	// If this TableGroup is pending deletion (from MultigresCluster pruning),
-	// propagate PendingDeletion to all child Shards and wait.
-	if tg.Annotations[multigresv1alpha1.AnnotationPendingDeletion] != "" {
-		return r.handlePendingDeletion(ctx, tg)
+	// The order preserves the controller lifecycle: fetch the parent, handle
+	// parent deletion before normal work, read the child snapshot once, apply the
+	// desired children, retire orphans through their drain handshake, then publish
+	// parent status from the observed child state.
+	rawSteps := []step{
+		stepFetchTableGroup,
+		stepHandlePendingDeletion,
+		stepShortCircuitDeletion,
+		stepListChildShards,
+		stepApplyDesiredShards,
+		stepReconcileUndesired,
+		stepComputeStatus,
+		stepPatchStatus,
+		stepRequeueIfPending,
 	}
 
-	// Reconcile Loop: Create/Update/Prune Shards
-	// If being deleted, let Kubernetes GC handle cleanup
-	if !tg.DeletionTimestamp.IsZero() {
-		return ctrl.Result{}, nil
+	recordSpanErr := func(err error) { monitoring.RecordSpanError(span, err) }
+	steps := make([]step, len(rawSteps))
+	for i, s := range rawSteps {
+		steps[i] = withStepErrorHandling(recordSpanErr, s)
 	}
 
-	oldPhase := tg.Status.Phase
-
-	activeShardNames := make(map[string]bool, len(tg.Spec.Shards))
-
-	for _, shardSpec := range tg.Spec.Shards {
-		desired, err := BuildShard(tg, &shardSpec, r.Scheme)
-		if err != nil {
-			l.Error(err, "Failed to build shard", "shard", shardSpec.Name)
-			r.Recorder.Eventf(
-				tg,
-				"Warning",
-				"FailedApply",
-				"Failed to build shard %s: %v",
-				shardSpec.Name,
-				err,
-			)
-			return ctrl.Result{}, fmt.Errorf("failed to build shard: %w", err)
-		}
-
-		// Use the ACTUAL name that BuildShard creates, not a manually computed one
-		activeShardNames[desired.Name] = true
-
-		// Use Server-Side Apply
-		desired.SetGroupVersionKind(multigresv1alpha1.GroupVersion.WithKind("Shard"))
-		if err := r.Patch(
-			ctx,
-			desired,
-			client.Apply,
-			client.ForceOwnership,
-			client.FieldOwner("multigres-operator"),
-		); err != nil {
-			l.Error(err, "Failed to apply shard", "shard", desired.Name)
-			r.Recorder.Eventf(
-				tg,
-				"Warning",
-				"FailedApply",
-				"Failed to apply shard %s: %v",
-				desired.Name,
-				err,
-			)
-			return ctrl.Result{}, fmt.Errorf("failed to apply shard: %w", err)
-		}
-
-		r.Recorder.Eventf(tg, "Normal", "Applied", "Applied Shard %s", desired.Name)
-	}
-
-	// Prune orphan Shards using PendingDeletion flow:
-	// 1. Set PendingDeletion annotation → shard controller drains pods
-	// 2. Wait for ReadyForDeletion condition
-	// 3. Delete the Shard CR
-	existingShards := &multigresv1alpha1.ShardList{}
-	if err := r.List(ctx, existingShards, client.InNamespace(tg.Namespace), client.MatchingLabels{
-		"multigres.com/cluster":    tg.Labels["multigres.com/cluster"],
-		"multigres.com/database":   string(tg.Spec.DatabaseName),
-		"multigres.com/tablegroup": string(tg.Spec.TableGroupName),
-	}); err != nil {
-		l.Error(err, "Failed to list shards for pruning")
-		r.Recorder.Eventf(
-			tg,
-			"Warning",
-			"CleanUpError",
-			"Failed to list shards for pruning: %v",
-			err,
-		)
-		return ctrl.Result{}, fmt.Errorf("failed to list shards for pruning: %w", err)
-	}
-
-	var pendingDeletion bool
-
-	for i := range existingShards.Items {
-		s := &existingShards.Items[i]
-		if activeShardNames[s.Name] {
-			continue
-		}
-
-		// Step 1: Set PendingDeletion annotation if not already set.
-		if s.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
-			patch := client.MergeFrom(s.DeepCopy())
-			if s.Annotations == nil {
-				s.Annotations = make(map[string]string)
-			}
-			s.Annotations[multigresv1alpha1.AnnotationPendingDeletion] = metav1.Now().
-				UTC().
-				Format(time.RFC3339)
-			if err := r.Patch(ctx, s, patch); err != nil {
-				l.Error(err, "Failed to set PendingDeletion annotation", "shard", s.Name)
-				r.Recorder.Eventf(
-					tg,
-					"Warning",
-					"CleanUpError",
-					"Failed to set PendingDeletion on shard %s: %v",
-					s.Name,
-					err,
-				)
-				return ctrl.Result{}, fmt.Errorf(
-					"failed to set PendingDeletion on shard '%s': %w",
-					s.Name,
-					err,
-				)
-			}
-			r.Recorder.Eventf(tg, "Normal", "PendingDeletion",
-				"Marked Shard %s for graceful deletion", s.Name)
-			pendingDeletion = true
-			continue
-		}
-
-		// Step 2: Wait for ReadyForDeletion condition.
-		if !meta.IsStatusConditionTrue(
-			s.Status.Conditions,
-			multigresv1alpha1.ConditionReadyForDeletion,
-		) {
-			l.V(1).Info("Shard pending deletion, waiting for drain", "shard", s.Name)
-			pendingDeletion = true
-			continue
-		}
-
-		// Step 3: Drain complete — safe to delete.
-		if err := r.Delete(ctx, s); err != nil && !errors.IsNotFound(err) {
-			l.Error(err, "Failed to delete orphan shard", "shard", s.Name)
-			r.Recorder.Eventf(
-				tg,
-				"Warning",
-				"CleanUpError",
-				"Failed to delete orphan shard %s: %v",
-				s.Name,
-				err,
-			)
-			return ctrl.Result{}, fmt.Errorf(
-				"failed to delete orphan shard '%s': %w",
-				s.Name,
-				err,
-			)
-		} else if err == nil {
-			r.Recorder.Eventf(tg, "Normal", "Deleted", "Deleted orphaned Shard %s", s.Name)
-		}
-	}
-
-	if pendingDeletion {
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
-	// Update Status
-	total := int32(len(tg.Spec.Shards)) //nolint:gosec // bounded by K8s object size limits
-	ready := int32(0)
-
-	// Re-list to check status
-	if err := r.List(ctx, existingShards, client.InNamespace(tg.Namespace), client.MatchingLabels{
-		"multigres.com/cluster":    tg.Labels["multigres.com/cluster"],
-		"multigres.com/database":   string(tg.Spec.DatabaseName),
-		"multigres.com/tablegroup": string(tg.Spec.TableGroupName),
-	}); err != nil {
-		l.Error(err, "Failed to list shards for status")
-		r.Recorder.Eventf(
-			tg,
-			"Warning",
-			"StatusError",
-			"Failed to list shards for status: %v",
-			err,
-		)
-		return ctrl.Result{}, fmt.Errorf("failed to list shards for status: %w", err)
-	}
-
-	var anyDegraded bool
-
-	for _, s := range existingShards.Items {
-		switch {
-		case s.Status.ObservedGeneration != s.Generation:
-			// Shard is stale/progressing, not ready
-		case s.Status.Phase == multigresv1alpha1.PhaseHealthy:
-			ready++
-		case s.Status.Phase == multigresv1alpha1.PhaseDegraded:
-			anyDegraded = true
-		default: // Initializing, Progressing, Unknown
-			// consider progressing
-		}
-	}
-
-	tg.Status.TotalShards = total
-	tg.Status.ReadyShards = ready
-
-	switch {
-	case total == 0:
-		tg.Status.Phase = multigresv1alpha1.PhaseInitializing
-		tg.Status.Message = "No Shards"
-	case anyDegraded:
-		tg.Status.Phase = multigresv1alpha1.PhaseDegraded
-		tg.Status.Message = "At least one shard is degraded"
-	case ready == total:
-		tg.Status.Phase = multigresv1alpha1.PhaseHealthy
-		tg.Status.Message = "Ready"
-	default:
-		tg.Status.Phase = multigresv1alpha1.PhaseProgressing
-		tg.Status.Message = fmt.Sprintf("%d/%d shards ready", ready, total)
-	}
-
-	condStatus := metav1.ConditionFalse
-	if tg.Status.Phase == multigresv1alpha1.PhaseHealthy {
-		condStatus = metav1.ConditionTrue
-	} else if total == 0 {
-		condStatus = metav1.ConditionTrue
-	}
-
-	meta.SetStatusCondition(&tg.Status.Conditions, metav1.Condition{
-		Type:               "Available",
-		Status:             condStatus,
-		Reason:             "ShardsReady",
-		Message:            fmt.Sprintf("%d/%d shards ready", ready, total),
-		LastTransitionTime: metav1.Now(),
-	})
-
-	tg.Status.ObservedGeneration = tg.Generation
-
-	// 1. Construct the Patch Object
-	patchObj := &multigresv1alpha1.TableGroup{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: multigresv1alpha1.GroupVersion.String(),
-			Kind:       "TableGroup",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      tg.Name,
-			Namespace: tg.Namespace,
-		},
-		Status: tg.Status,
-	}
-
-	// 2. Apply the Patch
-	if oldPhase != tg.Status.Phase {
-		r.Recorder.Eventf(
-			tg,
-			"Normal",
-			"PhaseChange",
-			"Transitioned from '%s' to '%s'",
-			oldPhase,
-			tg.Status.Phase,
-		)
-	}
-
-	// Note: We rely on Server-Side Apply (SSA) to handle idempotency.
-	// If the status hasn't changed, the API server will treat this Patch as a no-op,
-	// so we don't need a manual DeepEqual check here.
-	if err := r.Status().Patch(
-		ctx,
-		patchObj,
-		client.Apply,
-		client.FieldOwner("multigres-operator"),
-		client.ForceOwnership,
-	); err != nil {
-		l.Error(err, "Failed to patch status")
-		r.Recorder.Eventf(tg, "Warning", "StatusError", "Failed to patch status: %v", err)
-		return ctrl.Result{}, fmt.Errorf("failed to patch status: %w", err)
-	}
-
-	l.V(1).Info("reconcile complete", "duration", time.Since(start).String())
-	r.Recorder.Event(tg, "Normal", "Synced", "Successfully reconciled TableGroup")
-	return ctrl.Result{}, nil
+	return r.runSteps(ctx, rc, steps)
 }
 
-// handlePendingDeletion propagates PendingDeletion to all child Shards
-// and sets ReadyForDeletion on this TableGroup when all children are ready.
+// withStepErrorHandling records a failing step's error on the span and, for a
+// stepError with a non-empty reason, logs it and emits the event once the parent
+// object has been fetched. Normal events are emitted inline by the steps.
+func withStepErrorHandling(recordSpanErr func(error), s step) step {
+	return func(ctx context.Context, rc *reconcileContext) (stepResult, error) {
+		res, err := s(ctx, rc)
+		if err != nil {
+			recordSpanErr(err)
+
+			var se *stepError
+			if errors.As(err, &se) && se.reason != "" {
+				log.FromContext(ctx).Error(se.err, se.msg)
+				if rc.tg != nil {
+					rc.r.Recorder.Eventf(rc.tg, se.eventType, se.reason, "%s", se.msg)
+				}
+			}
+		}
+		return res, err
+	}
+}
+
+// handlePendingDeletion propagates PendingDeletion to all child Shards and sets
+// ReadyForDeletion on this TableGroup once every child reports ready. This
+// early-return path lists children itself because the normal child snapshot has
+// not been read yet.
 func (r *TableGroupReconciler) handlePendingDeletion(
 	ctx context.Context,
 	tg *multigresv1alpha1.TableGroup,
@@ -342,11 +117,7 @@ func (r *TableGroupReconciler) handlePendingDeletion(
 	l := log.FromContext(ctx)
 
 	shards := &multigresv1alpha1.ShardList{}
-	if err := r.List(ctx, shards, client.InNamespace(tg.Namespace), client.MatchingLabels{
-		"multigres.com/cluster":    tg.Labels["multigres.com/cluster"],
-		"multigres.com/database":   string(tg.Spec.DatabaseName),
-		"multigres.com/tablegroup": string(tg.Spec.TableGroupName),
-	}); err != nil {
+	if err := r.List(ctx, shards, childShardSelector(tg)...); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list shards for pending deletion: %w", err)
 	}
 
@@ -355,13 +126,7 @@ func (r *TableGroupReconciler) handlePendingDeletion(
 		s := &shards.Items[i]
 
 		if s.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
-			patch := client.MergeFrom(s.DeepCopy())
-			if s.Annotations == nil {
-				s.Annotations = make(map[string]string)
-			}
-			s.Annotations[multigresv1alpha1.AnnotationPendingDeletion] = metav1.Now().
-				UTC().Format(time.RFC3339)
-			if err := r.Patch(ctx, s, patch); err != nil {
+			if err := r.setShardPendingDeletion(ctx, s); err != nil {
 				return ctrl.Result{}, fmt.Errorf(
 					"failed to set PendingDeletion on shard '%s': %w", s.Name, err)
 			}
@@ -411,6 +176,34 @@ func (r *TableGroupReconciler) handlePendingDeletion(
 	r.Recorder.Eventf(tg, "Normal", "ReadyForDeletion",
 		"TableGroup %s marked ready for deletion", tg.Name)
 	return ctrl.Result{}, nil
+}
+
+// setShardPendingDeletion stamps the PendingDeletion annotation with an RFC3339
+// UTC timestamp. Callers decide when to emit events.
+func (r *TableGroupReconciler) setShardPendingDeletion(
+	ctx context.Context,
+	s *multigresv1alpha1.Shard,
+) error {
+	patch := client.MergeFrom(s.DeepCopy())
+	if s.Annotations == nil {
+		s.Annotations = make(map[string]string)
+	}
+	s.Annotations[multigresv1alpha1.AnnotationPendingDeletion] = metav1.Now().
+		UTC().Format(time.RFC3339)
+	return r.Patch(ctx, s, patch)
+}
+
+// childShardSelector returns the List options for child Shards belonging to the
+// given TableGroup.
+func childShardSelector(tg *multigresv1alpha1.TableGroup) []client.ListOption {
+	return []client.ListOption{
+		client.InNamespace(tg.Namespace),
+		client.MatchingLabels{
+			"multigres.com/cluster":    tg.Labels["multigres.com/cluster"],
+			"multigres.com/database":   string(tg.Spec.DatabaseName),
+			"multigres.com/tablegroup": string(tg.Spec.TableGroupName),
+		},
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -125,6 +125,11 @@ func (r *TableGroupReconciler) handlePendingDeletion(
 	for i := range shards.Items {
 		s := &shards.Items[i]
 
+		if s.DeletionTimestamp != nil {
+			allReady = false
+			continue
+		}
+
 		if s.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
 			if err := r.setShardPendingDeletion(ctx, s); err != nil {
 				return ctrl.Result{}, fmt.Errorf(

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
@@ -1,10 +1,13 @@
 package tablegroup
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -16,6 +19,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
@@ -43,7 +47,6 @@ func setupFixtures(
 				"multigres.com/database":   dbName,
 				"multigres.com/tablegroup": tgLabelName,
 			},
-			// Finalizers removed
 		},
 		Spec: multigresv1alpha1.TableGroupSpec{
 			DatabaseName:   multigresv1alpha1.DatabaseName(dbName),
@@ -100,7 +103,7 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 			},
 			validate: func(t testing.TB, c client.Client) {
 				ctx := t.Context()
-				// Expect hashed name: md5("test-cluster", "db1", "tg1", "shard-0") -> "0a..."
+				// The name is the md5 hash of test-cluster, db1, tg1, shard-0.
 				shardNameFull := name.JoinWithConstraints(
 					name.DefaultConstraints,
 					clusterName,
@@ -318,7 +321,6 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 		"Update: Shard Update Success": {
 			tableGroup: baseTG.DeepCopy(),
 			preReconcileUpdate: func(t testing.TB, tg *multigresv1alpha1.TableGroup) {
-				// Change spec to force update
 				tg.Spec.Shards[0].MultiOrch.Replicas = ptr.To(int32(5))
 			},
 			existingObjects: []client.Object{
@@ -370,10 +372,9 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 				tg.DeletionTimestamp = &now
 				tg.Finalizers = []string{
 					"test.finalizer",
-				} // Prevent immediate deletion/GC simulation issues
+				}
 			},
 			validate: func(t testing.TB, c client.Client) {
-				// Verify Shard is NOT created because checks are skipped
 				shardNameFull := fmt.Sprintf("%s-%s", tgName, "shard-0")
 				shard := &multigresv1alpha1.Shard{}
 				if err := c.Get(
@@ -552,7 +553,6 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 				tg.Spec.Shards[0].Name = "a" + string(make([]byte, 64)) // > 63 chars
 			},
 			existingObjects: []client.Object{},
-			// No validation needed if we just want to ensure it succeeds without error
 		},
 		"Success: Handle Pending Deletion (Propagate to Shards)": {
 			tableGroup: baseTG.DeepCopy(),
@@ -673,13 +673,11 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Apply pre-reconcile updates if defined
 			if tc.preReconcileUpdate != nil {
 				tc.preReconcileUpdate(t, tc.tableGroup)
 			}
 
 			objects := tc.existingObjects
-			// Inject TableGroup if creation is not skipped
 			if !tc.skipCreate {
 				objects = append(objects, tc.tableGroup)
 			}
@@ -714,7 +712,6 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 				t.Errorf("Unexpected error from Reconcile: %v", err)
 			}
 
-			// Verify Events
 			if len(tc.expectedEvents) > 0 {
 				close(recorder.Events)
 				var gotEvents []string
@@ -744,6 +741,162 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 				tc.validate(t, baseClient)
 			}
 		})
+	}
+}
+
+func TestTableGroupReconciler_DefaultMVPShape(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	const (
+		tgName      = "default-tablegroup"
+		namespace   = "default"
+		clusterName = "test-cluster"
+		dbName      = "postgres"
+		tgLabelName = "default"
+		shardName   = "0-inf"
+	)
+
+	tg := &multigresv1alpha1.TableGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tgName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"multigres.com/cluster":    clusterName,
+				"multigres.com/database":   dbName,
+				"multigres.com/tablegroup": tgLabelName,
+			},
+		},
+		Spec: multigresv1alpha1.TableGroupSpec{
+			DatabaseName:   multigresv1alpha1.DatabaseName(dbName),
+			TableGroupName: multigresv1alpha1.TableGroupName(tgLabelName),
+			IsDefault:      true,
+			Images: multigresv1alpha1.ShardImages{
+				MultiOrch:   "orch:v1",
+				MultiPooler: "pooler:v1",
+				Postgres:    "pg:15",
+			},
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+				Address: "http://etcd:2379",
+			},
+			Shards: []multigresv1alpha1.ShardResolvedSpec{
+				{
+					Name: shardName,
+					MultiOrch: multigresv1alpha1.MultiOrchSpec{
+						StatelessSpec: multigresv1alpha1.StatelessSpec{
+							Replicas: ptr.To(int32(1)),
+						},
+						Cells: []multigresv1alpha1.CellName{"zone-a"},
+					},
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"default": {
+							Type:            "readWrite",
+							ReplicasPerCell: ptr.To(int32(1)),
+							Cells:           []multigresv1alpha1.CellName{"zone-a"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tg).
+		WithStatusSubresource(
+			&multigresv1alpha1.TableGroup{},
+			&multigresv1alpha1.Shard{},
+		).
+		Build()
+
+	reconciler := &TableGroupReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(100),
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: tgName, Namespace: namespace},
+	}
+
+	if got, err := reconciler.Reconcile(t.Context(), req); err != nil {
+		t.Fatalf("unexpected error creating default shard: %v", err)
+	} else if got != (ctrl.Result{}) {
+		t.Fatalf("unexpected reconcile result creating default shard: got %+v", got)
+	}
+
+	fullShardName := name.JoinWithConstraints(
+		name.DefaultConstraints,
+		clusterName,
+		dbName,
+		tgLabelName,
+		shardName,
+	)
+	shard := &multigresv1alpha1.Shard{}
+	if err := c.Get(
+		t.Context(),
+		types.NamespacedName{Name: fullShardName, Namespace: namespace},
+		shard,
+	); err != nil {
+		t.Fatalf("default 0-inf Shard was not created: %v", err)
+	}
+
+	if got, want := shard.Spec.DatabaseName, multigresv1alpha1.DatabaseName(dbName); got != want {
+		t.Errorf("Shard DatabaseName mismatch: got %q, want %q", got, want)
+	}
+	if got, want := shard.Spec.TableGroupName, multigresv1alpha1.TableGroupName(tgLabelName); got != want {
+		t.Errorf("Shard TableGroupName mismatch: got %q, want %q", got, want)
+	}
+	if got, want := shard.Spec.ShardName, multigresv1alpha1.ShardName(shardName); got != want {
+		t.Errorf("ShardName mismatch: got %q, want %q", got, want)
+	}
+	if got, want := shard.Labels["multigres.com/tablegroup"], tgLabelName; got != want {
+		t.Errorf("tablegroup label mismatch: got %q, want %q", got, want)
+	}
+
+	healthyTG := tg.DeepCopy()
+	healthyShard := shard.DeepCopy()
+	healthyShard.Status.Phase = multigresv1alpha1.PhaseHealthy
+	healthyShard.Status.ObservedGeneration = healthyShard.Generation
+
+	c = fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(healthyShard, healthyTG).
+		WithStatusSubresource(
+			&multigresv1alpha1.TableGroup{},
+			&multigresv1alpha1.Shard{},
+		).
+		Build()
+
+	reconciler.Client = c
+	if got, err := reconciler.Reconcile(t.Context(), req); err != nil {
+		t.Fatalf("unexpected error reconciling healthy default shard: %v", err)
+	} else if got != (ctrl.Result{}) {
+		t.Fatalf("unexpected reconcile result for healthy default shard: got %+v", got)
+	}
+
+	updatedTG := &multigresv1alpha1.TableGroup{}
+	if err := c.Get(
+		t.Context(),
+		types.NamespacedName{Name: tgName, Namespace: namespace},
+		updatedTG,
+	); err != nil {
+		t.Fatalf("failed to get TableGroup: %v", err)
+	}
+
+	if got, want := updatedTG.Status.Phase, multigresv1alpha1.PhaseHealthy; got != want {
+		t.Errorf("TableGroup phase mismatch: got %q, want %q", got, want)
+	}
+	if got, want := updatedTG.Status.ReadyShards, int32(1); got != want {
+		t.Errorf("ReadyShards mismatch: got %d, want %d", got, want)
+	}
+	if got, want := updatedTG.Status.TotalShards, int32(1); got != want {
+		t.Errorf("TotalShards mismatch: got %d, want %d", got, want)
+	}
+	if !meta.IsStatusConditionTrue(updatedTG.Status.Conditions, "Available") {
+		t.Error("default 0-inf TableGroup should be Available after its shard is healthy")
 	}
 }
 
@@ -802,24 +955,20 @@ func TestTableGroupReconciler_Reconcile_Failure(t *testing.T) {
 			},
 			expectedEvents: []string{"Warning CleanUpError Failed to list shards for pruning"},
 		},
-		"Error: Status List Failed (Second List Call)": {
+		"Error: Status List Failed (single child read)": {
 			tableGroup:      baseTG.DeepCopy(),
 			existingObjects: []client.Object{},
 			failureConfig: &testutil.FailureConfig{
-				OnList: func() func(list client.ObjectList) error {
-					count := 0
-					return func(list client.ObjectList) error {
-						if _, ok := list.(*multigresv1alpha1.ShardList); ok {
-							count++
-							if count == 2 {
-								return errSimulated
-							}
-						}
-						return nil
+				OnList: func(list client.ObjectList) error {
+					if _, ok := list.(*multigresv1alpha1.ShardList); ok {
+						return errSimulated
 					}
-				}(),
+					return nil
+				},
 			},
-			expectedEvents: []string{"Warning StatusError Failed to list shards for status"},
+			// Child Shards are read exactly once, so a List failure
+			// surfaces as the pruning read error.
+			expectedEvents: []string{"Warning CleanUpError Failed to list shards for pruning"},
 		},
 		"Error: Set PendingDeletion Failed": {
 			tableGroup: baseTG.DeepCopy(),
@@ -1030,14 +1179,12 @@ func TestTableGroupReconciler_Reconcile_Failure(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			// Apply pre-reconcile updates
 			if tc.preReconcileUpdate != nil {
 				tc.preReconcileUpdate(t, tc.tableGroup)
 			}
 
 			objects := tc.existingObjects
-			// Default behavior: create the TableGroup unless getting it handling failure
-			// For failure tests, usually the object exists so the code can proceed to the failing step.
+			// Create the TableGroup so reconcile reaches the failing step.
 			objects = append(objects, tc.tableGroup)
 
 			clientBuilder := fake.NewClientBuilder().
@@ -1046,18 +1193,10 @@ func TestTableGroupReconciler_Reconcile_Failure(t *testing.T) {
 				WithStatusSubresource(&multigresv1alpha1.TableGroup{}, &multigresv1alpha1.Shard{})
 			baseClient := clientBuilder.Build()
 
-			// For OnStatusPatch failures, we need to make sure the object exists
-			// and that we are targeting the right call. The fake client intercepts calls.
 			finalClient := client.Client(baseClient)
 			if tc.failureConfig != nil {
 				finalClient = testutil.NewFakeClientWithFailures(baseClient, tc.failureConfig)
 			}
-
-			// Use explicit scheme for Reconciler.
-			// If we want to simulate Build failure, we might need to inject a broken scheme here?
-			// But the test structure iterates cases.
-			// Ideally we catch "Build Failed" in a separate manual test if it requires structural changes (like Reconciler.Scheme change).
-			// But let's try to add it here as a special case? No, the loop uses 'scheme'.
 
 			fakeRecorder := record.NewFakeRecorder(100)
 			reconciler := &TableGroupReconciler{
@@ -1078,7 +1217,6 @@ func TestTableGroupReconciler_Reconcile_Failure(t *testing.T) {
 				t.Error("Expected error from Reconcile, got nil")
 			}
 
-			// Verify Events
 			if len(tc.expectedEvents) > 0 {
 				close(fakeRecorder.Events)
 				var gotEvents []string
@@ -1113,13 +1251,12 @@ func TestTableGroupReconciler_Reconcile_BuildFailure(t *testing.T) {
 	_ = multigresv1alpha1.AddToScheme(scheme)
 	baseTG, _, _, _, _, _ := setupFixtures(t)
 
-	// Create client with VALID scheme
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(baseTG).Build()
 
-	// Create Reconciler with EMPTY scheme (causes BuildShard -> SetControllerReference to fail)
+	// The empty scheme makes BuildShard fail when it sets the owner reference.
 	r := &TableGroupReconciler{
 		Client:   c,
-		Scheme:   runtime.NewScheme(), // Empty!
+		Scheme:   runtime.NewScheme(),
 		Recorder: record.NewFakeRecorder(100),
 	}
 
@@ -1131,14 +1268,13 @@ func TestTableGroupReconciler_Reconcile_BuildFailure(t *testing.T) {
 		t.Fatal("Expected Reconcile to fail due to Build error")
 	}
 	if err.Error() != "failed to build shard: no kind is registered for the type v1alpha1.TableGroup" {
-		t.Logf("Got error: %v", err) // verify it's the right error
+		t.Logf("Got error: %v", err)
 	}
 }
 
 func TestSetupWithManager_Coverage(t *testing.T) {
 	t.Parallel()
 
-	// Test the default path (no options)
 	t.Run("No Options", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -1149,7 +1285,6 @@ func TestSetupWithManager_Coverage(t *testing.T) {
 		_ = reconciler.SetupWithManager(nil)
 	})
 
-	// Test the path with options to ensure coverage of the 'if len(opts) > 0' block
 	t.Run("With Options", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -1159,4 +1294,591 @@ func TestSetupWithManager_Coverage(t *testing.T) {
 		reconciler := &TableGroupReconciler{}
 		_ = reconciler.SetupWithManager(nil, controller.Options{MaxConcurrentReconciles: 1})
 	})
+}
+
+// TestTableGroupReconciler_ReadsChildShardsOnce asserts the reconcile lists
+// child Shards exactly once. Listing them twice in a single pass (a List, then a
+// re-List after writes) risks acting on a stale view, so an interceptor counts
+// the *ShardList Lists and the test fails if there is more than one.
+func TestTableGroupReconciler_ReadsChildShardsOnce(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	baseTG, tgName, namespace, clusterName, dbName, tgLabelName := setupFixtures(t)
+
+	shardName := name.JoinWithConstraints(
+		name.DefaultConstraints,
+		clusterName,
+		dbName,
+		tgLabelName,
+		"shard-0",
+	)
+
+	childShardLabels := map[string]string{
+		"multigres.com/cluster":    clusterName,
+		"multigres.com/database":   dbName,
+		"multigres.com/tablegroup": tgLabelName,
+	}
+
+	tests := map[string]struct {
+		tableGroup         *multigresv1alpha1.TableGroup
+		preReconcileUpdate func(testing.TB, *multigresv1alpha1.TableGroup)
+		existingObjects    []client.Object
+	}{
+		// Desired child already exists and is healthy.
+		"steady state with healthy child shard": {
+			tableGroup: baseTG.DeepCopy(),
+			existingObjects: []client.Object{
+				&multigresv1alpha1.Shard{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      shardName,
+						Namespace: namespace,
+						Labels:    childShardLabels,
+					},
+					Spec: multigresv1alpha1.ShardSpec{ShardName: "shard-0"},
+					Status: multigresv1alpha1.ShardStatus{
+						Phase: multigresv1alpha1.PhaseHealthy,
+					},
+				},
+			},
+		},
+		// Spec wants no Shards, but an orphan child still exists to prune.
+		"pending orphan child shard": {
+			tableGroup: baseTG.DeepCopy(),
+			preReconcileUpdate: func(_ testing.TB, tg *multigresv1alpha1.TableGroup) {
+				tg.Spec.Shards = []multigresv1alpha1.ShardResolvedSpec{}
+			},
+			existingObjects: []client.Object{
+				&multigresv1alpha1.Shard{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      shardName,
+						Namespace: namespace,
+						Labels:    childShardLabels,
+					},
+					Spec: multigresv1alpha1.ShardSpec{ShardName: "shard-0"},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.preReconcileUpdate != nil {
+				tc.preReconcileUpdate(t, tc.tableGroup)
+			}
+
+			objects := append([]client.Object{}, tc.existingObjects...)
+			objects = append(objects, tc.tableGroup)
+
+			// Count Lists of child Shards during one Reconcile.
+			var shardListCount atomic.Int64
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				WithStatusSubresource(
+					&multigresv1alpha1.TableGroup{},
+					&multigresv1alpha1.Shard{},
+				).
+				WithInterceptorFuncs(interceptor.Funcs{
+					List: func(
+						ctx context.Context,
+						cli client.WithWatch,
+						list client.ObjectList,
+						opts ...client.ListOption,
+					) error {
+						if _, ok := list.(*multigresv1alpha1.ShardList); ok {
+							shardListCount.Add(1)
+						}
+						return cli.List(ctx, list, opts...)
+					},
+				}).
+				Build()
+
+			reconciler := &TableGroupReconciler{
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(100),
+			}
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      tgName,
+					Namespace: namespace,
+				},
+			}
+
+			if _, err := reconciler.Reconcile(t.Context(), req); err != nil {
+				t.Fatalf("unexpected error from Reconcile: %v", err)
+			}
+
+			if got := shardListCount.Load(); got != 1 {
+				t.Errorf(
+					"expected exactly one List of child Shards per reconcile, got %d",
+					got,
+				)
+			}
+		})
+	}
+}
+
+// TestTableGroupReconciler_PendingDeletionUpgradeCompatibility verifies that a
+// child carrying a PendingDeletion annotation from an earlier operator version
+// is handled correctly across an upgrade. The controller requeues until the
+// child is ReadyForDeletion and then deletes it, without re-stamping the
+// annotation or deleting before the child is ready.
+func TestTableGroupReconciler_PendingDeletionUpgradeCompatibility(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	baseTG, tgName, namespace, clusterName, dbName, tgLabelName := setupFixtures(t)
+
+	shardName := name.JoinWithConstraints(
+		name.DefaultConstraints,
+		clusterName,
+		dbName,
+		tgLabelName,
+		"shard-0",
+	)
+
+	childShardLabels := map[string]string{
+		"multigres.com/cluster":    clusterName,
+		"multigres.com/database":   dbName,
+		"multigres.com/tablegroup": tgLabelName,
+	}
+
+	// PendingDeletion value as if written by an earlier operator version; the
+	// controller must keep it as-is.
+	const priorVersionTimestamp = "2026-01-01T00:00:00Z"
+
+	// orphanShard builds a no-longer-desired child already carrying the
+	// PendingDeletion annotation. ready toggles the ReadyForDeletion condition.
+	orphanShard := func(readyForDeletion bool) *multigresv1alpha1.Shard {
+		s := &multigresv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shardName,
+				Namespace: namespace,
+				Labels:    childShardLabels,
+				Annotations: map[string]string{
+					multigresv1alpha1.AnnotationPendingDeletion: priorVersionTimestamp,
+				},
+			},
+			Spec: multigresv1alpha1.ShardSpec{ShardName: "shard-0"},
+		}
+		if readyForDeletion {
+			meta.SetStatusCondition(&s.Status.Conditions, metav1.Condition{
+				Type:    multigresv1alpha1.ConditionReadyForDeletion,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Drained",
+				Message: "All pods drained",
+			})
+		}
+		return s
+	}
+
+	tests := map[string]struct {
+		readyForDeletion bool
+		wantResult       ctrl.Result
+		wantDeleted      bool
+	}{
+		// It hasn't drained yet, so the controller should requeue and leave it alone.
+		"annotation present but not ReadyForDeletion stays pending": {
+			readyForDeletion: false,
+			wantResult:       ctrl.Result{RequeueAfter: 5 * time.Second},
+			wantDeleted:      false,
+		},
+		// Now that it's drained, the controller should delete it.
+		"annotation present and ReadyForDeletion deletes the child": {
+			readyForDeletion: true,
+			wantResult:       ctrl.Result{},
+			wantDeleted:      true,
+		},
+	}
+
+	for tn, tc := range tests {
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			// No desired Shards, so the seeded child is an orphan.
+			tg := baseTG.DeepCopy()
+			tg.Spec.Shards = []multigresv1alpha1.ShardResolvedSpec{}
+
+			child := orphanShard(tc.readyForDeletion)
+
+			// Count child Patch/Delete calls to check the handshake isn't re-driven.
+			var shardPatchCount atomic.Int64
+			var shardDeleteCount atomic.Int64
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(child, tg).
+				WithStatusSubresource(
+					&multigresv1alpha1.TableGroup{},
+					&multigresv1alpha1.Shard{},
+				).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(
+						ctx context.Context,
+						cli client.WithWatch,
+						obj client.Object,
+						patch client.Patch,
+						opts ...client.PatchOption,
+					) error {
+						if _, ok := obj.(*multigresv1alpha1.Shard); ok {
+							shardPatchCount.Add(1)
+						}
+						return cli.Patch(ctx, obj, patch, opts...)
+					},
+					Delete: func(
+						ctx context.Context,
+						cli client.WithWatch,
+						obj client.Object,
+						opts ...client.DeleteOption,
+					) error {
+						if _, ok := obj.(*multigresv1alpha1.Shard); ok {
+							shardDeleteCount.Add(1)
+						}
+						return cli.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
+
+			reconciler := &TableGroupReconciler{
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(100),
+			}
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      tgName,
+					Namespace: namespace,
+				},
+			}
+
+			got, err := reconciler.Reconcile(t.Context(), req)
+			if err != nil {
+				t.Fatalf("unexpected error from Reconcile: %v", err)
+			}
+
+			if got != tc.wantResult {
+				t.Errorf("unexpected reconcile result: got %+v, want %+v", got, tc.wantResult)
+			}
+
+			// The annotation must never be re-stamped.
+			if patches := shardPatchCount.Load(); patches != 0 {
+				t.Errorf(
+					"handshake double-driven: expected zero Patch calls on the child Shard "+
+						"(annotation already set by a prior version), got %d",
+					patches,
+				)
+			}
+
+			fetched := &multigresv1alpha1.Shard{}
+			getErr := c.Get(
+				t.Context(),
+				types.NamespacedName{Name: shardName, Namespace: namespace},
+				fetched,
+			)
+
+			if tc.wantDeleted {
+				// Once it's drained the controller should delete it, exactly once.
+				if !apierrors.IsNotFound(getErr) {
+					t.Errorf(
+						"expected orphan child Shard to be deleted once ReadyForDeletion, "+
+							"but it still exists (get err: %v)",
+						getErr,
+					)
+				}
+				if deletes := shardDeleteCount.Load(); deletes != 1 {
+					t.Errorf(
+						"expected exactly one Delete of the child Shard, got %d",
+						deletes,
+					)
+				}
+				return
+			}
+
+			// While it's still draining the child should stay put and keep its
+			// original annotation.
+			if getErr != nil {
+				t.Fatalf("expected orphan child Shard to still exist while draining: %v", getErr)
+			}
+			if deletes := shardDeleteCount.Load(); deletes != 0 {
+				t.Errorf(
+					"handshake double-driven: expected no Delete of the child Shard while it "+
+						"is still draining, got %d",
+					deletes,
+				)
+			}
+			if got := fetched.Annotations[multigresv1alpha1.AnnotationPendingDeletion]; got !=
+				priorVersionTimestamp {
+				t.Errorf(
+					"PendingDeletion annotation was re-stamped across the version boundary: "+
+						"got %q, want preserved prior-version value %q",
+					got,
+					priorVersionTimestamp,
+				)
+			}
+		})
+	}
+}
+
+// TestTableGroupReconciler_PendingDeletionPublishesProgressingStatus verifies
+// that a removed child still draining forces current Progressing status before
+// the pending cleanup requeue.
+func TestTableGroupReconciler_PendingDeletionPublishesProgressingStatus(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	baseTG, tgName, namespace, clusterName, dbName, tgLabelName := setupFixtures(t)
+
+	shardName := name.JoinWithConstraints(
+		name.DefaultConstraints,
+		clusterName,
+		dbName,
+		tgLabelName,
+		"shard-0",
+	)
+
+	tg := baseTG.DeepCopy()
+	tg.Generation = 2
+	tg.Spec.Shards = []multigresv1alpha1.ShardResolvedSpec{}
+	tg.Status = multigresv1alpha1.TableGroupStatus{
+		Phase:              multigresv1alpha1.PhaseHealthy,
+		Message:            "Ready",
+		TotalShards:        1,
+		ReadyShards:        1,
+		ObservedGeneration: 1,
+	}
+	meta.SetStatusCondition(&tg.Status.Conditions, metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionTrue,
+		Reason:             "ShardsReady",
+		Message:            "1/1 shards ready",
+		ObservedGeneration: 1,
+	})
+
+	orphan := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shardName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"multigres.com/cluster":    clusterName,
+				"multigres.com/database":   dbName,
+				"multigres.com/tablegroup": tgLabelName,
+			},
+			Annotations: map[string]string{
+				multigresv1alpha1.AnnotationPendingDeletion: "2026-01-01T00:00:00Z",
+			},
+		},
+		Spec: multigresv1alpha1.ShardSpec{ShardName: "shard-0"},
+		Status: multigresv1alpha1.ShardStatus{
+			Phase:              multigresv1alpha1.PhaseHealthy,
+			ObservedGeneration: 1,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(orphan, tg).
+		WithStatusSubresource(
+			&multigresv1alpha1.TableGroup{},
+			&multigresv1alpha1.Shard{},
+		).
+		Build()
+
+	recorder := record.NewFakeRecorder(100)
+	reconciler := &TableGroupReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: recorder,
+	}
+
+	got, err := reconciler.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: tgName, Namespace: namespace},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from Reconcile: %v", err)
+	}
+	if want := (ctrl.Result{RequeueAfter: 5 * time.Second}); got != want {
+		t.Fatalf("unexpected reconcile result: got %+v, want %+v", got, want)
+	}
+
+	updatedTG := &multigresv1alpha1.TableGroup{}
+	if err := c.Get(
+		t.Context(),
+		types.NamespacedName{Name: tgName, Namespace: namespace},
+		updatedTG,
+	); err != nil {
+		t.Fatalf("failed to get tablegroup: %v", err)
+	}
+
+	if got, want := updatedTG.Status.Phase, multigresv1alpha1.PhaseProgressing; got != want {
+		t.Errorf("Phase mismatch while cleanup is pending: got %q, want %q", got, want)
+	}
+	if got, want := updatedTG.Status.Message, "Waiting for removed shards to drain"; got != want {
+		t.Errorf("Message mismatch while cleanup is pending: got %q, want %q", got, want)
+	}
+	if got, want := updatedTG.Status.ObservedGeneration, tg.Generation; got != want {
+		t.Errorf("ObservedGeneration mismatch: got %d, want %d", got, want)
+	}
+	if got, want := updatedTG.Status.ReadyShards, int32(0); got != want {
+		t.Errorf("ReadyShards mismatch: got %d, want %d", got, want)
+	}
+	if got, want := updatedTG.Status.TotalShards, int32(0); got != want {
+		t.Errorf("TotalShards mismatch: got %d, want %d", got, want)
+	}
+
+	cond := meta.FindStatusCondition(updatedTG.Status.Conditions, "Available")
+	if cond == nil {
+		t.Fatal("expected an Available condition to be set")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Available status mismatch: got %q, want %q", cond.Status, metav1.ConditionFalse)
+	}
+	if cond.Reason != "CleanupPending" {
+		t.Errorf("Available reason mismatch: got %q, want CleanupPending", cond.Reason)
+	}
+	if cond.Message != "Waiting for removed shards to drain" {
+		t.Errorf("Available message mismatch: got %q", cond.Message)
+	}
+	if cond.ObservedGeneration != tg.Generation {
+		t.Errorf(
+			"Available observedGeneration mismatch: got %d, want %d",
+			cond.ObservedGeneration,
+			tg.Generation,
+		)
+	}
+
+	close(recorder.Events)
+	for evt := range recorder.Events {
+		if strings.Contains(evt, "Synced") {
+			t.Errorf("unexpected Synced event while cleanup is still pending: %q", evt)
+		}
+	}
+}
+
+// TestTableGroupReconciler_SteadyStateDoesNotFlap verifies that reconciling an
+// already-Healthy TableGroup does not emit a spurious PhaseChange event. The
+// status-derivation half is covered by TestStepComputeStatus; this is the
+// full-reconcile assertion, since the PhaseChange gating spans the whole chain.
+func TestTableGroupReconciler_SteadyStateDoesNotFlap(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	baseTG, tgName, namespace, clusterName, dbName, tgLabelName := setupFixtures(t)
+
+	shardName := name.JoinWithConstraints(
+		name.DefaultConstraints,
+		clusterName,
+		dbName,
+		tgLabelName,
+		"shard-0",
+	)
+
+	childShardLabels := map[string]string{
+		"multigres.com/cluster":    clusterName,
+		"multigres.com/database":   dbName,
+		"multigres.com/tablegroup": tgLabelName,
+	}
+
+	// Seed the TG already Healthy, so any flap would visibly change the phase.
+	tg := baseTG.DeepCopy()
+	tg.Status = multigresv1alpha1.TableGroupStatus{
+		Phase:              multigresv1alpha1.PhaseHealthy,
+		Message:            "Ready",
+		TotalShards:        1,
+		ReadyShards:        1,
+		ObservedGeneration: tg.Generation,
+	}
+
+	// Healthy child with matching generations, so it counts as ready.
+	childShard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shardName,
+			Namespace: namespace,
+			Labels:    childShardLabels,
+		},
+		Spec: multigresv1alpha1.ShardSpec{ShardName: "shard-0"},
+		Status: multigresv1alpha1.ShardStatus{
+			Phase: multigresv1alpha1.PhaseHealthy,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(childShard, tg).
+		WithStatusSubresource(
+			&multigresv1alpha1.TableGroup{},
+			&multigresv1alpha1.Shard{},
+		).
+		Build()
+
+	recorder := record.NewFakeRecorder(100)
+
+	reconciler := &TableGroupReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: recorder,
+	}
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      tgName,
+			Namespace: namespace,
+		},
+	}
+
+	got, err := reconciler.Reconcile(t.Context(), req)
+	if err != nil {
+		t.Fatalf("unexpected error from Reconcile: %v", err)
+	}
+
+	// Nothing changed, so we shouldn't get a requeue.
+	if got != (ctrl.Result{}) {
+		t.Errorf("unexpected reconcile result: got %+v, want empty ctrl.Result{}", got)
+	}
+
+	// The status stays Healthy because it comes from the child's observed
+	// .Status, not the empty-status desired object.
+	updatedTG := &multigresv1alpha1.TableGroup{}
+	if err := c.Get(
+		t.Context(),
+		types.NamespacedName{Name: tgName, Namespace: namespace},
+		updatedTG,
+	); err != nil {
+		t.Fatalf("failed to get tablegroup: %v", err)
+	}
+
+	if got, want := updatedTG.Status.Phase, multigresv1alpha1.PhaseHealthy; got != want {
+		t.Errorf(
+			"steady-state reconcile flapped the phase: got %q, want %q (status must be "+
+				"computed from observed children, not empty-status desired objects)",
+			got,
+			want,
+		)
+	}
+
+	if got, want := updatedTG.Status.ReadyShards, int32(1); got != want {
+		t.Errorf("ReadyShards mismatch: got %d, want %d", got, want)
+	}
+
+	// Phase didn't change, so there should be no PhaseChange event.
+	close(recorder.Events)
+	for evt := range recorder.Events {
+		if strings.Contains(evt, "PhaseChange") {
+			t.Errorf("unexpected spurious PhaseChange event emitted in steady state: %q", evt)
+		}
+	}
 }

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
@@ -846,7 +846,8 @@ func TestTableGroupReconciler_DefaultMVPShape(t *testing.T) {
 	if got, want := shard.Spec.DatabaseName, multigresv1alpha1.DatabaseName(dbName); got != want {
 		t.Errorf("Shard DatabaseName mismatch: got %q, want %q", got, want)
 	}
-	if got, want := shard.Spec.TableGroupName, multigresv1alpha1.TableGroupName(tgLabelName); got != want {
+	if got, want := shard.Spec.TableGroupName,
+		multigresv1alpha1.TableGroupName(tgLabelName); got != want {
 		t.Errorf("Shard TableGroupName mismatch: got %q, want %q", got, want)
 	}
 	if got, want := shard.Spec.ShardName, multigresv1alpha1.ShardName(shardName); got != want {

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller_test.go
@@ -92,6 +92,7 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 		preReconcileClient func(testing.TB, client.Client) // Hook to modify client state before Reconcile
 		skipCreate         bool                            // If true, the object won't be created in the fake client (simulates Not Found)
 		expectedEvents     []string                        // events expected to be recorded
+		expectedResult     *ctrl.Result
 		validate           func(testing.TB, client.Client)
 	}{
 		"Create: Shard Creation": {
@@ -526,7 +527,7 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 				},
 			},
 			expectedEvents: []string{
-				"Normal Deleted Deleted orphaned Shard",
+				"Normal Deleted Deleted Shard",
 			},
 			validate: func(t testing.TB, c client.Client) {
 				shardName := name.JoinWithConstraints(
@@ -603,6 +604,75 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 				}
 				if shard.Annotations[multigresv1alpha1.AnnotationPendingDeletion] == "" {
 					t.Error("Expected PendingDeletion annotation to be set on Shard")
+				}
+			},
+		},
+		"Success: Handle Pending Deletion (Child Already Terminating)": {
+			tableGroup: baseTG.DeepCopy(),
+			preReconcileUpdate: func(t testing.TB, tg *multigresv1alpha1.TableGroup) {
+				if tg.Annotations == nil {
+					tg.Annotations = make(map[string]string)
+				}
+				tg.Annotations[multigresv1alpha1.AnnotationPendingDeletion] = "2026-01-01T00:00:00Z"
+			},
+			existingObjects: []client.Object{
+				&multigresv1alpha1.Shard{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name.JoinWithConstraints(
+							name.DefaultConstraints,
+							clusterName,
+							dbName,
+							tgLabelName,
+							"shard-0",
+						),
+						Namespace: namespace,
+						Labels: map[string]string{
+							"multigres.com/cluster":    clusterName,
+							"multigres.com/database":   dbName,
+							"multigres.com/tablegroup": tgLabelName,
+						},
+						DeletionTimestamp: ptr.To(metav1.Now()),
+						// Test fixture only: keep the fake object visible after
+						// DeletionTimestamp so the parent observes it mid-termination.
+						Finalizers: []string{"test.finalizer"},
+					},
+					Spec: multigresv1alpha1.ShardSpec{ShardName: "shard-0"},
+				},
+			},
+			expectedResult: ptr.To(ctrl.Result{RequeueAfter: 5 * time.Second}),
+			validate: func(t testing.TB, c client.Client) {
+				shardName := name.JoinWithConstraints(
+					name.DefaultConstraints,
+					clusterName,
+					dbName,
+					tgLabelName,
+					"shard-0",
+				)
+				shard := &multigresv1alpha1.Shard{}
+				if err := c.Get(
+					t.Context(),
+					types.NamespacedName{Name: shardName, Namespace: namespace},
+					shard,
+				); err != nil {
+					t.Fatalf("terminating Shard should still be visible: %v", err)
+				}
+				if got := shard.Annotations[multigresv1alpha1.AnnotationPendingDeletion]; got != "" {
+					t.Errorf("terminating Shard should not be restamped, got %q", got)
+				}
+
+				updatedTG := &multigresv1alpha1.TableGroup{}
+				if err := c.Get(
+					t.Context(),
+					types.NamespacedName{Name: tgName, Namespace: namespace},
+					updatedTG,
+				); err != nil {
+					t.Fatalf("failed to get TableGroup: %v", err)
+				}
+				if meta.IsStatusConditionTrue(
+					updatedTG.Status.Conditions,
+					multigresv1alpha1.ConditionReadyForDeletion,
+				) {
+					t.Error("TableGroup should wait for terminating child Shard to disappear")
 				}
 			},
 		},
@@ -707,9 +777,16 @@ func TestTableGroupReconciler_Reconcile_Success(t *testing.T) {
 				},
 			}
 
-			_, err := reconciler.Reconcile(t.Context(), req)
+			result, err := reconciler.Reconcile(t.Context(), req)
 			if err != nil {
 				t.Errorf("Unexpected error from Reconcile: %v", err)
+			}
+			if tc.expectedResult != nil && result != *tc.expectedResult {
+				t.Errorf(
+					"Unexpected result from Reconcile: got %+v, want %+v",
+					result,
+					*tc.expectedResult,
+				)
 			}
 
 			if len(tc.expectedEvents) > 0 {
@@ -1060,7 +1137,7 @@ func TestTableGroupReconciler_Reconcile_Failure(t *testing.T) {
 					errSimulated,
 				),
 			},
-			expectedEvents: []string{"Warning CleanUpError Failed to delete orphan shard"},
+			expectedEvents: []string{"Warning CleanUpError Failed to delete shard"},
 		},
 		"Error: Update Status Failed": {
 			tableGroup:      baseTG.DeepCopy(),
@@ -1726,7 +1803,7 @@ func TestTableGroupReconciler_PendingDeletionPublishesProgressingStatus(t *testi
 	if got, want := updatedTG.Status.Phase, multigresv1alpha1.PhaseProgressing; got != want {
 		t.Errorf("Phase mismatch while cleanup is pending: got %q, want %q", got, want)
 	}
-	if got, want := updatedTG.Status.Message, "Waiting for removed shards to drain"; got != want {
+	if got, want := updatedTG.Status.Message, "Waiting for shard cleanup to finish"; got != want {
 		t.Errorf("Message mismatch while cleanup is pending: got %q, want %q", got, want)
 	}
 	if got, want := updatedTG.Status.ObservedGeneration, tg.Generation; got != want {
@@ -1749,7 +1826,7 @@ func TestTableGroupReconciler_PendingDeletionPublishesProgressingStatus(t *testi
 	if cond.Reason != "CleanupPending" {
 		t.Errorf("Available reason mismatch: got %q, want CleanupPending", cond.Reason)
 	}
-	if cond.Message != "Waiting for removed shards to drain" {
+	if cond.Message != "Waiting for shard cleanup to finish" {
 		t.Errorf("Available message mismatch: got %q", cond.Message)
 	}
 	if cond.ObservedGeneration != tg.Generation {


### PR DESCRIPTION
## Description

this PR refactors the TableGroup reconciler around the lifecycle it owns: applying desired child Shards, retiring removed or replaced children through the existing drain handshake, and publishing aggregate status from observed child state.

The previous implementation kept child apply, orphan cleanup, child re-listing, status aggregation, event emission, and requeue decisions in one long reconcile flow. That made the controller’s state transitions implicit, especially around removed children and same-reconcile child updates. In those cases, TableGroup could leave stale parent status visible or count child state that no longer represented the current desired generation.

The new structure keeps TableGroup’s responsibility unchanged. It still applies owned Shard specs with Server-Side Apply and it still preserves the PendingDeletion / ReadyForDeletion cleanup flow. The refactor makes the lifecycle boundaries explicit in code and tightens status aggregation so the parent reports convergence honestly while children are draining, terminating or catching up.

## Main Changes

## Main Changes

- Split the TableGroup reconcile flow into package-local phases for parent lifecycle handling, child apply/cleanup, status aggregation, status patching, and cleanup requeue decisions.

- Replaced the previous normal-path child re-list with one observed child snapshot, so status is computed from child state the controller actually saw.

- Preserved the existing `PendingDeletion` / `ReadyForDeletion` cleanup handshake while preventing removed, replaced, or terminating children from being applied over or counted active.

- Counted readiness only from desired child Shards whose observed status has caught up to the generation applied by this reconcile.

- Added focused unit and envtest coverage for child cleanup, same-name replacement, terminating-child handling, generation-gated readiness, and stable convergence.

## Testing

- Added coverage around the lifecycle and status invariants that make this refactor risky.

- Status aggregation is tested directly: total comes from spec, readiness and degradation come from observed desired children, cleanup children do not make the parent look ready, pending cleanup forces `Progressing`, and readiness is gated on observed generation.

- Child cleanup is tested at the lifecycle boundaries: removed Shards are annotated once, existing annotations are preserved, children are not deleted before `ReadyForDeletion`, same-name replacements do not apply over children already in cleanup, and terminating children are waited on rather than restamped.

- Full reconcile tests verify the controller lists child Shards once on the normal path, publishes cleanup status before requeueing, requeues while parent cleanup is waiting on a terminating child, and does not flap an already-Healthy TableGroup.

- Envtest coverage exercises convergence against a real apiserver/cache, including initial child creation, stable terminal status, add/remove reconciliation, retained child cleanup, same-name replacement after deletion, and reconvergence after the replacement child reports Healthy.

