### PR TITLE
ci(compat): add nightly upstream compatibility canary

### DIFF
--- a/.github/workflows/_reusable-e2e.yaml
+++ b/.github/workflows/_reusable-e2e.yaml
@@ -36,34 +36,35 @@ on:
       # replace the whole data plane (nightly compatibility), selected
       # components (version-skew), or only postgres (custom Postgres builds).
       # An empty input leaves that component unset in the test CR, so the
-      # checked-out operator applies its compiled-in default.
+      # checked-out operator applies its compiled-in default. Non-empty values
+      # must be fully qualified OCI references with either a tag or sha256 digest.
       postgres-image:
-        description: Override the postgres/pgctld image in every e2e MultigresCluster
+        description: Fully qualified postgres/pgctld OCI image override
         default: ''
         required: false
         type: string
       multiadmin-image:
-        description: Override the multiadmin image in every e2e MultigresCluster
+        description: Fully qualified multiadmin OCI image override
         default: ''
         required: false
         type: string
       multiadmin-web-image:
-        description: Override the multiadmin-web image in every e2e MultigresCluster
+        description: Fully qualified multiadmin-web OCI image override
         default: ''
         required: false
         type: string
       multiorch-image:
-        description: Override the multiorch image in every e2e MultigresCluster
+        description: Fully qualified multiorch OCI image override
         default: ''
         required: false
         type: string
       multipooler-image:
-        description: Override the multipooler image in every e2e MultigresCluster
+        description: Fully qualified multipooler OCI image override
         default: ''
         required: false
         type: string
       multigateway-image:
-        description: Override the multigateway image in every e2e MultigresCluster
+        description: Fully qualified multigateway OCI image override
         default: ''
         required: false
         type: string
@@ -127,6 +128,16 @@ jobs:
           MULTIPOOLER_IMAGE: ${{ inputs.multipooler-image }}
           MULTIGATEWAY_IMAGE: ${{ inputs.multigateway-image }}
         run: |
+          validate_image() {
+            local image="$1"
+            [ -z "$image" ] ||
+              [[ "$image" =~ ^[a-z0-9.-]+(:[0-9]+)?/[a-z0-9._/-]+(:[A-Za-z0-9_][A-Za-z0-9._-]{0,127}|@sha256:[0-9a-f]{64})$ ]] ||
+              {
+                echo "::error::Invalid OCI image reference"
+                return 1
+              }
+          }
+
           replace_default() {
             local constant="$1"
             local image="$2"
@@ -137,6 +148,13 @@ jobs:
               api/v1alpha1/image_defaults.go
             grep -F "${constant} = \"${image}\"" api/v1alpha1/image_defaults.go
           }
+
+          validate_image "$POSTGRES_IMAGE"
+          validate_image "$MULTIADMIN_IMAGE"
+          validate_image "$MULTIADMIN_WEB_IMAGE"
+          validate_image "$MULTIORCH_IMAGE"
+          validate_image "$MULTIPOOLER_IMAGE"
+          validate_image "$MULTIGATEWAY_IMAGE"
 
           replace_default DefaultPostgresImage "$POSTGRES_IMAGE"
           replace_default DefaultMultiadminImage "$MULTIADMIN_IMAGE"
@@ -186,25 +204,41 @@ jobs:
             make pull-e2e-images
 
       - name: Compute test packages
-        id: packages
+        env:
+          MODE: ${{ inputs.mode }}
+          TEST_SPEC: ${{ inputs.test-spec }}
         run: |
-          mode="${{ inputs.mode }}"
-          spec="${{ inputs.test-spec }}"
-          if [ -z "$spec" ]; then
-            echo "packages=./test/e2e/${mode}/..." >> "$GITHUB_OUTPUT"
+          case "$MODE" in
+            shared | dedicated) ;;
+            *)
+              echo "::error::Mode must be 'shared' or 'dedicated'"
+              exit 1
+              ;;
+          esac
+
+          package_file="$RUNNER_TEMP/e2e-packages"
+          if [ -z "$TEST_SPEC" ]; then
+            printf './test/e2e/%s/...\n' "$MODE" > "$package_file"
           else
-            pkgs=""
-            for t in $(echo "$spec" | tr ',' ' '); do
-              pkgs="$pkgs ./test/e2e/${mode}/${t}/"
+            : > "$package_file"
+            IFS=',' read -r -a tests <<< "$TEST_SPEC"
+            for test_name in "${tests[@]}"; do
+              [[ "$test_name" =~ ^[a-z0-9][a-z0-9_-]*$ ]] ||
+                {
+                  echo "::error::Invalid e2e test name"
+                  exit 1
+                }
+              package="./test/e2e/${MODE}/${test_name}/"
+              [ -d "$package" ] ||
+                {
+                  echo "::error::Unknown e2e test '$test_name' for mode '$MODE'"
+                  exit 1
+                }
+              printf '%s\n' "$package" >> "$package_file"
             done
-            echo "packages=$pkgs" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run e2e tests
-        run: |
-          OPERATOR_IMG=$(make -s print-img) \
-          REPO_ROOT=$(pwd) \
-          go test -tags=e2e ${{ steps.packages.outputs.packages }} -v -count=1 -timeout=${{ inputs.timeout-minutes }}m
         env:
           E2E_KEEP_CLUSTERS: never
           E2E_POSTGRES_IMAGE: ${{ inputs.postgres-image }}
@@ -213,6 +247,24 @@ jobs:
           E2E_MULTIORCH_IMAGE: ${{ inputs.multiorch-image }}
           E2E_MULTIPOOLER_IMAGE: ${{ inputs.multipooler-image }}
           E2E_MULTIGATEWAY_IMAGE: ${{ inputs.multigateway-image }}
