### PR TITLE
feat: wire internal gRPC TLS

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -256,7 +256,35 @@ const (
 	// multigateway TLS certificate, matching the non-HA project convention.
 	// Referenced by both the Certificate spec and the Deployment volume.
 	CertSecretName = "generated-certs"
+
+	// Component certificate names used for internal gRPC TLS/mTLS.
+	ComponentMultiAdminTLS   = "multiadmin"
+	ComponentMultiGatewayTLS = "multigateway"
+
+	// InternalTLSIdentityDomain is the logical DNS suffix used for internal
+	// component identities. These names are verified through an explicit gRPC
+	// server-name override and are not expected to resolve through cluster DNS.
+	InternalTLSIdentityDomain = "multigres.internal"
+	ComponentMultiOrchTLS     = "multiorch"
+	ComponentMultiPoolerTLS   = "multipooler"
 )
+
+// ComponentCertSecretName returns the cert-manager Secret name for an internal
+// component certificate. By convention this is the same value as the CN/SAN
+// returned by ComponentCertCommonName.
+func ComponentCertSecretName(component, clusterName, namespace string) string {
+	return ComponentCertCommonName(component, clusterName, namespace)
+}
+
+// ComponentCertCommonName returns the logical DNS identity used as CN/SAN for
+// an internal component certificate. It is intentionally independent of the
+// end user facing CertCommonName and the workload's k8s routing name.
+func ComponentCertCommonName(component, clusterName, namespace string) string {
+	if component == "" || clusterName == "" || namespace == "" {
+		return ""
+	}
+	return component + "." + clusterName + "." + namespace + "." + InternalTLSIdentityDomain
+}
 
 // ============================================================================
 // Domain Specific Types (Strong Typing)

--- a/api/v1alpha1/shard_types.go
+++ b/api/v1alpha1/shard_types.go
@@ -196,6 +196,11 @@ type ShardSpec struct {
 	// Secret.
 	PostgresPasswordSecretRef PostgresPasswordSecretRef `json:"postgresPasswordSecretRef"`
 
+	// CertCommonName is the DNS name used by shard-side mTLS clients and servers.
+	// Inherited from MultigresCluster.Spec.CertCommonName.
+	// +optional
+	CertCommonName string `json:"certCommonName,omitempty"`
+
 	// CellTopologyLabels maps cell names to their topology nodeSelector labels.
 	// Each entry is a map like {"topology.kubernetes.io/zone": "us-east-1a"}.
 	// Propagated from the cluster's cell configs so the shard controller

--- a/api/v1alpha1/tablegroup_types.go
+++ b/api/v1alpha1/tablegroup_types.go
@@ -101,6 +101,11 @@ type TableGroupSpec struct {
 
 	// PostgresPasswordSecretRef is inherited from the MultigresCluster.
 	PostgresPasswordSecretRef PostgresPasswordSecretRef `json:"postgresPasswordSecretRef"`
+
+	// CertCommonName is the DNS name used by shard-side mTLS clients and servers.
+	// Inherited from MultigresCluster.Spec.CertCommonName.
+	// +optional
+	CertCommonName string `json:"certCommonName,omitempty"`
 }
 
 // ShardResolvedSpec represents the fully calculated spec for a shard,

--- a/config/crd/bases/multigres.com_shards.yaml
+++ b/config/crd/bases/multigres.com_shards.yaml
@@ -189,6 +189,11 @@ spec:
                   Propagated from the cluster's cell configs so the shard controller
                   can inject nodeSelector without looking up Cell CRs.
                 type: object
+              certCommonName:
+                description: |-
+                  CertCommonName is the DNS name used by shard-side mTLS clients and servers.
+                  Inherited from MultigresCluster.Spec.CertCommonName.
+                type: string
               databaseName:
                 description: DatabaseName is the name of the logical database this
                   shard belongs to.

--- a/config/crd/bases/multigres.com_tablegroups.yaml
+++ b/config/crd/bases/multigres.com_tablegroups.yaml
@@ -186,6 +186,11 @@ spec:
                   CellTopologyLabels maps cell names to their topology nodeSelector labels.
                   Propagated from the cluster's cell configs.
                 type: object
+              certCommonName:
+                description: |-
+                  CertCommonName is the DNS name used by shard-side mTLS clients and servers.
+                  Inherited from MultigresCluster.Spec.CertCommonName.
+                type: string
               databaseName:
                 description: DatabaseName is the name of the logical database.
                 maxLength: 30

--- a/pkg/cluster-handler/controller/multigrescluster/builders_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global.go
@@ -18,6 +18,12 @@ import (
 const (
 	globalMultigatewayReplicaPort       int32 = 5433
 	globalMultigatewayReplicaTargetPort       = "pg-replica"
+
+	multiAdminTLSVolumeName = "tls-certs"
+	multiAdminTLSMountPath  = "/etc/multiadmin/tls"
+	multiAdminTLSCertFile   = multiAdminTLSMountPath + "/tls.crt"
+	multiAdminTLSKeyFile    = multiAdminTLSMountPath + "/tls.key"
+	multiAdminTLSCAFile     = multiAdminTLSMountPath + "/ca.crt"
 )
 
 // BuildGlobalTopoServer constructs the desired TopoServer for the global topology.
@@ -192,6 +198,48 @@ func BuildMultiadminDeployment(
 		podSpec := &deploy.Spec.Template.Spec
 		podSpec.Volumes = append(podSpec.Volumes, *otelVol)
 		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, *otelMount)
+	}
+
+	if cluster.Spec.CertCommonName != "" {
+		podSpec := &deploy.Spec.Template.Spec
+		defaultMode := int32(0o444)
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name: multiAdminTLSVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: multigresv1alpha1.ComponentCertSecretName(
+						multigresv1alpha1.ComponentMultiAdminTLS,
+						cluster.Name,
+						cluster.Namespace,
+					),
+					DefaultMode: &defaultMode,
+				},
+			},
+		})
+		podSpec.Containers[0].VolumeMounts = append(
+			podSpec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      multiAdminTLSVolumeName,
+				MountPath: multiAdminTLSMountPath,
+				ReadOnly:  true,
+			},
+		)
+		podSpec.Containers[0].Args = append(podSpec.Containers[0].Args,
+			"--grpc-cert", multiAdminTLSCertFile,
+			"--grpc-key", multiAdminTLSKeyFile,
+			"--grpc-ca", multiAdminTLSCAFile,
+			"--grpc-server-ca", multiAdminTLSCAFile,
+			"--multipooler-grpc-cert", multiAdminTLSCertFile,
+			"--multipooler-grpc-key", multiAdminTLSKeyFile,
+			"--multipooler-grpc-ca", multiAdminTLSCAFile,
+			"--multipooler-grpc-server-name",
+			multigresv1alpha1.ComponentCertCommonName(
+				multigresv1alpha1.ComponentMultiPoolerTLS,
+				cluster.Name,
+				cluster.Namespace,
+			),
+			"--multipooler-grpc-require-tls",
+		)
 	}
 
 	if err := controllerutil.SetControllerReference(cluster, deploy, scheme); err != nil {

--- a/pkg/cluster-handler/controller/multigrescluster/builders_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global_test.go
@@ -2,8 +2,10 @@ package multigrescluster
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -172,6 +174,93 @@ func TestBuildMultiadminDeployment(t *testing.T) {
 		}
 		if len(got.Spec.Template.Spec.Containers[0].VolumeMounts) == 0 {
 			t.Errorf("Expected OTEL volume mount to be added")
+		}
+	})
+
+	t.Run("Success with internal mTLS", func(t *testing.T) {
+		tlsCluster := cluster.DeepCopy()
+		tlsCluster.Spec.CertCommonName = "db.abc123.supabase.red"
+
+		got, err := BuildMultiadminDeployment(tlsCluster, spec, scheme)
+		if err != nil {
+			t.Fatalf("BuildMultiadminDeployment() error = %v", err)
+		}
+
+		var foundVol bool
+		for _, v := range got.Spec.Template.Spec.Volumes {
+			if v.Name == multiAdminTLSVolumeName {
+				foundVol = true
+				if v.Secret == nil {
+					t.Fatal("TLS volume should use Secret source")
+				}
+				wantSecretName := "multiadmin.my-cluster.default.multigres.internal" //nolint:gosec // test constant
+				if v.Secret.SecretName != wantSecretName {
+					t.Errorf(
+						"TLS secretName = %q, want %q",
+						v.Secret.SecretName,
+						wantSecretName,
+					)
+				}
+				if strings.Contains(v.Secret.SecretName, tlsCluster.Spec.CertCommonName) {
+					t.Errorf(
+						"internal TLS secretName %q must not contain public CertCommonName %q",
+						v.Secret.SecretName,
+						tlsCluster.Spec.CertCommonName,
+					)
+				}
+				if v.Secret.DefaultMode == nil || *v.Secret.DefaultMode != 0o444 {
+					t.Errorf(
+						"TLS secret defaultMode = %v, want 0444",
+						v.Secret.DefaultMode,
+					)
+				}
+			}
+		}
+		if !foundVol {
+			t.Fatalf("expected TLS volume %q", multiAdminTLSVolumeName)
+		}
+
+		container := got.Spec.Template.Spec.Containers[0]
+		var foundMount bool
+		for _, m := range container.VolumeMounts {
+			if m.Name == multiAdminTLSVolumeName {
+				foundMount = true
+				if m.MountPath != multiAdminTLSMountPath {
+					t.Errorf(
+						"TLS mount path = %q, want %q",
+						m.MountPath,
+						multiAdminTLSMountPath,
+					)
+				}
+			}
+		}
+		if !foundMount {
+			t.Fatalf("expected TLS volume mount %q", multiAdminTLSVolumeName)
+		}
+
+		wantArgs := []string{
+			"--grpc-cert", multiAdminTLSCertFile,
+			"--grpc-key", multiAdminTLSKeyFile,
+			"--grpc-ca", multiAdminTLSCAFile,
+			"--grpc-server-ca", multiAdminTLSCAFile,
+			"--multipooler-grpc-cert", multiAdminTLSCertFile,
+			"--multipooler-grpc-key", multiAdminTLSKeyFile,
+			"--multipooler-grpc-ca", multiAdminTLSCAFile,
+			"--multipooler-grpc-server-name",
+			"multipooler.my-cluster.default.multigres.internal",
+			"--multipooler-grpc-require-tls",
+		}
+		tailArgs := container.Args[len(container.Args)-len(wantArgs):]
+		if diff := cmp.Diff(wantArgs, tailArgs); diff != "" {
+			t.Errorf("mTLS args mismatch (-want +got):\n%s", diff)
+		}
+		serverName := tailArgs[len(tailArgs)-2]
+		if strings.Contains(serverName, tlsCluster.Spec.CertCommonName) {
+			t.Errorf(
+				"multipooler gRPC server name %q must not contain public CertCommonName %q",
+				serverName,
+				tlsCluster.Spec.CertCommonName,
+			)
 		}
 	})
 

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup.go
@@ -77,6 +77,7 @@ func BuildTableGroup(
 			),
 			PostgresSuperuser:         cluster.Spec.PostgresSuperuser,
 			PostgresPasswordSecretRef: cluster.Spec.PostgresPasswordSecretRef,
