### PR TITLE
fix(e2e): preserve cell topology in scaling patches

### DIFF
--- a/test/e2e/shared/scaling/scaling_test.go
+++ b/test/e2e/shared/scaling/scaling_test.go
@@ -73,6 +73,7 @@ func testScaleMultigateway(t *testing.T) {
 		"spec": {
 			"cells": [{
 				"name": "zone-a",
+				"zoneId": "us-central1-a",
 				"spec": {
 					"multigateway": {
 						"replicas": 2
@@ -133,14 +134,14 @@ func testLargeScaleMultigateway(t *testing.T) {
 
 	// Scale 1 → 5.
 	framework.PatchCluster(t, c, cr, []byte(`{
-		"spec": {"cells": [{"name": "zone-a", "spec": {"multigateway": {"replicas": 5}}}]}
+		"spec": {"cells": [{"name": "zone-a", "zoneId": "us-central1-a", "spec": {"multigateway": {"replicas": 5}}}]}
 	}`))
 	framework.WaitForDeploymentReplicas(t, c, ns, "multigateway", 5)
 	cluster.WaitForAllPodsReady(t, ns)
 
 	// Scale 5 → 1.
 	framework.PatchCluster(t, c, cr, []byte(`{
-		"spec": {"cells": [{"name": "zone-a", "spec": {"multigateway": {"replicas": 1}}}]}
+		"spec": {"cells": [{"name": "zone-a", "zoneId": "us-central1-a", "spec": {"multigateway": {"replicas": 1}}}]}
 	}`))
 	framework.WaitForDeploymentReplicas(t, c, ns, "multigateway", 1)
 	cluster.WaitForAllPodsReady(t, ns)


### PR DESCRIPTION
## Description

this pr fixes the multigateway scaling e2e tests so their cell patches remain valid under the existing topology validation.

## Main changes

- Preserves the `zoneId` when replacing the `zone-a` cell during multigateway scaling.
- Covers the regular scale-up and both large-scale transitions.

## Testing

Compiled the scaling e2e package with the `e2e` build tag and verified all cell replacement patches retain their required topology field. Also ran `git diff --check`.