### PR TITLE
fix(e2e): handle digest-pinned canary images

### DIFF
--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -80,16 +80,32 @@ func (c *Cluster) CRClient() (client.Client, error) {
 	return client.New(c.RestCfg, client.Options{Scheme: scheme})
 }
 
-// LoadImages loads multiple container images into a Kind cluster in a single
-// `kind load docker-image` call. This is ~2× faster than loading one-by-one
-// because Kind creates one shared archive instead of five separate ones.
+// LoadImages loads locally tagged container images into a Kind cluster in a
+// single `kind load docker-image` call. Digest-pinned images are pulled by
+// Kubernetes instead: Kind's Docker archive import does not preserve a usable
+// name for digest-only references.
 func LoadImages(ctx context.Context, clusterName string, images []string) error {
-	logf("loading %d images into %s...", len(images), clusterName)
+	images = kindLoadableImages(images)
+	if len(images) == 0 {
+		return nil
+	}
+	logf("loading %d locally tagged images into %s...", len(images), clusterName)
 	args := append([]string{"load", "docker-image", "--name", clusterName}, images...)
 	cmd := exec.CommandContext(ctx, "kind", args...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func kindLoadableImages(images []string) []string {
+	loadable := make([]string, 0, len(images))
+	for _, image := range images {
+		if strings.Contains(image, "@") {
+			continue
+		}
+		loadable = append(loadable, image)
+	}
+	return loadable
 }
 
 // ---------------------------------------------------------------------------
@@ -132,7 +148,7 @@ func setupCluster(name string) (*Cluster, error) {
 	// Label nodes with cloud topology labels so pods with nodeSelectors
 	// derived from zoneId/region fields can be scheduled in Kind.
 	if err := labelAllNodes(kubecfg, map[string]string{
-		"topology.k8s.aws/zone-id":     "us-central1-a",
+		"topology.k8s.aws/zone-id":      "us-central1-a",
 		"topology.kubernetes.io/region": "us-central1",
 	}); err != nil {
 		return nil, fmt.Errorf("label kind nodes: %w", err)

--- a/test/e2e/framework/image_overrides_test.go
+++ b/test/e2e/framework/image_overrides_test.go
@@ -43,6 +43,22 @@ func TestRuntimeImagesUsesOverridesAndDeduplicates(t *testing.T) {
 	}
 }
 
+func TestKindLoadableImagesSkipsDigestReferences(t *testing.T) {
+	images := []string{
+		"ghcr.io/multigres/multigres-operator:test",
+		"ghcr.io/multigres/multigres@sha256:6193a83dc4db60c61965a0f1bfac071987569eb8775d9040c0ef5d0a867213b0",
+		"gcr.io/etcd-development/etcd:v3.6.7",
+	}
+	want := []string{
+		"ghcr.io/multigres/multigres-operator:test",
+		"gcr.io/etcd-development/etcd:v3.6.7",
+	}
+
+	if got := kindLoadableImages(images); !slices.Equal(got, want) {
+		t.Fatalf("kindLoadableImages() = %v, want %v", got, want)
+	}
+}
+
 func count(values []string, target string) int {
 	total := 0
 	for _, value := range values {

--- a/test/e2e/shared/webhook/webhook_test.go
+++ b/test/e2e/shared/webhook/webhook_test.go
@@ -33,7 +33,8 @@ func testRemoveCell(t *testing.T) {
 	// Create cluster with 2 cells so we can try removing one.
 	cr := framework.MustLoadCluster("test/e2e/fixtures/base.yaml", ns)
 	cr.Spec.Cells = append(cr.Spec.Cells, multigresv1alpha1.CellConfig{
-		Name: "zone-b",
+		Name:   "zone-b",
+		Region: "us-central1",
 	})
 	if err := c.Create(context.Background(), cr); err != nil {
 		t.Fatalf("create MultigresCluster: %v", err)


### PR DESCRIPTION
## Description

this pr fixes two e2e harness failures exposed by the digest-pinned nightly compatibility canary.

## Main changes

- Lets Kubernetes pull digest-pinned runtime images directly instead of passing digest-only references through Kind’s Docker archive import.
- Keeps locally tagged images on the existing Kind load path.
- Makes the webhook removal fixture valid by supplying the required cell topology.
- Adds coverage for excluding digest references from Kind loading.

## Testing

Ran the e2e framework unit tests with the `e2e` build tag and compiled the webhook e2e package. Also verified formatting and whitespace with `gofmt` and `git diff --check`.