+			CertCommonName:            cluster.Spec.CertCommonName,
 		},
 	}
 

--- a/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_tablegroup_test.go
@@ -106,6 +106,23 @@ func TestBuildTableGroup(t *testing.T) {
 		}
 	})
 
+	t.Run("CertCommonName", func(t *testing.T) {
+		c := *cluster
+		c.Spec.CertCommonName = "db.abc123.supabase.red"
+		tgCfg := &multigresv1alpha1.TableGroupConfig{Name: "tg-tls"}
+		got, err := BuildTableGroup(&c, dbCfg, tgCfg, nil, globalTopoRef, scheme)
+		if err != nil {
+			t.Fatalf("BuildTableGroup() error = %v", err)
+		}
+		if got.Spec.CertCommonName != "db.abc123.supabase.red" {
+			t.Errorf(
+				"CertCommonName = %q, want %q",
+				got.Spec.CertCommonName,
+				"db.abc123.supabase.red",
+			)
+		}
+	})
+
 	t.Run("Name Truncation", func(t *testing.T) {
 		longName := strings.Repeat("a", 250) // Very long name
 		tgCfg := &multigresv1alpha1.TableGroupConfig{

--- a/pkg/cluster-handler/controller/multigrescluster/certificate.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate.go
@@ -6,8 +6,12 @@ import (
 	"fmt"
 	"strings"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,6 +40,14 @@ var certGVK = schema.GroupVersionKind{
 	Kind:    "Certificate",
 }
 
+type certSpec struct {
+	name       string
+	secretName string
+	commonName string
+	dnsNames   []any
+	usages     []any
+}
+
 // buildCertificate constructs an unstructured cert-manager Certificate for the
 // multigateway TLS certificate. The Certificate spec matches what non-HA
 // projects use, with the supabase-issuer ClusterIssuer.
@@ -47,15 +59,95 @@ func buildCertificate(
 ) (*unstructured.Unstructured, error) {
 	cn := cluster.Spec.CertCommonName
 
-	// Build the secondary SAN by stripping the "db." prefix if present.
-	dnsNames := []any{cn}
-	if after, ok := strings.CutPrefix(cn, "db."); ok {
+	dnsNames := publicGatewayDNSNames(cn)
+
+	return buildCertificateFromSpec(cluster, scheme, certSpec{
+		name:       cn,
+		secretName: multigresv1alpha1.CertSecretName,
+		commonName: cn,
+		dnsNames:   dnsNames,
+		usages: []any{
+			"digital signature",
+			"key encipherment",
+			"server auth",
+		},
+	})
+}
+
+func publicGatewayDNSNames(commonName string) []any {
+	dnsNames := []any{commonName}
+	if after, ok := strings.CutPrefix(commonName, "db."); ok {
 		dnsNames = append(dnsNames, after)
 	}
+	return dnsNames
+}
 
+func buildInternalCertificates(
+	cluster *multigresv1alpha1.MultigresCluster,
+	scheme *runtime.Scheme,
+) ([]*unstructured.Unstructured, error) {
+	components := []string{
+		multigresv1alpha1.ComponentMultiAdminTLS,
+		multigresv1alpha1.ComponentMultiGatewayTLS,
+		multigresv1alpha1.ComponentMultiOrchTLS,
+		multigresv1alpha1.ComponentMultiPoolerTLS,
+	}
+	certs := make([]*unstructured.Unstructured, 0, len(components))
+	for _, component := range components {
+		cn := multigresv1alpha1.ComponentCertCommonName(
+			component,
+			cluster.Name,
+			cluster.Namespace,
+		)
+		dnsNames := []any{cn}
+		if component == multigresv1alpha1.ComponentMultiGatewayTLS {
+			// multigateway's --multipooler-grpc-* client flags are reused by
+			// multigres core for gateway-to-gateway cancel forwarding, so its
+			// certificate also carries the logical pooler server identity.
+			dnsNames = append(dnsNames, multigresv1alpha1.ComponentCertCommonName(
+				multigresv1alpha1.ComponentMultiPoolerTLS,
+				cluster.Name,
+				cluster.Namespace,
+			))
+			// Keep the public gateway DNS identities as SANs while retaining
+			// the internal logical identity as this certificate's CN and name.
+			dnsNames = append(
+				dnsNames,
+				publicGatewayDNSNames(cluster.Spec.CertCommonName)...,
+			)
+		}
+		cert, err := buildCertificateFromSpec(cluster, scheme, certSpec{
+			name: cn,
+			secretName: multigresv1alpha1.ComponentCertSecretName(
+				component,
+				cluster.Name,
+				cluster.Namespace,
+			),
+			commonName: cn,
+			dnsNames:   dnsNames,
+			usages: []any{
+				"digital signature",
+				"key encipherment",
+				"server auth",
+				"client auth",
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+	}
+	return certs, nil
+}
+
+func buildCertificateFromSpec(
+	cluster *multigresv1alpha1.MultigresCluster,
+	scheme *runtime.Scheme,
+	spec certSpec,
+) (*unstructured.Unstructured, error) {
 	cert := &unstructured.Unstructured{}
 	cert.SetGroupVersionKind(certGVK)
-	cert.SetName(cn)
+	cert.SetName(spec.name)
 	cert.SetNamespace(cluster.Namespace)
 
 	if err := ctrl.SetControllerReference(cluster, cert, scheme); err != nil {
@@ -63,10 +155,10 @@ func buildCertificate(
 	}
 
 	cert.Object["spec"] = map[string]any{
-		"secretName":     multigresv1alpha1.CertSecretName,
-		"dnsNames":       dnsNames,
+		"secretName":     spec.secretName,
+		"dnsNames":       spec.dnsNames,
 		"duration":       CertDuration,
-		"literalSubject": fmt.Sprintf(CertLiteralSubjectTemplate, cn),
+		"literalSubject": fmt.Sprintf(CertLiteralSubjectTemplate, spec.commonName),
 		"issuerRef": map[string]any{
 			"name":  CertIssuerName,
 			"kind":  "ClusterIssuer",
@@ -76,11 +168,7 @@ func buildCertificate(
 			"algorithm": "RSA",
 			"size":      int64(2048),
 		},
-		"usages": []any{
-			"digital signature",
-			"key encipherment",
-			"server auth",
-		},
+		"usages": spec.usages,
 	}
 
 	return cert, nil
@@ -95,17 +183,15 @@ func (r *MultigresClusterReconciler) reconcileCertificate(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
 ) error {
-	// Clean up stale Certificates owned by this cluster. When the CN
-	// changes the old Certificate (named after the previous CN) would
-	// otherwise linger and conflict on the same generated-certs secret.
-	// When the CN is empty this removes all our Certificates.
-	if err := r.deleteOwnedCertificates(
-		ctx, cluster, cluster.Spec.CertCommonName,
-	); err != nil {
+	certList, err := r.listCertificates(ctx, cluster)
+	if err != nil {
 		return err
 	}
 
 	if cluster.Spec.CertCommonName == "" {
+		if err := r.deleteOwnedCertificates(ctx, cluster, certList, nil, nil); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -115,30 +201,63 @@ func (r *MultigresClusterReconciler) reconcileCertificate(
 			"failed to build cert-manager Certificate: %w", err,
 		)
 	}
-	if err := r.Patch(
-		ctx,
-		desired,
-		client.Apply,
-		client.ForceOwnership,
-		client.FieldOwner("multigres-operator"),
+	desiredCerts := []*unstructured.Unstructured{desired}
+	internalCerts, err := buildInternalCertificates(cluster, r.Scheme)
+	if err != nil {
+		return fmt.Errorf("failed to build internal cert-manager Certificates: %w", err)
+	}
+	desiredCerts = append(desiredCerts, internalCerts...)
+
+	keepNames := make(map[string]struct{}, len(desiredCerts))
+	keepSecretNames := make(map[string]struct{}, len(desiredCerts))
+	for _, cert := range desiredCerts {
+		keepNames[cert.GetName()] = struct{}{}
+		if secretName, _, _ := unstructured.NestedString(
+			cert.Object, "spec", "secretName",
+		); secretName != "" {
+			keepSecretNames[secretName] = struct{}{}
+		}
+	}
+
+	if err := r.deleteOwnedCertificates(
+		ctx, cluster, certList, keepNames, keepSecretNames,
 	); err != nil {
-		return fmt.Errorf(
-			"failed to apply cert-manager Certificate: %w", err,
-		)
+		return err
+	}
+
+	for _, cert := range desiredCerts {
+		// Skip the Patch entirely when the live spec already matches the
+		// desired spec, so a no-op reconcile doesn't churn resourceVersion.
+		if existing := findCertificateByName(certList, cert.GetName()); existing != nil &&
+			isOwnedBy(existing, cluster) &&
+			apiequality.Semantic.DeepEqual(existing.Object["spec"], cert.Object["spec"]) {
+			continue
+		}
+		if err := r.Patch(
+			ctx,
+			cert,
+			client.Apply,
+			client.ForceOwnership,
+			client.FieldOwner("multigres-operator"),
+		); err != nil {
+			return fmt.Errorf(
+				"failed to apply cert-manager Certificate %q: %w",
+				cert.GetName(),
+				err,
+			)
+		}
 	}
 	return nil
 }
 
-// deleteOwnedCertificates removes cert-manager Certificates owned by this
-// cluster whose name does not match keepName. Pass "" for keepName to delete
-// all Certificates owned by this cluster (used when TLS is disabled).
-func (r *MultigresClusterReconciler) deleteOwnedCertificates(
+// listCertificates lists cert-manager Certificates owned by this cluster's
+// namespace. When the cert-manager CRD is not installed, this returns an
+// empty list rather than an error so callers can treat "no Certificates"
+// uniformly.
+func (r *MultigresClusterReconciler) listCertificates(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
-	keepName string,
-) error {
-	logger := log.FromContext(ctx)
-
+) (*unstructured.UnstructuredList, error) {
 	certList := &unstructured.UnstructuredList{}
 	certList.SetGroupVersionKind(certGVK)
 	if err := r.List(
@@ -147,21 +266,74 @@ func (r *MultigresClusterReconciler) deleteOwnedCertificates(
 		client.InNamespace(cluster.Namespace),
 	); err != nil {
 		if apierrors.IsNotFound(err) || isNoMatchError(err) {
-			return nil
+			return certList, nil
 		}
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"failed to list cert-manager Certificates: %w", err,
 		)
 	}
+	return certList, nil
+}
+
+// findCertificateByName returns the Certificate named name from certList, or
+// nil if it is not present.
+func findCertificateByName(
+	certList *unstructured.UnstructuredList,
+	name string,
+) *unstructured.Unstructured {
+	for i := range certList.Items {
+		if certList.Items[i].GetName() == name {
+			return &certList.Items[i]
+		}
+	}
+	return nil
+}
+
+// deleteOwnedCertificates removes cert-manager Certificates owned by this
+// cluster whose name is not in keepNames, along with each one's generated
+// secret (unless its name is in keepSecretNames. Pass nil for both
+// maps to delete all certificates and secrets owned by this cluster (used
+// when TLS is disabled).
+func (r *MultigresClusterReconciler) deleteOwnedCertificates(
+	ctx context.Context,
+	cluster *multigresv1alpha1.MultigresCluster,
+	certList *unstructured.UnstructuredList,
+	keepNames map[string]struct{},
+	keepSecretNames map[string]struct{},
+) error {
+	logger := log.FromContext(ctx)
 
 	for i := range certList.Items {
 		cert := &certList.Items[i]
 		if !isOwnedBy(cert, cluster) {
 			continue
 		}
-		if cert.GetName() == keepName {
-			continue
+		if keepNames != nil {
+			if _, ok := keepNames[cert.GetName()]; ok {
+				continue
+			}
 		}
+		// Delete the generated secret first. If this operation fails, keeping
+		// the certificate makes the Secret discoverable on the next reconcile
+		// so cleanup can be retried instead of leaving private key material
+		// permanently orphaned.
+		secretName, _, _ := unstructured.NestedString(cert.Object, "spec", "secretName")
+		_, keepSecret := keepSecretNames[secretName]
+		if secretName != "" && !keepSecret {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: cluster.Namespace,
+				},
+			}
+			if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf(
+					"failed to delete generated TLS Secret %q: %w",
+					secretName, err,
+				)
+			}
+		}
+
 		if err := r.Delete(ctx, cert); err != nil &&
 			!apierrors.IsNotFound(err) {
 			return fmt.Errorf(

--- a/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
@@ -1,16 +1,21 @@
 package multigrescluster
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 )
@@ -130,7 +135,179 @@ func TestBuildCertificate(t *testing.T) {
 			if diff := cmp.Diff(tc.wantSecretName, spec["secretName"]); diff != "" {
 				t.Errorf("secretName mismatch (-want +got):\n%s", diff)
 			}
+			wantIssuerRef := map[string]any{
+				"name":  CertIssuerName,
+				"kind":  "ClusterIssuer",
+				"group": "cert-manager.io",
+			}
+			if diff := cmp.Diff(wantIssuerRef, spec["issuerRef"]); diff != "" {
+				t.Errorf("issuerRef mismatch (-want +got):\n%s", diff)
+			}
+			wantUsages := []any{
+				"digital signature",
+				"key encipherment",
+				"server auth",
+			}
+			if diff := cmp.Diff(wantUsages, spec["usages"]); diff != "" {
+				t.Errorf("usages mismatch (-want +got):\n%s", diff)
+			}
 		})
+	}
+}
+
+func TestBuildInternalCertificates(t *testing.T) {
+	scheme := setupScheme()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "multigres.com/v1alpha1",
+			Kind:       "MultigresCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "supabase",
+			UID:       "cluster-uid",
+		},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			CertCommonName: "db.abc123.supabase.red",
+		},
+	}
+
+	got, err := buildInternalCertificates(cluster, scheme)
+	if err != nil {
+		t.Fatalf("buildInternalCertificates() error: %v", err)
+	}
+
+	want := map[string]string{
+		"multiadmin.test-cluster.supabase.multigres.internal": multigresv1alpha1.ComponentCertSecretName(
+			multigresv1alpha1.ComponentMultiAdminTLS,
+			cluster.Name,
+			cluster.Namespace,
+		),
+		"multigateway.test-cluster.supabase.multigres.internal": multigresv1alpha1.ComponentCertSecretName(
+			multigresv1alpha1.ComponentMultiGatewayTLS,
+			cluster.Name,
+			cluster.Namespace,
+		),
+		"multiorch.test-cluster.supabase.multigres.internal": multigresv1alpha1.ComponentCertSecretName(
+			multigresv1alpha1.ComponentMultiOrchTLS,
+			cluster.Name,
+			cluster.Namespace,
+		),
+		"multipooler.test-cluster.supabase.multigres.internal": multigresv1alpha1.ComponentCertSecretName(
+			multigresv1alpha1.ComponentMultiPoolerTLS,
+			cluster.Name,
+			cluster.Namespace,
+		),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d certs, want %d", len(got), len(want))
+	}
+	for _, cert := range got {
+		secretName, ok := want[cert.GetName()]
+		if !ok {
+			t.Fatalf("unexpected Certificate %q", cert.GetName())
+		}
+		spec, ok := cert.Object["spec"].(map[string]any)
+		if !ok {
+			t.Fatal("spec is not a map")
+		}
+		if diff := cmp.Diff(secretName, spec["secretName"]); diff != "" {
+			t.Errorf("secretName mismatch for %s (-want +got):\n%s", cert.GetName(), diff)
+		}
+		wantSubject := "C=US, ST=Delware, L=New Castle,O=Supabase Inc, CN=" + cert.GetName()
+		if diff := cmp.Diff(wantSubject, spec["literalSubject"]); diff != "" {
+			t.Errorf("literalSubject mismatch for %s (-want +got):\n%s", cert.GetName(), diff)
+		}
+		wantUsages := []any{
+			"digital signature",
+			"key encipherment",
+			"server auth",
+			"client auth",
+		}
+		if diff := cmp.Diff(wantUsages, spec["usages"]); diff != "" {
+			t.Errorf("usages mismatch for %s (-want +got):\n%s", cert.GetName(), diff)
+		}
+		wantDNSNames := []any{cert.GetName()}
+		if cert.GetName() == "multigateway.test-cluster.supabase.multigres.internal" {
+			// multigateway's cert also needs to verify against the logical
+			// MultiPooler identity used for gateway-to-gateway cancel forwarding.
+			wantDNSNames = append(
+				wantDNSNames,
+				"multipooler.test-cluster.supabase.multigres.internal",
+				cluster.Spec.CertCommonName,
+				"abc123.supabase.red",
+			)
+		}
+		if diff := cmp.Diff(wantDNSNames, spec["dnsNames"]); diff != "" {
+			t.Errorf("dnsNames mismatch for %s (-want +got):\n%s", cert.GetName(), diff)
+		}
+	}
+
+	changedExternalName := cluster.DeepCopy()
+	changedExternalName.Spec.CertCommonName = "db.changed.supabase.red"
+	gotAfterExternalNameChange, err := buildInternalCertificates(changedExternalName, scheme)
+	if err != nil {
+		t.Fatalf("buildInternalCertificates() after external name change: %v", err)
+	}
+	if len(gotAfterExternalNameChange) != len(got) {
+		t.Fatalf(
+			"got %d certs after external name change, want %d",
+			len(gotAfterExternalNameChange),
+			len(got),
+		)
+	}
+
+	changedByName := make(map[string]*unstructured.Unstructured, len(gotAfterExternalNameChange))
+	for _, cert := range gotAfterExternalNameChange {
+		changedByName[cert.GetName()] = cert
+	}
+
+	gatewayName := "multigateway.test-cluster.supabase.multigres.internal"
+	gatewayChecked := false
+	for _, originalCert := range got {
+		changedCert, ok := changedByName[originalCert.GetName()]
+		if !ok {
+			t.Fatalf("Certificate %q missing after external name change", originalCert.GetName())
+		}
+		if originalCert.GetName() != gatewayName {
+			if diff := cmp.Diff(originalCert, changedCert); diff != "" {
+				t.Errorf(
+					"internal Certificate %q changed with external CertCommonName (-want +got):\n%s",
+					originalCert.GetName(),
+					diff,
+				)
+			}
+			continue
+		}
+
+		gatewayChecked = true
+		changedSpec, ok := changedCert.Object["spec"].(map[string]any)
+		if !ok {
+			t.Fatal("changed multigateway spec is not a map")
+		}
+		wantChangedDNSNames := []any{
+			gatewayName,
+			"multipooler.test-cluster.supabase.multigres.internal",
+			"db.changed.supabase.red",
+			"changed.supabase.red",
+		}
+		if diff := cmp.Diff(wantChangedDNSNames, changedSpec["dnsNames"]); diff != "" {
+			t.Errorf("changed multigateway dnsNames mismatch (-want +got):\n%s", diff)
+		}
+
+		originalWithoutDNSNames := originalCert.DeepCopy()
+		changedWithoutDNSNames := changedCert.DeepCopy()
+		delete(originalWithoutDNSNames.Object["spec"].(map[string]any), "dnsNames")
+		delete(changedWithoutDNSNames.Object["spec"].(map[string]any), "dnsNames")
+		if diff := cmp.Diff(originalWithoutDNSNames, changedWithoutDNSNames); diff != "" {
+			t.Errorf(
+				"multigateway Certificate changed beyond public DNS SANs (-want +got):\n%s",
+				diff,
+			)
+		}
+	}
+	if !gatewayChecked {
+		t.Fatal("multigateway Certificate was not checked after external name change")
 	}
 }
 
@@ -216,6 +393,61 @@ func TestReconcileCertificate(t *testing.T) {
 		}
 		if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
 			t.Fatalf("second call: %v", err)
+		}
+	})
+
+	t.Run("no Patch when nothing changed", func(t *testing.T) {
+		var patchCount int
+		fc := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(
+					ctx context.Context,
+					cli client.WithWatch,
+					obj client.Object,
+					patch client.Patch,
+					opts ...client.PatchOption,
+				) error {
+					patchCount++
+					return cli.Patch(ctx, obj, patch, opts...)
+				},
+			}).
+			Build()
+		r := &MultigresClusterReconciler{
+			Client:   fc,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(10),
+		}
+		cluster := &multigresv1alpha1.MultigresCluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "multigres.com/v1alpha1",
+				Kind:       "MultigresCluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "c8", Namespace: "default", UID: "uid-8",
+			},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				CertCommonName: "db.noop.supabase.red",
+			},
+		}
+
+		if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
+			t.Fatalf("first reconcile: %v", err)
+		}
+		if patchCount != 5 {
+			t.Fatalf("patchCount after first reconcile = %d, want 5", patchCount)
+		}
+
+		// Reconciling again with the same spec should not re-patch any
+		// Certificate since the live specs already match desired.
+		if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
+			t.Fatalf("second reconcile: %v", err)
+		}
+		if patchCount != 5 {
+			t.Errorf(
+				"patchCount after second reconcile = %d, want 5 (no new patches)",
+				patchCount,
+			)
 		}
 	})
 
