### PR TITLE
fix(build): bump Go to 1.26.5 to clear CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Containerfile for multigres-operator
 
-FROM --platform=$BUILDPLATFORM golang:1.26.0-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/multigres/multigres-operator
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/tools/observer/Dockerfile
+++ b/tools/observer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.0-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/tools/observer/go.mod
+++ b/tools/observer/go.mod
@@ -1,6 +1,6 @@
 module github.com/multigres/multigres-operator/tools/observer
 
-go 1.26
+go 1.26.5
 
 // Keep the observer compiled against the operator API in this repository.
 replace github.com/multigres/multigres-operator => ../..


### PR DESCRIPTION
this pr bumps the Go toolchain and container builders from 1.26.0 to 1.26.5.

This clears Go std library vulnerabilities reported by Grype, including GO-2026-5037, CVE-2026-27145, and CVE-2026-33811, and unblocks the main image-publish workflow.

The operator and observer Go versions are updated together to keep local development, CI, and container builds consistent.