### PR TITLE
fix(certificate): truncate CN longer than 64 chars

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/certificate.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate.go
@@ -2,6 +2,8 @@ package multigrescluster
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -140,6 +142,22 @@ func buildInternalCertificates(
 	return certs, nil
 }
 
+// maxCommonNameBytes is the X.509 upper bound for the CN attribute
+// (RFC 5280 ub-common-name). cert-manager's webhook rejects longer CNs.
+const maxCommonNameBytes = 64
+
+// truncateCommonName returns cn unchanged when it fits the X.509 CN limit.
+// Longer values are truncated and given a deterministic hash suffix so the
+// result stays unique per identity and stable across reconciles.
+func truncateCommonName(cn string) string {
+	if len(cn) <= maxCommonNameBytes {
+		return cn
+	}
+	sum := sha256.Sum256([]byte(cn))
+	suffix := "-" + hex.EncodeToString(sum[:4])
+	return cn[:maxCommonNameBytes-len(suffix)] + suffix
+}
+
 func buildCertificateFromSpec(
 	cluster *multigresv1alpha1.MultigresCluster,
 	scheme *runtime.Scheme,
@@ -155,10 +173,13 @@ func buildCertificateFromSpec(
 	}
 
 	cert.Object["spec"] = map[string]any{
-		"secretName":     spec.secretName,
-		"dnsNames":       spec.dnsNames,
-		"duration":       CertDuration,
-		"literalSubject": fmt.Sprintf(CertLiteralSubjectTemplate, spec.commonName),
+		"secretName": spec.secretName,
+		"dnsNames":   spec.dnsNames,
+		"duration":   CertDuration,
+		"literalSubject": fmt.Sprintf(
+			CertLiteralSubjectTemplate,
+			truncateCommonName(spec.commonName),
+		),
 		"issuerRef": map[string]any{
 			"name":  CertIssuerName,
 			"kind":  "ClusterIssuer",

--- a/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
@@ -311,6 +311,60 @@ func TestBuildInternalCertificates(t *testing.T) {
 	}
 }
 
+func TestTruncateCommonName(t *testing.T) {
+	const shortCN = "multiadmin.mgc-x.ha-project-x.multigres.internal"
+	const longCN = "multiadmin.mgc-iaogrkvrpaubkinljowl.ha-project-iaogrkvrpaubkinljowl.multigres.internal"
+	const longCNVariant = "multiadmin.mgc-iaogrkvrpaubkinljowm.ha-project-iaogrkvrpaubkinljowl.multigres.internal"
+
+	t.Run("short CN is returned unchanged", func(t *testing.T) {
+		if len(shortCN) > maxCommonNameBytes {
+			t.Fatalf(
+				"test fixture shortCN is %d bytes, want <= %d",
+				len(shortCN),
+				maxCommonNameBytes,
+			)
+		}
+		got := truncateCommonName(shortCN)
+		if diff := cmp.Diff(shortCN, got); diff != "" {
+			t.Errorf("truncateCommonName() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("long CN is truncated to the X.509 limit", func(t *testing.T) {
+		if len(longCN) <= maxCommonNameBytes {
+			t.Fatalf("test fixture longCN is %d bytes, want > %d", len(longCN), maxCommonNameBytes)
+		}
+		got := truncateCommonName(longCN)
+		if len(got) > maxCommonNameBytes {
+			t.Errorf(
+				"truncateCommonName() = %q (%d bytes), want <= %d bytes",
+				got,
+				len(got),
+				maxCommonNameBytes,
+			)
+		}
+	})
+
+	t.Run("truncation is deterministic", func(t *testing.T) {
+		first := truncateCommonName(longCN)
+		second := truncateCommonName(longCN)
+		if diff := cmp.Diff(first, second); diff != "" {
+			t.Errorf("truncateCommonName() not deterministic (-first +second):\n%s", diff)
+		}
+	})
+
+	t.Run("different long inputs produce different outputs", func(t *testing.T) {
+		got := truncateCommonName(longCN)
+		gotVariant := truncateCommonName(longCNVariant)
+		if got == gotVariant {
+			t.Errorf(
+				"truncateCommonName() collided: %q == %q for different inputs",
+				got, gotVariant,
+			)
+		}
+	})
+}
+
 func TestReconcileCertificate(t *testing.T) {
 	scheme := setupScheme()
 


### PR DESCRIPTION
cert-manager's webhook rejects Certificates whose CN exceeds the RFC 5280 ub-common-name bound, so clusters with long name/namespace combinations failed TLS reconciliation:

spec.commonName: Too long: must have at most 64 bytes

Truncate only the CN inside literalSubject, with a deterministic hash suffix for uniqueness. SANs, certificate names, and secret names keep the full identity (gRPC verifies SANs, not CN, so peer verification is unchanged).