@@ -365,6 +597,207 @@ func TestReconcileCertificate(t *testing.T) {
 				Name: "db.other.supabase.red", Namespace: "default",
 			}, got); err != nil {
 				t.Fatal("Certificate owned by another cluster should survive")
+			}
+		},
+	)
+
+	t.Run(
+		"legacy internal identity retries cleanup after Secret deletion fails",
+		func(t *testing.T) {
+			oldCertificateName := "multipooler.db.secretold.supabase.red"
+			oldSecretName := oldCertificateName
+			deleteFailure := errors.New("injected Secret deletion failure")
+			failSecretDelete := false
+			fc := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(
+						ctx context.Context,
+						cli client.WithWatch,
+						obj client.Object,
+						opts ...client.DeleteOption,
+					) error {
+						if obj.GetName() == oldSecretName && failSecretDelete {
+							failSecretDelete = false
+							return deleteFailure
+						}
+						return cli.Delete(ctx, obj, opts...)
+					},
+				}).
+				Build()
+			r := &MultigresClusterReconciler{
+				Client:   fc,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
+			cluster := &multigresv1alpha1.MultigresCluster{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "multigres.com/v1alpha1",
+					Kind:       "MultigresCluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c9", Namespace: "default", UID: "uid-9",
+				},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					CertCommonName: "db.secretold.supabase.red",
+				},
+			}
+
+			legacyCertificate, err := buildCertificateFromSpec(cluster, scheme, certSpec{
+				name:       oldCertificateName,
+				secretName: oldSecretName,
+				commonName: oldCertificateName,
+				dnsNames:   []any{oldCertificateName},
+				usages:     []any{"server auth", "client auth"},
+			})
+			if err != nil {
+				t.Fatalf("build legacy Certificate: %v", err)
+			}
+			if err := fc.Create(t.Context(), legacyCertificate); err != nil {
+				t.Fatalf("create legacy Certificate: %v", err)
+			}
+			oldSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      oldSecretName,
+					Namespace: "default",
+				},
+			}
+			if err := fc.Create(t.Context(), oldSecret); err != nil {
+				t.Fatalf("failed to create old secret: %v", err)
+			}
+
+			failSecretDelete = true
+			err = r.reconcileCertificate(t.Context(), cluster)
+			if !errors.Is(err, deleteFailure) {
+				t.Fatalf("first cleanup error = %v, want wrapped deletion failure", err)
+			}
+
+			staleCertificate := &unstructured.Unstructured{}
+			staleCertificate.SetGroupVersionKind(certGVK)
+			if err := fc.Get(t.Context(), types.NamespacedName{
+				Name: oldCertificateName, Namespace: "default",
+			}, staleCertificate); err != nil {
+				t.Errorf("stale Certificate should remain after Secret deletion failure: %v", err)
+			}
+			if err := fc.Get(t.Context(), types.NamespacedName{
+				Name: oldSecretName, Namespace: "default",
+			}, &corev1.Secret{}); err != nil {
+				t.Errorf("stale Secret should remain after deletion failure: %v", err)
+			}
+
+			if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
+				t.Fatalf("cleanup retry: %v", err)
+			}
+			if err := fc.Get(t.Context(), types.NamespacedName{
+				Name: oldCertificateName, Namespace: "default",
+			}, staleCertificate); err == nil {
+				t.Error("stale Certificate should be deleted on cleanup retry")
+			}
+			if err := fc.Get(t.Context(), types.NamespacedName{
+				Name: oldSecretName, Namespace: "default",
+			}, &corev1.Secret{}); err == nil {
+				t.Error("stale internal Secret should be deleted on cleanup retry")
+			}
+		},
+	)
+
+	t.Run("CN change keeps the shared external Secret", func(t *testing.T) {
+		fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+		r := &MultigresClusterReconciler{
+			Client:   fc,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(10),
+		}
+		cluster := &multigresv1alpha1.MultigresCluster{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "multigres.com/v1alpha1",
+				Kind:       "MultigresCluster",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "c10", Namespace: "default", UID: "uid-10",
+			},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				CertCommonName: "db.sharedold.supabase.red",
+			},
+		}
+		if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
+			t.Fatalf("create old: %v", err)
+		}
+
+		// The external gateway cert always uses the fixed secret name, so it
+		// must survive the CN rotation for the new Certificate to reuse it.
+		sharedSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      multigresv1alpha1.CertSecretName,
+				Namespace: "default",
+			},
+		}
+		if err := fc.Create(t.Context(), sharedSecret); err != nil {
+			t.Fatalf("failed to create shared secret: %v", err)
+		}
+
+		cluster.Spec.CertCommonName = "db.sharednew.supabase.red"
+		if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
+			t.Fatalf("create new: %v", err)
+		}
+
+		if err := fc.Get(t.Context(), types.NamespacedName{
+			Name: multigresv1alpha1.CertSecretName, Namespace: "default",
+		}, &corev1.Secret{}); err != nil {
+			t.Errorf("shared external Secret should survive CN rotation: %v", err)
+		}
+	})
+
+	t.Run(
+		"re-applies a Certificate with matching spec but no ownerRef",
+		func(t *testing.T) {
+			fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+			r := &MultigresClusterReconciler{
+				Client:   fc,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
+			cluster := &multigresv1alpha1.MultigresCluster{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "multigres.com/v1alpha1",
+					Kind:       "MultigresCluster",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c11", Namespace: "default", UID: "uid-11",
+				},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					CertCommonName: "db.unmanaged.supabase.red",
+				},
+			}
+
+			desired, err := buildCertificate(cluster, scheme)
+			if err != nil {
+				t.Fatalf("buildCertificate: %v", err)
+			}
+			// Pre-create a Certificate with a matching spec but no
+			// ownerRef, simulating one left unmanaged by a prior bug.
+			unowned := &unstructured.Unstructured{}
+			unowned.SetGroupVersionKind(certGVK)
+			unowned.SetName(desired.GetName())
+			unowned.SetNamespace("default")
+			unowned.Object["spec"] = desired.Object["spec"]
+			if err := fc.Create(t.Context(), unowned); err != nil {
+				t.Fatalf("failed to create unowned cert: %v", err)
+			}
+
+			if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+
+			got := &unstructured.Unstructured{}
+			got.SetGroupVersionKind(certGVK)
+			if err := fc.Get(t.Context(), types.NamespacedName{
+				Name: desired.GetName(), Namespace: "default",
+			}, got); err != nil {
+				t.Fatalf("Certificate should exist: %v", err)
+			}
+			if len(got.GetOwnerReferences()) == 0 {
+				t.Error("Certificate should have been re-applied with an ownerRef")
 			}
 		},
 	)

