### PR TITLE
fix(ci): consume attested full-sha nightlies

### DIFF
--- a/.github/workflows/nightly-compatibility.yaml
+++ b/.github/workflows/nightly-compatibility.yaml
@@ -88,32 +88,15 @@ jobs:
         run: |
           sha="$INPUT_SHA"
           if [ -z "$sha" ]; then
-            run_id="$(
-              curl --fail --retry 3 --silent --show-error \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/repos/multigres/multigres/actions/workflows/nightly-build.yml/runs?branch=main&status=success&per_page=1" |
-                jq -r '.workflow_runs[0].id // empty'
-            )"
-            [ -n "$run_id" ] ||
-              { echo "::error::No successful upstream nightly build found"; exit 1; }
             sha="$(
               curl --fail --retry 3 --silent --show-error \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
-                "https://api.github.com/repos/multigres/multigres/actions/runs/$run_id/artifacts?per_page=100" |
-                jq -r '
-                  [
-                    .artifacts[]
-                    | select(.expired == false)
-                    | .name
-                    | select(test("^nightly-source-[0-9a-f]{40}$"))
-                    | sub("^nightly-source-"; "")
-                  ][0] // empty
-                '
+                "https://api.github.com/repos/multigres/multigres/actions/workflows/nightly-build.yml/runs?branch=main&status=success&per_page=1" |
+                jq -r '.workflow_runs[0].head_sha // empty'
             )"
             [ -n "$sha" ] ||
-              { echo "::error::Successful nightly run $run_id has no source SHA artifact"; exit 1; }
+              { echo "::error::No successful upstream nightly build found"; exit 1; }
           fi
 
           [[ "$sha" =~ ^[0-9a-f]{40}$ ]] ||
@@ -127,9 +110,9 @@ jobs:
             echo "sha=$sha"
             echo "short_sha=$short_sha"
             echo "operator_ref=$operator_ref"
-            echo "multigres_image=ghcr.io/multigres/multigres:nightly-sha-$short_sha"
-            echo "pgctld_image=ghcr.io/multigres/pgctld:nightly-sha-$short_sha"
-            echo "multiadmin_web_image=ghcr.io/multigres/multiadmin-web:nightly-sha-$short_sha"
+            echo "multigres_image=ghcr.io/multigres/multigres:nightly-sha-$sha"
+            echo "pgctld_image=ghcr.io/multigres/pgctld:nightly-sha-$sha"
+            echo "multiadmin_web_image=ghcr.io/multigres/multiadmin-web:nightly-sha-$sha"
           } >> "$GITHUB_OUTPUT"
 
       - name: Validate and gate upstream SHA
@@ -188,7 +171,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      attestations: read # Fetch signed provenance from GitHub.
       packages: read # Authenticate to GHCR for OCI verification.
     outputs:
       multigres-image: ${{ steps.images.outputs.multigres_image }}
@@ -240,6 +222,7 @@ jobs:
             verification="$(
               gh attestation verify "oci://$image" \
                 --repo multigres/multigres \
+                --bundle-from-oci \
                 --signer-workflow \
                   multigres/multigres/.github/workflows/nightly-build.yml \
                 --source-ref refs/heads/main \
@@ -306,7 +289,7 @@ jobs:
           SHORT_SHA: ${{ needs.resolve.outputs.short-sha }}
           LAST_GREEN_SHA: ${{ needs.resolve.outputs.last-green-sha }}
           OPERATOR_REF: ${{ needs.resolve.outputs.operator-ref }}
-          IMAGE_TAG: nightly-sha-${{ needs.resolve.outputs.short-sha }}
+          IMAGE_TAG: nightly-sha-${{ needs.resolve.outputs.sha }}
         with:
           script: |
             const marker = '<!-- nightly-compatibility-canary -->';


### PR DESCRIPTION
## Description

this pr updates the nightly compatibility canary to consume the immutable, attested images produced by the Multigres nightly build.

## Main changes

- Reads the source SHA from the latest successful upstream nightly run.
- Uses full-SHA image tags for verification, e2e execution, and failure reporting.
- Verifies provenance directly from each image’s OCI registry bundle.
- Keeps permissions minimal while preserving ancestry validation, digest pinning, and tracking issue behavior.

## Testing

Validated the workflow with `actionlint`, `zizmor`, and `git diff --check`. The updated resolution and verification flow was also checked against a successful upstream nightly build with published full-SHA images and provenance attestations.