+          TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+        run: |
+          [[ "$TIMEOUT_MINUTES" =~ ^[0-9]+$ ]] ||
+            {
+              echo "::error::Timeout must be a whole number of minutes"
+              exit 1
+            }
+          mapfile -t packages < "$RUNNER_TEMP/e2e-packages"
+          [ "${#packages[@]}" -gt 0 ] ||
+            {
+              echo "::error::No e2e test packages selected"
+              exit 1
+            }
+
+          OPERATOR_IMG="$(make -s print-img)" \
+          REPO_ROOT="$GITHUB_WORKSPACE" \
+          go test -tags=e2e "${packages[@]}" -v -count=1 \
+            "-timeout=${TIMEOUT_MINUTES}m"
 
       - name: Collect Kind logs on failure
         if: failure()

--- a/.github/workflows/_reusable-e2e.yaml
+++ b/.github/workflows/_reusable-e2e.yaml
@@ -32,6 +32,41 @@ on:
         default: ''
         required: false
         type: string
+      # Component image overrides are deliberately independent. Callers can
+      # replace the whole data plane (nightly compatibility), selected
+      # components (version-skew), or only postgres (custom Postgres builds).
+      # An empty input leaves that component unset in the test CR, so the
+      # checked-out operator applies its compiled-in default.
+      postgres-image:
+        description: Override the postgres/pgctld image in every e2e MultigresCluster
+        default: ''
+        required: false
+        type: string
+      multiadmin-image:
+        description: Override the multiadmin image in every e2e MultigresCluster
+        default: ''
+        required: false
+        type: string
+      multiadmin-web-image:
+        description: Override the multiadmin-web image in every e2e MultigresCluster
+        default: ''
+        required: false
+        type: string
+      multiorch-image:
+        description: Override the multiorch image in every e2e MultigresCluster
+        default: ''
+        required: false
+        type: string
+      multipooler-image:
+        description: Override the multipooler image in every e2e MultigresCluster
+        default: ''
+        required: false
+        type: string
+      multigateway-image:
+        description: Override the multigateway image in every e2e MultigresCluster
+        default: ''
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -46,6 +81,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -79,12 +115,75 @@ jobs:
         if: inputs.operator-image-artifact != ''
         run: docker load -i /tmp/operator-image.tar
 
+      # This source-level override keeps `ref: <old-operator-commit>` useful:
+      # refs predating E2E_* support still compile the requested runtime images
+      # into the operator. Current refs also apply the same values to test CRs.
+      - name: Apply runtime image overrides
+        env:
+          POSTGRES_IMAGE: ${{ inputs.postgres-image }}
+          MULTIADMIN_IMAGE: ${{ inputs.multiadmin-image }}
+          MULTIADMIN_WEB_IMAGE: ${{ inputs.multiadmin-web-image }}
+          MULTIORCH_IMAGE: ${{ inputs.multiorch-image }}
+          MULTIPOOLER_IMAGE: ${{ inputs.multipooler-image }}
+          MULTIGATEWAY_IMAGE: ${{ inputs.multigateway-image }}
+        run: |
+          replace_default() {
+            local constant="$1"
+            local image="$2"
+            [ -n "$image" ] || return 0
+            local escaped="${image//&/\\&}"
+            sed -i -E \
+              "s|(${constant}[[:space:]]*=[[:space:]]*\")[^\"]+\"|\\1${escaped}\"|" \
+              api/v1alpha1/image_defaults.go
+            grep -F "${constant} = \"${image}\"" api/v1alpha1/image_defaults.go
+          }
+
+          replace_default DefaultPostgresImage "$POSTGRES_IMAGE"
+          replace_default DefaultMultiadminImage "$MULTIADMIN_IMAGE"
+          replace_default DefaultMultiadminWebImage "$MULTIADMIN_WEB_IMAGE"
+          replace_default DefaultMultiorchImage "$MULTIORCH_IMAGE"
+          replace_default DefaultMultipoolerImage "$MULTIPOOLER_IMAGE"
+          replace_default DefaultMultigatewayImage "$MULTIGATEWAY_IMAGE"
+
       - name: Build operator image
         if: inputs.operator-image-artifact == ''
         run: make container
 
       - name: Pull e2e images
-        run: make pull-e2e-images
+        env:
+          POSTGRES_IMAGE: ${{ inputs.postgres-image }}
+          MULTIADMIN_IMAGE: ${{ inputs.multiadmin-image }}
+          MULTIADMIN_WEB_IMAGE: ${{ inputs.multiadmin-web-image }}
+          MULTIORCH_IMAGE: ${{ inputs.multiorch-image }}
+          MULTIPOOLER_IMAGE: ${{ inputs.multipooler-image }}
+          MULTIGATEWAY_IMAGE: ${{ inputs.multigateway-image }}
+        run: |
+          images=("gcr.io/etcd-development/etcd:v3.6.7")
+
+          # One upstream multigres image supplies all four Go components.
+          if [ -z "$MULTIADMIN_IMAGE" ] ||
+             [ -z "$MULTIORCH_IMAGE" ] ||
+             [ -z "$MULTIPOOLER_IMAGE" ] ||
+             [ -z "$MULTIGATEWAY_IMAGE" ]; then
+            images+=("ghcr.io/multigres/multigres:main")
+          fi
+          [ -n "$POSTGRES_IMAGE" ] ||
+            images+=("ghcr.io/multigres/pgctld:main")
+          [ -n "$MULTIADMIN_WEB_IMAGE" ] ||
+            images+=("ghcr.io/multigres/multiadmin-web:main")
+
+          for image in \
+            "$POSTGRES_IMAGE" \
+            "$MULTIADMIN_IMAGE" \
+            "$MULTIADMIN_WEB_IMAGE" \
+            "$MULTIORCH_IMAGE" \
+            "$MULTIPOOLER_IMAGE" \
+            "$MULTIGATEWAY_IMAGE"; do
+            [ -z "$image" ] || images+=("$image")
+          done
+
+          E2E_IMAGES="$(printf '%s\n' "${images[@]}" | sort -u | tr '\n' ' ')" \
+            make pull-e2e-images
 
       - name: Compute test packages
         id: packages