--- a/pkg/cluster-handler/controller/tablegroup/builders.go
+++ b/pkg/cluster-handler/controller/tablegroup/builders.go
@@ -70,6 +70,7 @@ func BuildShard(
 			DurabilityPolicy:          tg.Spec.DurabilityPolicy,
 			PostgresSuperuser:         tg.Spec.PostgresSuperuser,
 			PostgresPasswordSecretRef: tg.Spec.PostgresPasswordSecretRef,
+			CertCommonName:            tg.Spec.CertCommonName,
 			CellTopologyLabels:        tg.Spec.CellTopologyLabels,
 		},
 	}

--- a/pkg/cluster-handler/controller/tablegroup/builders_test.go
+++ b/pkg/cluster-handler/controller/tablegroup/builders_test.go
@@ -131,6 +131,22 @@ func TestBuildShard(t *testing.T) {
 		}
 	})
 
+	t.Run("CertCommonName propagates from TableGroup to Shard", func(t *testing.T) {
+		tgWithTLS := tg.DeepCopy()
+		tgWithTLS.Spec.CertCommonName = "db.abc123.supabase.red"
+
+		got, err := BuildShard(tgWithTLS, shardSpec, scheme)
+		if err != nil {
+			t.Fatalf("BuildShard() error = %v", err)
+		}
+		if got.Spec.CertCommonName != "db.abc123.supabase.red" {
+			t.Errorf(
+				"Spec.CertCommonName = %v, want db.abc123.supabase.red",
+				got.Spec.CertCommonName,
+			)
+		}
+	})
+
 	t.Run("DurabilityPolicy empty when not set on TableGroup", func(t *testing.T) {
 		got, err := BuildShard(tg, shardSpec, scheme)
 		if err != nil {

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -41,6 +41,14 @@ const (
 	tlsMountPath  = "/etc/multigateway/tls"
 	tlsCertFile   = tlsMountPath + "/tls.crt"
 	tlsKeyFile    = tlsMountPath + "/tls.key"
+	tlsCAFile     = tlsMountPath + "/ca.crt"
+
+	// Internal TLS volume/mount constants for gRPC mTLS between components.
+	internalTLSVolumeName = tlsVolumeName + "-internal"
+	internalTLSMountPath  = tlsMountPath + "-internal"
+	internalTLSCertFile   = internalTLSMountPath + "/tls.crt"
+	internalTLSKeyFile    = internalTLSMountPath + "/tls.key"
+	internalTLSCAFile     = internalTLSMountPath + "/ca.crt"
 )
 
 // BuildMultigatewayDeploymentName generates the Deployment name.
@@ -227,12 +235,25 @@ func BuildMultigatewayDeployment(
 	// Mount TLS certificate and add flags when CertCommonName is configured.
 	if cell.Spec.CertCommonName != "" {
 		podSpec := &deployment.Spec.Template.Spec
-		defaultMode := int32(0o440)
+		defaultMode := int32(0o444)
 		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 			Name: tlsVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  multigresv1alpha1.CertSecretName,
+					DefaultMode: &defaultMode,
+				},
+			},
+		})
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name: internalTLSVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: multigresv1alpha1.ComponentCertSecretName(
+						multigresv1alpha1.ComponentMultiGatewayTLS,
+						clusterName,
+						cell.Namespace,
+					),
 					DefaultMode: &defaultMode,
 				},
 			},
