### PR TITLE
chore: Reduce certificate lifetime to 14 days, clean up subject/SANs

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/certificate.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -22,12 +21,12 @@ const (
 	// CertIssuerName is the cert-manager ClusterIssuer used for TLS certificates.
 	CertIssuerName = "supabase-issuer"
 
-	// CertDuration is the certificate duration (5 years), matching non-HA projects.
-	CertDuration = "44640h0m0s"
+	// CertDuration is the certificate duration.
+	CertDuration = "336h0m0s"
 
 	// CertLiteralSubjectTemplate is the literal subject template for certificates.
 	// The CN placeholder is replaced with the certCommonName.
-	CertLiteralSubjectTemplate = "C=US, ST=Delware, L=New Castle,O=Supabase Inc, CN=%s"
+	CertLiteralSubjectTemplate = "C=US, ST=Delaware, L=New Castle, O=Supabase Inc, CN=%s"
 )
 
 var certGVK = schema.GroupVersionKind{
@@ -47,11 +46,7 @@ func buildCertificate(
 ) (*unstructured.Unstructured, error) {
 	cn := cluster.Spec.CertCommonName
 
-	// Build the secondary SAN by stripping the "db." prefix if present.
 	dnsNames := []any{cn}
-	if after, ok := strings.CutPrefix(cn, "db."); ok {
-		dnsNames = append(dnsNames, after)
-	}
 
 	cert := &unstructured.Unstructured{}
 	cert.SetGroupVersionKind(certGVK)

--- a/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
@@ -33,7 +33,7 @@ func TestBuildCertificate(t *testing.T) {
 		wantSubject    string
 		wantSecretName string
 	}{
-		"standard certCommonName with db prefix": {
+		"standard certCommonName": {
 			cluster: &multigresv1alpha1.MultigresCluster{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "multigres.com/v1alpha1",
@@ -51,29 +51,8 @@ func TestBuildCertificate(t *testing.T) {
 			wantName: "db.abc123.supabase.red",
 			wantDNSNames: []any{
 				"db.abc123.supabase.red",
-				"abc123.supabase.red",
 			},
-			wantSubject:    "C=US, ST=Delware, L=New Castle,O=Supabase Inc, CN=db.abc123.supabase.red",
-			wantSecretName: multigresv1alpha1.CertSecretName,
-		},
-		"certCommonName without db prefix": {
-			cluster: &multigresv1alpha1.MultigresCluster{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "multigres.com/v1alpha1",
-					Kind:       "MultigresCluster",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "supabase",
-					UID:       "cluster-uid-2",
-				},
-				Spec: multigresv1alpha1.MultigresClusterSpec{
-					CertCommonName: "custom.example.com",
-				},
-			},
-			wantName:       "custom.example.com",
-			wantDNSNames:   []any{"custom.example.com"},
-			wantSubject:    "C=US, ST=Delware, L=New Castle,O=Supabase Inc, CN=custom.example.com",
+			wantSubject:    "C=US, ST=Delaware, L=New Castle, O=Supabase Inc, CN=db.abc123.supabase.red",
 			wantSecretName: multigresv1alpha1.CertSecretName,
 		},
 	}


### PR DESCRIPTION
This PR reduces the duration of an issued certificate from 5 years to 14 days, fixes a typo in the subject name, and removes logic that modifies the DNS SANs based on whether the DNS name starts with "db.".