@@ -108,6 +207,12 @@ jobs:
           go test -tags=e2e ${{ steps.packages.outputs.packages }} -v -count=1 -timeout=${{ inputs.timeout-minutes }}m
         env:
           E2E_KEEP_CLUSTERS: never
+          E2E_POSTGRES_IMAGE: ${{ inputs.postgres-image }}
+          E2E_MULTIADMIN_IMAGE: ${{ inputs.multiadmin-image }}
+          E2E_MULTIADMIN_WEB_IMAGE: ${{ inputs.multiadmin-web-image }}
+          E2E_MULTIORCH_IMAGE: ${{ inputs.multiorch-image }}
+          E2E_MULTIPOOLER_IMAGE: ${{ inputs.multipooler-image }}
+          E2E_MULTIGATEWAY_IMAGE: ${{ inputs.multigateway-image }}
 
       - name: Collect Kind logs on failure
         if: failure()

--- a/.github/workflows/nightly-compatibility.yaml
+++ b/.github/workflows/nightly-compatibility.yaml
@@ -1,14 +1,11 @@
 name: Nightly upstream compatibility
 
 on:
-  repository_dispatch:
-    types: [nightly-published]
-# Fallback if the post-publish repository dispatch is missed. Each run selects
-# only a fully successful upstream nightly build; an in-progress build is never
-# consumed. A SHA already recorded green is skipped, while failed attempts may
-# be retried.
+# Poll once after the upstream 05:00 UTC build. The run selects only a fully
+# successful nightly build; an in-progress build is never consumed. A SHA
+# already recorded green is skipped, while failures can be retried manually.
   schedule:
-    - cron: "0 7,9,11 * * *"
+    - cron: "0 9 * * *"
   workflow_dispatch:
     inputs:
       upstream-sha:
@@ -34,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: read
+      actions: read # Read prior canary runs and green-state artifacts.
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
       short-sha: ${{ steps.resolve.outputs.short_sha }}
@@ -62,7 +59,7 @@ jobs:
               },
             );
             const canonicalRuns = runs