@@ -244,10 +265,29 @@ func BuildMultigatewayDeployment(
 				MountPath: tlsMountPath,
 				ReadOnly:  true,
 			},
+			corev1.VolumeMount{
+				Name:      internalTLSVolumeName,
+				MountPath: internalTLSMountPath,
+				ReadOnly:  true,
+			},
 		)
 		podSpec.Containers[0].Args = append(podSpec.Containers[0].Args,
 			"--pg-tls-cert-file", tlsCertFile,
 			"--pg-tls-key-file", tlsKeyFile,
+			"--grpc-cert", internalTLSCertFile,
+			"--grpc-key", internalTLSKeyFile,
+			"--grpc-ca", internalTLSCAFile,
+			"--grpc-server-ca", internalTLSCAFile,
+			"--multipooler-grpc-cert", internalTLSCertFile,
+			"--multipooler-grpc-key", internalTLSKeyFile,
+			"--multipooler-grpc-ca", internalTLSCAFile,
+			"--multipooler-grpc-server-name",
+			multigresv1alpha1.ComponentCertCommonName(
+				multigresv1alpha1.ComponentMultiPoolerTLS,
+				clusterName,
+				cell.Namespace,
+			),
+			"--multipooler-grpc-require-tls",
 		)
 	}
 

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -2052,26 +2052,66 @@ func TestBuildMultigatewayDeployment_TLS(t *testing.T) {
 
 		// Verify TLS volume exists
 		var foundVol bool
+		var foundInternalVol bool
 		for _, v := range deploy.Spec.Template.Spec.Volumes {
 			if v.Name == tlsVolumeName {
 				foundVol = true
 				if v.Secret == nil {
 					t.Error("TLS volume should use a Secret source")
-				} else if v.Secret.SecretName != multigresv1alpha1.CertSecretName {
-					t.Errorf(
-						"TLS volume secretName = %q, want %q",
-						v.Secret.SecretName, multigresv1alpha1.CertSecretName,
-					)
+				} else {
+					if v.Secret.SecretName != multigresv1alpha1.CertSecretName {
+						t.Errorf(
+							"TLS volume secretName = %q, want %q",
+							v.Secret.SecretName, multigresv1alpha1.CertSecretName,
+						)
+					}
+					if v.Secret.DefaultMode == nil || *v.Secret.DefaultMode != 0o444 {
+						t.Errorf(
+							"TLS volume defaultMode = %v, want 0444",
+							v.Secret.DefaultMode,
+						)
+					}
+				}
+			}
+			if v.Name == internalTLSVolumeName {
+				foundInternalVol = true
+				if v.Secret == nil {
+					t.Error("internal TLS volume should use a Secret source")
+				} else {
+					wantSecretName := "multigateway.test-cluster.default.multigres.internal"
+					if v.Secret.SecretName != wantSecretName {
+						t.Errorf(
+							"internal TLS volume secretName = %q, want %q",
+							v.Secret.SecretName, wantSecretName,
+						)
+					}
+					if strings.Contains(v.Secret.SecretName, cellObj.Spec.CertCommonName) {
+						t.Errorf(
+							"internal TLS volume secretName %q must not contain public CertCommonName %q",
+							v.Secret.SecretName,
+							cellObj.Spec.CertCommonName,
+						)
+					}
+					if v.Secret.DefaultMode == nil || *v.Secret.DefaultMode != 0o444 {
+						t.Errorf(
+							"internal TLS volume defaultMode = %v, want 0444",
+							v.Secret.DefaultMode,
+						)
+					}
 				}
 			}
 		}
 		if !foundVol {
 			t.Errorf("expected TLS volume %q in pod spec", tlsVolumeName)
 		}
+		if !foundInternalVol {
+			t.Errorf("expected internal TLS volume %q in pod spec", internalTLSVolumeName)
+		}
 
 		// Verify TLS volumeMount exists
 		container := deploy.Spec.Template.Spec.Containers[0]
 		var foundMount bool
+		var foundInternalMount bool
 		for _, m := range container.VolumeMounts {
 			if m.Name == tlsVolumeName {
 				foundMount = true
@@ -2082,9 +2122,24 @@ func TestBuildMultigatewayDeployment_TLS(t *testing.T) {
 					t.Error("TLS mount should be readOnly")
 				}
 			}
+			if m.Name == internalTLSVolumeName {
+				foundInternalMount = true
+				if m.MountPath != internalTLSMountPath {
+					t.Errorf(
+						"internal TLS mount path = %q, want %q",
+						m.MountPath, internalTLSMountPath,
+					)
+				}
+				if !m.ReadOnly {
+					t.Error("internal TLS mount should be readOnly")
+				}
+			}
 		}
 		if !foundMount {
 			t.Errorf("expected TLS volumeMount %q in container", tlsVolumeName)
+		}
+		if !foundInternalMount {
+			t.Errorf("expected internal TLS volumeMount %q in container", internalTLSVolumeName)
 		}
 
 		// Verify TLS args are appended
@@ -2092,14 +2147,32 @@ func TestBuildMultigatewayDeployment_TLS(t *testing.T) {
 		wantArgs := []string{
 			"--pg-tls-cert-file", tlsCertFile,
 			"--pg-tls-key-file", tlsKeyFile,
+			"--grpc-cert", internalTLSCertFile,
+			"--grpc-key", internalTLSKeyFile,
+			"--grpc-ca", internalTLSCAFile,
+			"--grpc-server-ca", internalTLSCAFile,
+			"--multipooler-grpc-cert", internalTLSCertFile,
+			"--multipooler-grpc-key", internalTLSKeyFile,
+			"--multipooler-grpc-ca", internalTLSCAFile,
+			"--multipooler-grpc-server-name",
+			"multipooler.test-cluster.default.multigres.internal",
+			"--multipooler-grpc-require-tls",
 		}
-		// The TLS args should be the last 4 args
-		if len(args) < 4 {
-			t.Fatalf("expected at least 4 args, got %d", len(args))
+		// The TLS args should be appended as a group.
+		if len(args) < len(wantArgs) {
+			t.Fatalf("expected at least %d args, got %d", len(wantArgs), len(args))
 		}
-		tailArgs := args[len(args)-4:]
+		tailArgs := args[len(args)-len(wantArgs):]
 		if diff := cmp.Diff(wantArgs, tailArgs); diff != "" {
 			t.Errorf("TLS args mismatch (-want +got):\n%s", diff)
+		}
+		serverName := tailArgs[len(tailArgs)-2]
+		if strings.Contains(serverName, cellObj.Spec.CertCommonName) {
+			t.Errorf(
+				"multipooler gRPC server name %q must not contain public CertCommonName %q",
+				serverName,
+				cellObj.Spec.CertCommonName,
+			)
 		}
 	})
 
@@ -2136,7 +2209,13 @@ func TestBuildMultigatewayDeployment_TLS(t *testing.T) {
 		// No TLS args should be present
 		container := deploy.Spec.Template.Spec.Containers[0]
 		for _, arg := range container.Args {
-			if arg == "--pg-tls-cert-file" || arg == "--pg-tls-key-file" {
+			if arg == "--pg-tls-cert-file" ||
+				arg == "--pg-tls-key-file" ||
+				arg == "--grpc-cert" ||
+				arg == "--grpc-key" ||
+				arg == "--grpc-ca" ||
+				arg == "--grpc-server-ca" ||
+				strings.HasPrefix(arg, "--multipooler-grpc-") {
 				t.Errorf("TLS arg %q should not be present when CertCommonName is empty", arg)
 			}
 		}

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -99,6 +99,20 @@ const (
 	// PgBackRestCipherKeyFilePath is the full path to the mounted cipher key
 	// file, passed to multipooler via --pgbackrest-cipher-key-file.
 	PgBackRestCipherKeyFilePath = PgBackRestCipherKeyMountPath + "/" + PgBackRestCipherKeyDataKey
+	// ShardTLSVolumeName is the volume for the generated shard-side mTLS Secret.
+	ShardTLSVolumeName = "tls-certs"
+
+	// ShardTLSMountPath is where shard-side mTLS certificates are mounted.
+	ShardTLSMountPath = "/etc/multigres/tls"
+
+	// ShardTLSCertFile is the mounted certificate path from the generated Secret.
+	ShardTLSCertFile = ShardTLSMountPath + "/tls.crt"
+
+	// ShardTLSKeyFile is the mounted private key path from the generated Secret.
+	ShardTLSKeyFile = ShardTLSMountPath + "/tls.key"
+
+	// ShardTLSCAFile is the mounted CA certificate path from the generated Secret.
+	ShardTLSCAFile = ShardTLSMountPath + "/ca.crt"
 
 	// DefaultMultipoolerConnPoolGlobalCapacity keeps multipooler below pgctld's
 	// small default max_connections so admin and internal connections have headroom.
@@ -167,6 +181,35 @@ func postgresPasswordVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      PostgresPasswordVolumeName,
 		MountPath: PostgresPasswordMountPath,
+		ReadOnly:  true,
+	}
+}
+
+func shardTLSConfigured(shard *multigresv1alpha1.Shard) bool {
+	return shard.Spec.CertCommonName != ""
+}
+
+func buildShardTLSVolume(shard *multigresv1alpha1.Shard, component string) corev1.Volume {
+	defaultMode := int32(0o444)
+	return corev1.Volume{
+		Name: ShardTLSVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: multigresv1alpha1.ComponentCertSecretName(
+					component,
+					shard.Labels[metadata.LabelMultigresCluster],
+					shard.Namespace,
+				),
+				DefaultMode: &defaultMode,
+			},
+		},
+	}
+}
+
+func shardTLSVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      ShardTLSVolumeName,
+		MountPath: ShardTLSMountPath,
 		ReadOnly:  true,
 	}
 }
@@ -413,6 +456,14 @@ func buildMultipoolerContainer(
 			"--pgbackrest-ca-file="+PgBackRestCertMountPath+"/ca.crt",
 		)
 	}
+	if shardTLSConfigured(shard) {
+		args = append(args,
+			"--grpc-cert", ShardTLSCertFile,
+			"--grpc-key", ShardTLSKeyFile,
+			"--grpc-ca", ShardTLSCAFile,
+			"--grpc-server-ca", ShardTLSCAFile,
+		)
+	}
 
 	if shard.Spec.Backup != nil && shard.Spec.Backup.Encryption != nil {
 		args = append(args,
@@ -500,6 +551,10 @@ func buildMultipoolerContainer(
 			ReadOnly:  true,
 		})
 	}
+
+	if shardTLSConfigured(shard) {
+		c.VolumeMounts = append(c.VolumeMounts, shardTLSVolumeMount())
+	}
 	if _, otelMount := multigresv1alpha1.BuildOTELSamplingVolume(
 		shard.Spec.Observability,
 	); otelMount != nil {
@@ -527,6 +582,24 @@ func buildMultiorchContainer(shard *multigresv1alpha1.Shard, cellName string) co
 		"--cell=" + cellName,
 		"--watch-targets=" + watchTarget,
 		"--log-level=" + string(shard.Spec.LogLevels.Multiorch),
+	}
+	if shardTLSConfigured(shard) {
+		args = append(args,
+			"--grpc-cert", ShardTLSCertFile,
+			"--grpc-key", ShardTLSKeyFile,
+			"--grpc-ca", ShardTLSCAFile,
+			"--grpc-server-ca", ShardTLSCAFile,
+			"--multipooler-grpc-cert", ShardTLSCertFile,
+			"--multipooler-grpc-key", ShardTLSKeyFile,
+			"--multipooler-grpc-ca", ShardTLSCAFile,
+			"--multipooler-grpc-server-name",
+			multigresv1alpha1.ComponentCertCommonName(
+				multigresv1alpha1.ComponentMultiPoolerTLS,
+				shard.Labels[metadata.LabelMultigresCluster],
+				shard.Namespace,
+			),
+			"--multipooler-grpc-require-tls",
+		)
 	}
 
 	c := corev1.Container{
@@ -571,6 +644,9 @@ func buildMultiorchContainer(shard *multigresv1alpha1.Shard, cellName string) co
 		shard.Spec.Observability,
 	); otelMount != nil {
 		c.VolumeMounts = append(c.VolumeMounts, *otelMount)
+	}
+	if shardTLSConfigured(shard) {
+		c.VolumeMounts = append(c.VolumeMounts, shardTLSVolumeMount())
 	}
 	return c
 }