-              .filter((run) => ['schedule', 'repository_dispatch'].includes(run.event))
+              .filter((run) => run.event === 'schedule')
               .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
             for (const run of canonicalRuns) {
               const { data } = await github.rest.actions.listWorkflowRunArtifacts({
@@ -86,12 +83,10 @@ jobs:
       - name: Resolve upstream SHA
         id: resolve
         env:
-          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
           INPUT_SHA: ${{ inputs.upstream-sha }}
           INPUT_OPERATOR_REF: ${{ inputs.operator-ref }}
         run: |
-          sha="$DISPATCH_SHA"
-          [ -n "$sha" ] || sha="$INPUT_SHA"
+          sha="$INPUT_SHA"
           if [ -z "$sha" ]; then
             run_id="$(
               curl --fail --retry 3 --silent --show-error \
@@ -137,38 +132,22 @@ jobs:
             echo "multiadmin_web_image=ghcr.io/multigres/multiadmin-web:nightly-sha-$short_sha"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        with:
-          app-id: ${{ vars.MULTIGRES_BOT_APP_ID }}
-          private-key: ${{ secrets.MULTIGRES_BOT_APP_PRIVATE_KEY }}
-          owner: multigres
-          repositories: multigres
-          permission-contents: read
-
       - name: Validate and gate upstream SHA
         id: gate
         env:
           SHA: ${{ steps.resolve.outputs.sha }}
           OPERATOR_REF: ${{ steps.resolve.outputs.operator_ref }}
           EVENT_NAME: ${{ github.event_name }}
-          DISPATCH_SENDER: ${{ github.event.sender.login }}
-          EXPECTED_SENDER: ${{ steps.app-token.outputs.app-slug }}[bot]
           LAST_GREEN_SHA: ${{ steps.last-green.outputs.sha }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
-            [ -n "$EXPECTED_SENDER" ] &&
-              [ "${DISPATCH_SENDER,,}" = "${EXPECTED_SENDER,,}" ] ||
-              {
-                echo "::error::nightly-published dispatch came from an unexpected sender"
-                exit 1
-              }
-          fi
-
-          gh api "repos/multigres/multigres/compare/main...$SHA" --jq '.status' |
-            grep -qE '^(identical|behind)$' ||
+          relation="$(
+            curl --fail --retry 3 --silent --show-error \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/multigres/multigres/compare/main...$SHA" |
+              jq -r '.status'
+          )"
+          [[ "$relation" =~ ^(identical|behind)$ ]] ||
             { echo "::error::SHA is not on multigres/main"; exit 1; }
 
           should_run=true
@@ -176,9 +155,11 @@ jobs:
              [ "$OPERATOR_REF" = "main" ] &&
              [ -n "$LAST_GREEN_SHA" ]; then
             relation="$(
-              gh api \
-                "repos/multigres/multigres/compare/$LAST_GREEN_SHA...$SHA" \
-                --jq '.status'
+              curl --fail --retry 3 --silent --show-error \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/multigres/multigres/compare/$LAST_GREEN_SHA...$SHA" |
+                jq -r '.status'
             )"
             case "$relation" in
               identical | behind)
@@ -206,12 +187,20 @@ jobs:
     if: needs.resolve.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions: {}
+    permissions:
+      attestations: read # Fetch signed provenance from GitHub.
+      packages: read # Authenticate to GHCR for OCI verification.
     outputs:
       multigres-image: ${{ steps.images.outputs.multigres_image }}
       pgctld-image: ${{ steps.images.outputs.pgctld_image }}
       multiadmin-web-image: ${{ steps.images.outputs.multiadmin_web_image }}
     steps:
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_USER: ${{ github.actor }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
       - name: Resolve immutable nightly image digests
         id: images
         env:
@@ -235,6 +224,47 @@ jobs:
             echo "pgctld_image=$(resolve_digest "$PGCTLD_IMAGE")"
             echo "multiadmin_web_image=$(resolve_digest "$MULTIADMIN_WEB_IMAGE")"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Verify nightly image provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM_SHA: ${{ needs.resolve.outputs.sha }}
+          MULTIGRES_IMAGE: ${{ steps.images.outputs.multigres_image }}
+          PGCTLD_IMAGE: ${{ steps.images.outputs.pgctld_image }}
+          MULTIADMIN_WEB_IMAGE: ${{ steps.images.outputs.multiadmin_web_image }}
+        run: |
+          verify_image() {
+            local image="$1"
+            local expected_name="${image%@*}"
+            local verification
+            verification="$(
+              gh attestation verify "oci://$image" \
+                --repo multigres/multigres \
+                --signer-workflow \
+                  multigres/multigres/.github/workflows/nightly-build.yml \
+                --source-ref refs/heads/main \
+                --source-digest "$UPSTREAM_SHA" \
+                --deny-self-hosted-runners \
+                --format json
+            )"
+            jq -e --arg expected_name "$expected_name" '
+              any(
+                .[];
+                any(
+                  .verificationResult.statement.subject[]?;
+                  .name == $expected_name
+                )
+              )
+            ' <<< "$verification" > /dev/null ||
+              {
+                echo "::error::Attestation subject does not match $expected_name"
+                return 1
+              }
+          }
+
+          verify_image "$MULTIGRES_IMAGE"
+          verify_image "$PGCTLD_IMAGE"
+          verify_image "$MULTIADMIN_WEB_IMAGE"
 
   e2e:
     name: Canary e2e
@@ -263,7 +293,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      issues: write
+      issues: write # Create or update the compatibility tracking issue.
     steps:
       - name: Update tracking issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -290,7 +320,7 @@ jobs:
               process.env.E2E_RESULT === 'success';
             const canonicalRun =
               process.env.OPERATOR_REF === 'main' &&
-              ['schedule', 'repository_dispatch'].includes(process.env.EVENT_NAME);
+              process.env.EVENT_NAME === 'schedule';
             const failureStage =
               process.env.RESOLVE_RESULT !== 'success' ? 'SHA resolution/validation' :
               process.env.PREFLIGHT_RESULT !== 'success' ? 'nightly image preflight' :
@@ -415,8 +445,7 @@ jobs:
           needs.preflight.result == 'success' &&
           needs.e2e.result == 'success' &&
           needs.resolve.outputs.operator-ref == 'main' &&
-          (github.event_name == 'schedule' ||
-           github.event_name == 'repository_dispatch')
+          github.event_name == 'schedule'
         env:
           SHA: ${{ needs.resolve.outputs.sha }}
         run: |
@@ -429,8 +458,7 @@ jobs:
           needs.preflight.result == 'success' &&
           needs.e2e.result == 'success' &&
           needs.resolve.outputs.operator-ref == 'main' &&
-          (github.event_name == 'schedule' ||
-           github.event_name == 'repository_dispatch')
+          github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nightly-compatibility-green-${{ needs.resolve.outputs.sha }}

--- a/.github/workflows/nightly-compatibility.yaml
+++ b/.github/workflows/nightly-compatibility.yaml
@@ -1,0 +1,452 @@
+name: Nightly upstream compatibility
+
+on:
+  repository_dispatch:
+    types: [nightly-published]
+# Fallback if the post-publish repository dispatch is missed. Each run selects
+# only a fully successful upstream nightly build; an in-progress build is never
+# consumed. A SHA already recorded green is skipped, while failed attempts may
+# be retried.
+  schedule:
+    - cron: "0 7,9,11 * * *"
+  workflow_dispatch:
+    inputs:
+      upstream-sha:
+        description: Full multigres commit SHA (empty uses the latest successful nightly build)
+        required: false
+        default: ""
+        type: string
+      operator-ref:
+        description: Operator ref to test (useful for intentionally testing an incompatible pair)
+        required: false
+        default: main
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: nightly-upstream-compatibility
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Resolve immutable nightly
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      short-sha: ${{ steps.resolve.outputs.short_sha }}
+      operator-ref: ${{ steps.resolve.outputs.operator_ref }}
+      last-green-sha: ${{ steps.last-green.outputs.sha }}
+      should-run: ${{ steps.gate.outputs.should_run }}
+      multigres-image: ${{ steps.resolve.outputs.multigres_image }}
+      pgctld-image: ${{ steps.resolve.outputs.pgctld_image }}
+      multiadmin-web-image: ${{ steps.resolve.outputs.multiadmin_web_image }}
+    steps:
+      - name: Find last green canary
+        id: last-green
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const prefix = 'nightly-compatibility-green-';
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'nightly-compatibility.yaml',
+                status: 'success',
+                per_page: 100,
+              },
+            );
+            const canonicalRuns = runs
+              .filter((run) => ['schedule', 'repository_dispatch'].includes(run.event))
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+            for (const run of canonicalRuns) {
+              const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+              });
+              const artifact = data.artifacts.find((candidate) =>
+                !candidate.expired &&
+                candidate.name.startsWith(prefix) &&
+                /^[0-9a-f]{40}$/.test(candidate.name.slice(prefix.length))
+              );
+              if (artifact) {
+                core.setOutput('sha', artifact.name.slice(prefix.length));
+                return;
+              }
+            }
+            core.setOutput('sha', '');
+
+      - name: Resolve upstream SHA
+        id: resolve
+        env:
+          DISPATCH_SHA: ${{ github.event.client_payload.sha }}
+          INPUT_SHA: ${{ inputs.upstream-sha }}
+          INPUT_OPERATOR_REF: ${{ inputs.operator-ref }}
+        run: |
+          sha="$DISPATCH_SHA"
+          [ -n "$sha" ] || sha="$INPUT_SHA"
+          if [ -z "$sha" ]; then
+            run_id="$(
+              curl --fail --retry 3 --silent --show-error \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/multigres/multigres/actions/workflows/nightly-build.yml/runs?branch=main&status=success&per_page=1" |
+                jq -r '.workflow_runs[0].id // empty'
+            )"
+            [ -n "$run_id" ] ||
+              { echo "::error::No successful upstream nightly build found"; exit 1; }
+            sha="$(
+              curl --fail --retry 3 --silent --show-error \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/multigres/multigres/actions/runs/$run_id/artifacts?per_page=100" |
+                jq -r '
+                  [
+                    .artifacts[]
+                    | select(.expired == false)
+                    | .name
+                    | select(test("^nightly-source-[0-9a-f]{40}$"))
+                    | sub("^nightly-source-"; "")
+                  ][0] // empty
+                '
+            )"
+            [ -n "$sha" ] ||
+              { echo "::error::Successful nightly run $run_id has no source SHA artifact"; exit 1; }
+          fi
+
+          [[ "$sha" =~ ^[0-9a-f]{40}$ ]] ||
+            { echo "::error::Expected a full upstream commit SHA, got '$sha'"; exit 1; }
+          short_sha="${sha:0:7}"
+          operator_ref="${INPUT_OPERATOR_REF:-main}"
+          [[ "$operator_ref" =~ ^[A-Za-z0-9._/@+-]+$ ]] ||
+            { echo "::error::Invalid operator ref '$operator_ref'"; exit 1; }
+
+          {
+            echo "sha=$sha"
+            echo "short_sha=$short_sha"
+            echo "operator_ref=$operator_ref"
+            echo "multigres_image=ghcr.io/multigres/multigres:nightly-sha-$short_sha"
+            echo "pgctld_image=ghcr.io/multigres/pgctld:nightly-sha-$short_sha"
+            echo "multiadmin_web_image=ghcr.io/multigres/multiadmin-web:nightly-sha-$short_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.MULTIGRES_BOT_APP_ID }}
+          private-key: ${{ secrets.MULTIGRES_BOT_APP_PRIVATE_KEY }}
+          owner: multigres
+          repositories: multigres
+          permission-contents: read
+
+      - name: Validate and gate upstream SHA
+        id: gate
+        env:
+          SHA: ${{ steps.resolve.outputs.sha }}
+          OPERATOR_REF: ${{ steps.resolve.outputs.operator_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_SENDER: ${{ github.event.sender.login }}
+          EXPECTED_SENDER: ${{ steps.app-token.outputs.app-slug }}[bot]
+          LAST_GREEN_SHA: ${{ steps.last-green.outputs.sha }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            [ -n "$EXPECTED_SENDER" ] &&
+              [ "${DISPATCH_SENDER,,}" = "${EXPECTED_SENDER,,}" ] ||
+              {
+                echo "::error::nightly-published dispatch came from an unexpected sender"
+                exit 1
+              }
+          fi
+
+          gh api "repos/multigres/multigres/compare/main...$SHA" --jq '.status' |
+            grep -qE '^(identical|behind)$' ||
+            { echo "::error::SHA is not on multigres/main"; exit 1; }
+
+          should_run=true
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] &&
+             [ "$OPERATOR_REF" = "main" ] &&
+             [ -n "$LAST_GREEN_SHA" ]; then
+            relation="$(
+              gh api \
+                "repos/multigres/multigres/compare/$LAST_GREEN_SHA...$SHA" \
+                --jq '.status'
+            )"
+            case "$relation" in
+              identical | behind)
+                should_run=false
+                ;;
+              ahead)
+                ;;
+              *)
+                echo "::error::Upstream SHA diverges from the last green SHA"
+                exit 1
+                ;;
+            esac
+          fi
+          echo "should_run=$should_run" >> "$GITHUB_OUTPUT"
+
+      - name: Record skipped duplicate or stale request
+        if: steps.gate.outputs.should_run == 'false'
+        env:
+          SHA: ${{ steps.resolve.outputs.sha }}
+        run: echo "Skipping $SHA because it is not newer than the last green SHA."
+
+  preflight:
+    name: Verify immutable nightly
+    needs: resolve
+    if: needs.resolve.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    outputs:
+      multigres-image: ${{ steps.images.outputs.multigres_image }}
+      pgctld-image: ${{ steps.images.outputs.pgctld_image }}
+      multiadmin-web-image: ${{ steps.images.outputs.multiadmin_web_image }}
+    steps:
+      - name: Resolve immutable nightly image digests
+        id: images
+        env:
+          MULTIGRES_IMAGE: ${{ needs.resolve.outputs.multigres-image }}
+          PGCTLD_IMAGE: ${{ needs.resolve.outputs.pgctld-image }}
+          MULTIADMIN_WEB_IMAGE: ${{ needs.resolve.outputs.multiadmin-web-image }}
+        run: |
+          resolve_digest() {
+            local image="$1"
+            local digest
+            digest="$(
+              docker buildx imagetools inspect "$image" \
+                --format '{{json .Manifest}}' |
+                jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))'
+            )"
+            echo "${image%:*}@$digest"
+          }
+
+          {
+            echo "multigres_image=$(resolve_digest "$MULTIGRES_IMAGE")"
+            echo "pgctld_image=$(resolve_digest "$PGCTLD_IMAGE")"
+            echo "multiadmin_web_image=$(resolve_digest "$MULTIADMIN_WEB_IMAGE")"
+          } >> "$GITHUB_OUTPUT"
+
+  e2e:
+    name: Canary e2e
+    needs: [resolve, preflight]
+    if: needs.preflight.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_reusable-e2e.yaml
+    with:
+      ref: ${{ needs.resolve.outputs.operator-ref }}
+      timeout-minutes: 30
+      postgres-image: ${{ needs.preflight.outputs.pgctld-image }}
+      multiadmin-image: ${{ needs.preflight.outputs.multigres-image }}
+      multiadmin-web-image: ${{ needs.preflight.outputs.multiadmin-web-image }}
+      multiorch-image: ${{ needs.preflight.outputs.multigres-image }}
+      multipooler-image: ${{ needs.preflight.outputs.multigres-image }}
+      multigateway-image: ${{ needs.preflight.outputs.multigres-image }}
+
+  report:
+    name: Record compatibility result
+    needs: [resolve, preflight, e2e]
+    if: >-
+      always() &&
+      (needs.resolve.result != 'success' ||
+       needs.resolve.outputs.should-run == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+    steps:
+      - name: Update tracking issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          RESOLVE_RESULT: ${{ needs.resolve.result }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+          EVENT_NAME: ${{ github.event_name }}
+          UPSTREAM_SHA: ${{ needs.resolve.outputs.sha }}
+          SHORT_SHA: ${{ needs.resolve.outputs.short-sha }}
+          LAST_GREEN_SHA: ${{ needs.resolve.outputs.last-green-sha }}
+          OPERATOR_REF: ${{ needs.resolve.outputs.operator-ref }}
+          IMAGE_TAG: nightly-sha-${{ needs.resolve.outputs.short-sha }}
+        with:
+          script: |
+            const marker = '<!-- nightly-compatibility-canary -->';
+            const label = 'upstream-compatibility';
+            const runUrl =
+              `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+            const succeeded =
+              process.env.RESOLVE_RESULT === 'success' &&
+              process.env.PREFLIGHT_RESULT === 'success' &&
+              process.env.E2E_RESULT === 'success';
+            const canonicalRun =
+              process.env.OPERATOR_REF === 'main' &&
+              ['schedule', 'repository_dispatch'].includes(process.env.EVENT_NAME);
+            const failureStage =
+              process.env.RESOLVE_RESULT !== 'success' ? 'SHA resolution/validation' :
+              process.env.PREFLIGHT_RESULT !== 'success' ? 'nightly image preflight' :
+              'operator e2e';
+            const upstreamSha = process.env.UPSTREAM_SHA || 'unknown';
+            const shortSha = process.env.SHORT_SHA || 'unknown';
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'd73a4a',
+                description: 'Compatibility impact from an upstream Multigres change',
+              });
+            }
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+            const tracking = issues.find(
+              (issue) => !issue.pull_request && issue.body?.includes(marker),
+            );
+
+            if (succeeded) {
+              // Diagnostic skew runs must not advance or clear the canonical
+              // main-vs-nightly compatibility state.
+              if (!canonicalRun) {
+                core.info(
+                  `Diagnostic ${process.env.EVENT_NAME} run passed; ` +
+                  'leaving the main canary state unchanged.',
+                );
+                return;
+              }
+              if (tracking) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking.number,
+                  body:
+                    `✅ Compatibility recovered at ` +
+                    `[multigres@${upstreamSha}]` +
+                    `(https://github.com/multigres/multigres/commit/${upstreamSha}). ` +
+                    `[Canary run](${runUrl})`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: tracking.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+              return;
+            }
+
+            const range =
+              process.env.LAST_GREEN_SHA && process.env.UPSTREAM_SHA
+              ? `[${process.env.LAST_GREEN_SHA.slice(0, 7)}...${shortSha}]` +
+                `(https://github.com/multigres/multigres/compare/` +
+                `${process.env.LAST_GREEN_SHA}...${upstreamSha})`
+              : 'Unavailable (this is the first recorded canary result)';
+            const title =
+              `Nightly compatibility canary failing at multigres/${shortSha}`;
+            const body = `${marker}
+            ## Nightly compatibility failure
+
+            The nightly compatibility canary failed during **${failureStage}** for
+            ${process.env.UPSTREAM_SHA
+              ? `[multigres@${upstreamSha}](https://github.com/multigres/multigres/commit/${upstreamSha})`
+              : 'an unresolved upstream SHA'}.
+
+            - **Upstream image tag:** \`${process.env.IMAGE_TAG}\`
+            - **Operator ref:** \`${process.env.OPERATOR_REF}\`
+            - **Range since last green:** ${range}
+            - **Latest failed run:** [GitHub Actions](${runUrl})
+
+            This issue is updated on consecutive nightly failures and closed by the
+            first green canary, so one compatibility breakage produces one issue.
+            `;
+
+            if (tracking) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                title,
+                body,
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: tracking.number,
+                body:
+                  `Still failing during ${failureStage} at \`${upstreamSha}\`. ` +
+                  `[Latest run](${runUrl})`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+            }
+
+      - name: Write green state
+        if: >-
+          needs.resolve.result == 'success' &&
+          needs.preflight.result == 'success' &&
+          needs.e2e.result == 'success' &&
+          needs.resolve.outputs.operator-ref == 'main' &&
+          (github.event_name == 'schedule' ||
+           github.event_name == 'repository_dispatch')
+        env:
+          SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          mkdir -p /tmp/nightly-compatibility
+          echo "$SHA" > /tmp/nightly-compatibility/upstream-sha
+
+      - name: Preserve green state
+        if: >-
+          needs.resolve.result == 'success' &&
+          needs.preflight.result == 'success' &&
+          needs.e2e.result == 'success' &&
+          needs.resolve.outputs.operator-ref == 'main' &&
+          (github.event_name == 'schedule' ||
+           github.event_name == 'repository_dispatch')
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: nightly-compatibility-green-${{ needs.resolve.outputs.sha }}
+          path: /tmp/nightly-compatibility/upstream-sha
+          retention-days: 90
+
+      - name: Fail when canary failed
+        if: >-
+          always() &&
+          (needs.resolve.result != 'success' ||
+           needs.preflight.result != 'success' ||
+           needs.e2e.result != 'success')
+        env:
+          RESOLVE_RESULT: ${{ needs.resolve.result }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+        run: |
+          echo "::error::Canary results: resolve=$RESOLVE_RESULT preflight=$PREFLIGHT_RESULT e2e=$E2E_RESULT"
+          exit 1

--- a/.github/workflows/proto-sync-failure.yaml
+++ b/.github/workflows/proto-sync-failure.yaml
@@ -1,15 +1,11 @@
 name: Proto sync failure tracking
 
-on:
+on: # zizmor: ignore[dangerous-triggers] Observer never loads or executes PR content.
   workflow_run:
     workflows: ["CI"]
     types: [completed]
 
-# workflow_run executes from the default branch, so it can safely record a
-# failure from the bot-created PR without checking out or running PR code.
-permissions:
-  issues: write
-  pull-requests: read
+permissions: {}
 
 concurrency:
   group: proto-sync-failure-tracking
@@ -23,6 +19,9 @@ jobs:
       github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      issues: write # Label the PR and create or update its tracking issue.
+      pull-requests: read # Verify the PR head, branch, body, and bot identity.
     steps:
       - name: Create or update upstream-impact issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8

--- a/.github/workflows/proto-sync-failure.yaml
+++ b/.github/workflows/proto-sync-failure.yaml
@@ -1,0 +1,147 @@
+name: Proto sync failure tracking
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+# workflow_run executes from the default branch, so it can safely record a
+# failure from the bot-created PR without checking out or running PR code.
+permissions:
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: proto-sync-failure-tracking
+  cancel-in-progress: false
+
+jobs:
+  track:
+    name: Surface failed proto sync
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Create or update upstream-impact issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          # Exact App bot login, for example "multigres-bot[bot]".
+          EXPECTED_BOT_LOGIN: ${{ vars.MULTIGRES_BOT_LOGIN }}
+        with:
+          script: |
+            const prs = context.payload.workflow_run.pull_requests;
+            if (!prs?.length) {
+              core.info('The failed CI run is not associated with a pull request.');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prs[0].number,
+            });
+            const expectedRepo = `${context.repo.owner}/${context.repo.repo}`;
+            const branchMatch = pr.head.ref.match(/^chore\/sync-proto-([0-9a-f]{7})$/);
+            const upstreamSha =
+              pr.body?.match(/multigres\/multigres@([0-9a-f]{40})/)?.[1];
+            const matchesSyncShape =
+              pr.head.repo?.full_name === expectedRepo &&
+              pr.user?.type === 'Bot' &&
+              branchMatch &&
+              upstreamSha?.startsWith(branchMatch[1]);
+            if (!matchesSyncShape) {
+              core.info(`PR #${pr.number} is not an automated proto-sync PR.`);
+              return;
+            }
+
+            const expectedBotLogin =
+              process.env.EXPECTED_BOT_LOGIN?.trim().toLowerCase();
+            if (!expectedBotLogin) {
+              core.setFailed(
+                'Could not resolve the expected GitHub App bot identity.',
+              );
+              return;
+            }
+            if (pr.user?.login?.toLowerCase() !== expectedBotLogin) {
+              core.info(
+                `PR #${pr.number} was opened by an unexpected bot identity.`,
+              );
+              return;
+            }
+
+            const label = 'upstream-impact';
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'b60205',
+                description: 'An upstream change requires operator follow-up',
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: [label],
+            });
+
+            const marker = `<!-- proto-sync-failure:${pr.number} -->`;
+            const runUrl = context.payload.workflow_run.html_url;
+            const title = `Proto sync PR #${pr.number} failed CI (${upstreamSha})`;
+            const body = `${marker}
+            ## Upstream proto sync failed
+
+            Automated proto-sync PR #${pr.number} failed CI. This records the
+            upstream impact even if the generated PR is later repaired in place.
+
+            - **Proto-sync PR:** ${pr.html_url}
+            - **Upstream SHA:** \`${upstreamSha}\`
+            - **Failed CI run:** ${runUrl}
+            `;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              labels: label,
+              per_page: 100,
+            });
+            const existing = issues.find(
+              (issue) => !issue.pull_request && issue.body?.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                title,
+                body,
+                state: 'open',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `CI failed again: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+            }

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -140,7 +140,7 @@ func setupCluster(name string) (*Cluster, error) {
 
 	// Load images (batch — single CLI call, idempotent).
 	preset := testutil.DefaultOperatorPreset()
-	imgs := append([]string{preset.Image}, testutil.MultigresImages...)
+	imgs := append([]string{preset.Image}, runtimeImages()...)
 	if err := LoadImages(ctx, name, imgs); err != nil {
 		return nil, fmt.Errorf("load images: %w", err)
 	}

--- a/test/e2e/framework/image_overrides.go
+++ b/test/e2e/framework/image_overrides.go
@@ -1,0 +1,105 @@
+//go:build e2e
+
+package framework
+
+import (
+	"os"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/testutil"
+)
+
+const (
+	postgresImageEnv      = "E2E_POSTGRES_IMAGE"
+	multiadminImageEnv    = "E2E_MULTIADMIN_IMAGE"
+	multiadminWebImageEnv = "E2E_MULTIADMIN_WEB_IMAGE"
+	multiorchImageEnv     = "E2E_MULTIORCH_IMAGE"
+	multipoolerImageEnv   = "E2E_MULTIPOOLER_IMAGE"
+	multigatewayImageEnv  = "E2E_MULTIGATEWAY_IMAGE"
+)
+
+type imageOverrides struct {
+	postgres      string
+	multiadmin    string
+	multiadminWeb string
+	multiorch     string
+	multipooler   string
+	multigateway  string
+}
+
+func imageOverridesFromEnv() imageOverrides {
+	return imageOverrides{
+		postgres:      os.Getenv(postgresImageEnv),
+		multiadmin:    os.Getenv(multiadminImageEnv),
+		multiadminWeb: os.Getenv(multiadminWebImageEnv),
+		multiorch:     os.Getenv(multiorchImageEnv),
+		multipooler:   os.Getenv(multipoolerImageEnv),
+		multigateway:  os.Getenv(multigatewayImageEnv),
+	}
+}
+
+func applyImageOverrides(cluster *multigresv1alpha1.MultigresCluster) {
+	overrides := imageOverridesFromEnv()
+	if overrides.postgres != "" {
+		cluster.Spec.Images.Postgres = multigresv1alpha1.ImageRef(overrides.postgres)
+	}
+	if overrides.multiadmin != "" {
+		cluster.Spec.Images.Multiadmin = multigresv1alpha1.ImageRef(overrides.multiadmin)
+	}
+	if overrides.multiadminWeb != "" {
+		cluster.Spec.Images.MultiadminWeb = multigresv1alpha1.ImageRef(overrides.multiadminWeb)
+	}
+	if overrides.multiorch != "" {
+		cluster.Spec.Images.Multiorch = multigresv1alpha1.ImageRef(overrides.multiorch)
+	}
+	if overrides.multipooler != "" {
+		cluster.Spec.Images.Multipooler = multigresv1alpha1.ImageRef(overrides.multipooler)
+	}
+	if overrides.multigateway != "" {
+		cluster.Spec.Images.Multigateway = multigresv1alpha1.ImageRef(overrides.multigateway)
+	}
+}
+
+// runtimeImages returns exactly the runtime images needed by an e2e cluster.
+// Defaults are retained for components without an override, and duplicate
+// references are removed before loading them into Kind.
+func runtimeImages() []string {
+	overrides := imageOverridesFromEnv()
+	images := []string{testutil.MultigresImages[3]} // etcd is not overridable.
+
+	if overrides.postgres == "" {
+		images = append(images, testutil.MultigresImages[1])
+	} else {
+		images = append(images, overrides.postgres)
+	}
+	if overrides.multiadminWeb == "" {
+		images = append(images, testutil.MultigresImages[2])
+	} else {
+		images = append(images, overrides.multiadminWeb)
+	}
+
+	goComponentOverrides := []string{
+		overrides.multiadmin,
+		overrides.multiorch,
+		overrides.multipooler,
+		overrides.multigateway,
+	}
+	for _, image := range goComponentOverrides {
+		if image == "" {
+			images = append(images, testutil.MultigresImages[0])
+		} else {
+			images = append(images, image)
+		}
+	}
+
+	seen := make(map[string]struct{}, len(images))
+	unique := make([]string, 0, len(images))
+	for _, image := range images {
+		if _, ok := seen[image]; ok {
+			continue
+		}
+		seen[image] = struct{}{}
+		unique = append(unique, image)
+	}
+	return unique
+}

--- a/test/e2e/framework/image_overrides_test.go
+++ b/test/e2e/framework/image_overrides_test.go
@@ -1,0 +1,54 @@
+//go:build e2e
+
+package framework
+
+import (
+	"slices"
+	"testing"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+func TestApplyImageOverrides(t *testing.T) {
+	t.Setenv(postgresImageEnv, "example.test/postgres:custom")
+	t.Setenv(multigatewayImageEnv, "example.test/multigres:gateway")
+
+	cluster := &multigresv1alpha1.MultigresCluster{}
+	applyImageOverrides(cluster)
+
+	if got := string(cluster.Spec.Images.Postgres); got != "example.test/postgres:custom" {
+		t.Fatalf("postgres image = %q", got)
+	}
+	if got := string(cluster.Spec.Images.Multigateway); got != "example.test/multigres:gateway" {
+		t.Fatalf("multigateway image = %q", got)
+	}
+	if cluster.Spec.Images.Multiadmin != "" {
+		t.Fatalf("unset multiadmin override unexpectedly changed to %q", cluster.Spec.Images.Multiadmin)
+	}
+}
+
+func TestRuntimeImagesUsesOverridesAndDeduplicates(t *testing.T) {
+	const multigresNightly = "ghcr.io/multigres/multigres:nightly-sha-abcdef0"
+	t.Setenv(multiadminImageEnv, multigresNightly)
+	t.Setenv(multiorchImageEnv, multigresNightly)
+	t.Setenv(multipoolerImageEnv, multigresNightly)
+	t.Setenv(multigatewayImageEnv, multigresNightly)
+
+	images := runtimeImages()
+	if got := count(images, multigresNightly); got != 1 {
+		t.Fatalf("nightly multigres image occurs %d times in %v", got, images)
+	}
+	if slices.Contains(images, "ghcr.io/multigres/multigres:main") {
+		t.Fatalf("default multigres image retained despite complete override: %v", images)
+	}
+}
+
+func count(values []string, target string) int {
+	total := 0
+	for _, value := range values {
+		if value == target {
+			total++
+		}
+	}
+	return total
+}

--- a/test/e2e/framework/loader.go
+++ b/test/e2e/framework/loader.go
@@ -74,6 +74,7 @@ func MustLoadCluster(repoRelPath, namespace string) *multigresv1alpha1.Multigres
 	for _, obj := range objs {
 		if cr, ok := obj.(*multigresv1alpha1.MultigresCluster); ok {
 			cr.Namespace = namespace
+			applyImageOverrides(cr)
 			WithCIResources(&cr.Spec)
 			return cr
 		}


### PR DESCRIPTION
## Description

this PR adds a nightly compatibility canary that runs the operator’s e2e suite against immutable images from the latest successful Multigres nightly build. It catches runtime wire-level and semantic incompatibilities that Go module compilation cannot detect and preserves failures as actionable tracking issues.

## Main changes

- The upstream nightly records its source SHA and signs its image digests. The operator polls for the latest successful build at 09:00 UTC.
- `nightly-compatibility.yaml` validates the upstream SHA, verifies each image’s digest and provenance, then calls `_reusable-e2e.yaml`.
- `_reusable-e2e.yaml` accepts per-component image overrides. The e2e framework applies them to test clusters and loads the deduplicated image set into Kind.
- Canary failures update one tracking issue with the failing SHA and range since the last green run. A successful scheduled run closes it.
- The existing `sync-multigres-proto.yml` still updates the dependency and opens the sync PR. `proto-sync-failure.yaml` observes failed CI on that PR, verifies its bot identity and expected shape, then creates or updates an upstream-impact issue.
- Security controls include pull-based discovery, signed provenance verification, validated workflow inputs, pinned actions, non-persisted checkout credentials, and job-scoped permissions.

## Testing

Focused Go tests verify that component overrides are applied correctly, unspecified images retain their defaults, and duplicate image references are removed before loading them into Kind. The complete cross-repository dispatch and Docker/Kind path requires published nightly images and will be exercised in GitHub Actions.

Requires https://github.com/multigres/multigres/pull/1323