@@ -626,6 +702,12 @@ func buildPoolVolumes(shard *multigresv1alpha1.Shard, cellName string) []corev1.
 	}
 	if cipherVol := buildPgBackRestCipherKeyVolume(shard); cipherVol != nil {
 		volumes = append(volumes, *cipherVol)
+	}
+	if shardTLSConfigured(shard) {
+		volumes = append(volumes, buildShardTLSVolume(
+			shard,
+			multigresv1alpha1.ComponentMultiPoolerTLS,
+		))
 	}
 	if otelVol, _ := multigresv1alpha1.BuildOTELSamplingVolume(
 		shard.Spec.Observability,

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -1071,6 +1071,127 @@ func TestBuildMultiorchContainer_WithObservability(t *testing.T) {
 	assertOTELResourceAttribute(t, c.Env, "multigres.component=multiorch")
 }
 
+func TestShardTLSContainerArgsAndMounts(t *testing.T) {
+	baseShard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-shard",
+			Namespace: "default",
+			Labels:    map[string]string{"multigres.com/cluster": "test"},
+		},
+		Spec: multigresv1alpha1.ShardSpec{
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+				Address:  "topo:2379",
+				RootPath: "/multigres/global",
+			},
+			DatabaseName:   "db",
+			TableGroupName: "tg",
+			ShardName:      "s1",
+		},
+	}
+
+	t.Run("multipooler gets grpc server mTLS flags and mount", func(t *testing.T) {
+		shard := baseShard.DeepCopy()
+		shard.Spec.CertCommonName = "db.abc123.supabase.red"
+
+		c := buildMultipoolerContainer(
+			shard,
+			multigresv1alpha1.PoolSpec{},
+			"primary",
+			"zone1",
+			"p-tls1234",
+		)
+
+		assertContainsFlag(t, c.Args, "--grpc-cert")
+		assertContainsFlag(t, c.Args, ShardTLSCertFile)
+		assertContainsFlag(t, c.Args, "--grpc-key")
+		assertContainsFlag(t, c.Args, ShardTLSKeyFile)
+		assertContainsFlag(t, c.Args, "--grpc-ca")
+		assertContainsFlag(t, c.Args, ShardTLSCAFile)
+		assertContainsFlag(t, c.Args, "--grpc-server-ca")
+		assertContainsFlag(t, c.Args, ShardTLSCAFile)
+		assertReadOnlyVolumeMount(t, c.VolumeMounts, ShardTLSVolumeName, ShardTLSMountPath)
+	})
+
+	t.Run("multipooler omits shard mTLS when certCommonName is empty", func(t *testing.T) {
+		c := buildMultipoolerContainer(
+			baseShard.DeepCopy(),
+			multigresv1alpha1.PoolSpec{},
+			"primary",
+			"zone1",
+			"p-plain12",
+		)
+
+		assertNotContainsFlag(t, c.Args, "--grpc-cert")
+		assertNotContainsFlag(t, c.Args, "--grpc-key")
+		assertNotContainsFlag(t, c.Args, "--grpc-ca")
+		assertNotContainsFlag(t, c.Args, "--grpc-server-ca")
+		assertNotContainsVolumeMount(t, c.VolumeMounts, ShardTLSVolumeName)
+	})
+
+	t.Run("multiorch gets multipooler client mTLS flags and mount", func(t *testing.T) {
+		shard := baseShard.DeepCopy()
+		shard.Spec.CertCommonName = "db.abc123.supabase.red"
+
+		c := buildMultiorchContainer(shard, "zone1")
+
+		assertContainsFlag(t, c.Args, "--grpc-cert")
+		assertContainsFlag(t, c.Args, ShardTLSCertFile)
+		assertContainsFlag(t, c.Args, "--grpc-key")
+		assertContainsFlag(t, c.Args, ShardTLSKeyFile)
+		assertContainsFlag(t, c.Args, "--grpc-ca")
+		assertContainsFlag(t, c.Args, ShardTLSCAFile)
+		assertContainsFlag(t, c.Args, "--grpc-server-ca")
+		assertContainsFlag(t, c.Args, ShardTLSCAFile)
+		assertContainsFlag(t, c.Args, "--multipooler-grpc-cert")
+		assertContainsFlag(t, c.Args, ShardTLSCertFile)
+		assertContainsFlag(t, c.Args, "--multipooler-grpc-key")
+		assertContainsFlag(t, c.Args, ShardTLSKeyFile)
+		assertContainsFlag(t, c.Args, "--multipooler-grpc-ca")
+		assertContainsFlag(t, c.Args, ShardTLSCAFile)
+		const serverNameFlag = "--multipooler-grpc-server-name"
+		assertContainsFlag(t, c.Args, serverNameFlag)
+		for i, arg := range c.Args {
+			if arg != serverNameFlag {
+				continue
+			}
+			if i+1 >= len(c.Args) {
+				t.Fatalf("%s has no value", serverNameFlag)
+			}
+			serverName := c.Args[i+1]
+			wantServerName := "multipooler.test.default.multigres.internal"
+			if serverName != wantServerName {
+				t.Errorf("%s = %q, want %q", serverNameFlag, serverName, wantServerName)
+			}
+			if strings.Contains(serverName, shard.Spec.CertCommonName) {
+				t.Errorf(
+					"%s %q must not contain public CertCommonName %q",
+					serverNameFlag,
+					serverName,
+					shard.Spec.CertCommonName,
+				)
+			}
+			break
+		}
+		assertContainsFlag(t, c.Args, "--multipooler-grpc-require-tls")
+		assertReadOnlyVolumeMount(t, c.VolumeMounts, ShardTLSVolumeName, ShardTLSMountPath)
+	})
+
+	t.Run("multiorch omits shard mTLS when certCommonName is empty", func(t *testing.T) {
+		c := buildMultiorchContainer(baseShard.DeepCopy(), "zone1")
+
+		assertNotContainsFlag(t, c.Args, "--multipooler-grpc-cert")
+		assertNotContainsFlag(t, c.Args, "--multipooler-grpc-key")
+		assertNotContainsFlag(t, c.Args, "--multipooler-grpc-ca")
+		assertNotContainsFlag(t, c.Args, "--multipooler-grpc-server-name")
+		assertNotContainsFlag(t, c.Args, "--multipooler-grpc-require-tls")
+		assertNotContainsFlag(t, c.Args, "--grpc-cert")
+		assertNotContainsFlag(t, c.Args, "--grpc-key")
+		assertNotContainsFlag(t, c.Args, "--grpc-ca")
+		assertNotContainsFlag(t, c.Args, "--grpc-server-ca")
+		assertNotContainsVolumeMount(t, c.VolumeMounts, ShardTLSVolumeName)
+	})
+}
+
 func assertContainsOTELEnvVar(t *testing.T, envVars []corev1.EnvVar, fnName string) {
 	t.Helper()
 	for _, e := range envVars {
@@ -1715,6 +1836,69 @@ func TestBuildPoolVolumes_CertVolumePresence(t *testing.T) {
 		for _, v := range volumes {
 			if v.Name == PostgresConfigVolumeName {
 				t.Error("should not have postgres config volume when postgresConfigRef is nil")
+			}
+		}
+	})
+
+	t.Run("shard tls volume present when certCommonName set", func(t *testing.T) {
+		shard := &multigresv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-shard",
+				Namespace: "default",
+				Labels:    map[string]string{"multigres.com/cluster": "test"},
+			},
+			Spec: multigresv1alpha1.ShardSpec{
+				CertCommonName: "db.abc123.supabase.red",
+			},
+		}
+
+		volumes := buildPoolVolumes(shard, "zone1")
+		for _, v := range volumes {
+			if v.Name != ShardTLSVolumeName {
+				continue
+			}
+			if v.Secret == nil {
+				t.Fatal("shard TLS volume should use Secret source")
+			}
+			wantSecretName := "multipooler.test.default.multigres.internal"
+			if v.Secret.SecretName != wantSecretName {
+				t.Errorf(
+					"shard TLS secret = %q, want %q",
+					v.Secret.SecretName,
+					wantSecretName,
+				)
+			}
+			if strings.Contains(v.Secret.SecretName, shard.Spec.CertCommonName) {
+				t.Errorf(
+					"shard TLS secret %q must not contain public CertCommonName %q",
+					v.Secret.SecretName,
+					shard.Spec.CertCommonName,
+				)
+			}
+			if v.Secret.DefaultMode == nil || *v.Secret.DefaultMode != 0o444 {
+				t.Errorf(
+					"shard TLS secret defaultMode = %v, want 0444",
+					v.Secret.DefaultMode,
+				)
+			}
+			return
+		}
+		t.Error("expected shard TLS volume when certCommonName is set")
+	})
+
+	t.Run("shard tls volume omitted when certCommonName empty", func(t *testing.T) {
+		shard := &multigresv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "test-shard",
+				Labels: map[string]string{"multigres.com/cluster": "test"},
+			},
+			Spec: multigresv1alpha1.ShardSpec{},
+		}
+
+		volumes := buildPoolVolumes(shard, "zone1")
+		for _, v := range volumes {
+			if v.Name == ShardTLSVolumeName {
+				t.Error("shard TLS volume should not be present when certCommonName is empty")
 			}
 		}
 	})

--- a/pkg/resource-handler/controller/shard/multiorch.go
+++ b/pkg/resource-handler/controller/shard/multiorch.go
@@ -84,6 +84,13 @@ func BuildMultiorchDeployment(
 		deployment.Spec.Template.Spec.Volumes = append(
 			deployment.Spec.Template.Spec.Volumes, *otelVol)
 	}
+	if shardTLSConfigured(shard) {
+		deployment.Spec.Template.Spec.Volumes = append(
+			deployment.Spec.Template.Spec.Volumes, buildShardTLSVolume(
+				shard,
+				multigresv1alpha1.ComponentMultiOrchTLS,
+			))
+	}
 
 	if err := ctrl.SetControllerReference(shard, deployment, scheme); err != nil {
 		return nil, fmt.Errorf("failed to set controller reference: %w", err)

--- a/pkg/resource-handler/controller/shard/multiorch_test.go
+++ b/pkg/resource-handler/controller/shard/multiorch_test.go
@@ -1,6 +1,7 @@
 package shard
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -751,6 +752,67 @@ func TestBuildMultiorchDeployment_OmitsPrometheusScrapeAnnotations(t *testing.T)
 	if got := deploy.Spec.Template.Annotations["custom-annotation"]; got != "keep-me" {
 		t.Fatalf("custom annotation = %q, want %q", got, "keep-me")
 	}
+}
+
+func TestBuildMultiorchDeployment_ShardTLSVolume(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-shard",
+			Namespace: "default",
+			UID:       "test-uid",
+			Labels:    map[string]string{metadata.LabelMultigresCluster: "test-cluster"},
+		},
+		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:   "testdb",
+			TableGroupName: "default",
+			ShardName:      "0",
+			CertCommonName: "db.abc123.supabase.red",
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+				Address:  "global-topo:2379",
+				RootPath: "/multigres/global",
+			},
+		},
+	}
+
+	got, err := BuildMultiorchDeployment(shard, "zone-a", scheme)
+	if err != nil {
+		t.Fatalf("BuildMultiorchDeployment() error = %v", err)
+	}
+
+	for _, v := range got.Spec.Template.Spec.Volumes {
+		if v.Name != ShardTLSVolumeName {
+			continue
+		}
+		if v.Secret == nil {
+			t.Fatal("shard TLS volume should use Secret source")
+		}
+		wantSecretName := "multiorch.test-cluster.default.multigres.internal" //nolint:gosec // test constant
+		if v.Secret.SecretName != wantSecretName {
+			t.Errorf(
+				"shard TLS secret = %q, want %q",
+				v.Secret.SecretName,
+				wantSecretName,
+			)
+		}
+		if strings.Contains(v.Secret.SecretName, shard.Spec.CertCommonName) {
+			t.Errorf(
+				"shard TLS secret %q must not contain public CertCommonName %q",
+				v.Secret.SecretName,
+				shard.Spec.CertCommonName,
+			)
+		}
+		if v.Secret.DefaultMode == nil || *v.Secret.DefaultMode != 0o444 {
+			t.Errorf(
+				"shard TLS secret defaultMode = %v, want 0444",
+				v.Secret.DefaultMode,
+			)
+		}
+		return
+	}
+	t.Error("expected shard TLS volume when certCommonName is set")
 }
 
 func TestBuildMultiorchService(t *testing.T) {


### PR DESCRIPTION
## Description

Wire cert-manager-backed TLS/mTLS for managed Multigres workload gRPC
listeners and multipooler-facing clients, using the TLS support added in
multigres/multigres#826.

The operator issues separate certificates and Secrets for multiadmin,
multigateway, multiorch, and multipooler. Their primary logical identities use:

`<component>.<cluster>.<namespace>.multigres.internal`

Public PostgreSQL TLS remains configured separately through the existing
`generated-certs` Secret and `certCommonName`.

### Internal workload traffic policy

When TLS is enabled:

- **multipooler**
  - Its gRPC listener uses its multipooler certificate.
  - The listener requires and verifies client certificates through `--grpc-ca`.

- **multiorch**
  - Its gRPC listener requires and verifies client certificates.
  - multiorch presents its component certificate when calling multipooler.
  - multipooler server certificates are verified against
    `multipooler.<cluster>.<namespace>.multigres.internal`.
  - `--multipooler-grpc-require-tls` prevents plaintext fallback.

- **multiadmin**
  - Its gRPC listener requires and verifies client certificates.
  - multiadmin presents its component certificate when calling multipooler.
  - multipooler server certificates are verified against the logical
    multipooler identity.
  - `--multipooler-grpc-require-tls` prevents plaintext fallback.

- **multigateway**
  - Its gRPC listener is internal-only and requires and verifies client
    certificates through `--grpc-ca`.
  - multigateway presents its component certificate when calling multipooler.
  - multipooler server certificates are verified against the logical
    multipooler identity.
  - `--multipooler-grpc-require-tls` prevents plaintext fallback.

The projected certificate secrets use file modes compatible with non-root
workloads. Stale cert-manager Certificates and their generated Secrets are
removed when certificate names change, with cleanup remaining retryable.

### Current compatibility constraints

Upstream Multigres currently reuses the `--multipooler-grpc-*` transport
configuration for gateway-to-gateway cancel forwarding. multiadmin also reuses
its multipooler transport configuration for RPCs to other component types.

Because those clients currently use the multipooler server-name override, the
multigateway certificate temporarily includes the logical multipooler SAN.
Destination-specific upstream TLS settings are needed before that compatibility
SAN can be removed.

### Enablement

Internal workload TLS is currently enabled when
`MultigresCluster.spec.certCommonName` is set. Clusters without
`certCommonName` remain unchanged.

Internal and public certificates currently use the same configured
`supabase-issuer`. Separating internal TLS enablement and issuer configuration
from the public PostgreSQL certificate remains follow-up work.