### PR TITLE
chore(toposerver): always delete topo PVCs with cluster

### DIFF
--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -50,6 +50,7 @@ type MultigresClusterReconciler struct {
 // +kubebuilder:rbac:groups=multigres.com,resources=cells;tablegroups;toposervers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=multigres.com,resources=shards,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;delete
 func (r *MultigresClusterReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
@@ -103,6 +104,13 @@ func (r *MultigresClusterReconciler) Reconcile(
 		defer span.End()
 		ctx = monitoring.EnrichLoggerWithTrace(ctx)
 		l = log.FromContext(ctx)
+	}
+
+	if !cluster.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, cluster)
+	}
+	if err := r.ensureClusterFinalizer(ctx, cluster); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	res := resolver.NewResolver(r.Client, cluster.Namespace)
@@ -162,10 +170,6 @@ func (r *MultigresClusterReconciler) Reconcile(
 			}
 			l.V(1).Info("Patched tracking labels on cluster")
 		}
-	}
-
-	if !cluster.DeletionTimestamp.IsZero() {
-		return r.handleDeletion(ctx, cluster)
 	}
 
 	{
@@ -312,8 +316,29 @@ func (r *MultigresClusterReconciler) Reconcile(
 	return ctrl.Result{}, nil
 }
 
-// handleDeletion performs best-effort cleanup by deleting Cells and TableGroups.
-// Without finalizers, Kubernetes GC cascade via ownerReferences handles the rest.
+func (r *MultigresClusterReconciler) ensureClusterFinalizer(
+	ctx context.Context,
+	cluster *multigresv1alpha1.MultigresCluster,
+) error {
+	if slices.Contains(cluster.Finalizers, multigresv1alpha1.FinalizerClusterCleanup) {
+		return nil
+	}
+
+	before := cluster.DeepCopy()
+	cluster.Finalizers = append(cluster.Finalizers, multigresv1alpha1.FinalizerClusterCleanup)
+	patch := client.MergeFromWithOptions(
+		before,
+		client.MergeFromWithOptimisticLock{},
+	)
+	if err := r.Patch(ctx, cluster, patch); err != nil {
+		return fmt.Errorf("failed to add cluster cleanup finalizer: %w", err)
+	}
+
+	return nil
+}
+
+// handleDeletion deletes cluster children and retained topology PVCs before
+// releasing the cluster cleanup finalizer.
 func (r *MultigresClusterReconciler) handleDeletion(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
@@ -358,7 +383,57 @@ func (r *MultigresClusterReconciler) handleDeletion(
 		}
 	}
 
-	l.Info("Cluster best-effort cleanup complete")
+	// Topology PVCs may outlive their TopoServer when a cluster switches from
+	// managed to external topology. Clean them up from the cluster lifecycle so
+	// they cannot be orphaned when the cluster is later deleted.
+	topoPVCs := &corev1.PersistentVolumeClaimList{}
+	if err := r.List(
+		ctx,
+		topoPVCs,
+		ns,
+		client.MatchingLabels{
+			metadata.LabelMultigresCluster: cluster.Name,
+			metadata.LabelAppComponent:     metadata.ComponentTopoServer,
+		},
+	); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list topo PVCs: %w", err)
+	}
+	for i := range topoPVCs.Items {
+		if topoPVCs.Items[i].DeletionTimestamp.IsZero() {
+			if err := r.Delete(ctx, &topoPVCs.Items[i]); err != nil && !errors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf(
+					"failed to delete topo PVC %q: %w",
+					topoPVCs.Items[i].Name,
+					err,
+				)
+			}
+			l.Info("Initiated topo PVC deletion", "pvc", topoPVCs.Items[i].Name)
+		}
+	}
+
+	if slices.Contains(cluster.Finalizers, multigresv1alpha1.FinalizerClusterCleanup) {
+		before := cluster.DeepCopy()
+
+		cluster.Finalizers = slices.DeleteFunc(
+			cluster.Finalizers,
+			func(finalizer string) bool {
+				return finalizer == multigresv1alpha1.FinalizerClusterCleanup
+			},
+		)
+
+		patch := client.MergeFromWithOptions(
+			before,
+			client.MergeFromWithOptimisticLock{},
+		)
+		if err := r.Patch(ctx, cluster, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf(
+				"failed to remove cluster cleanup finalizer: %w",
+				err,
+			)
+		}
+	}
+
+	l.Info("Cluster cleanup complete")
 	r.Recorder.Event(cluster, "Normal", "CleanupComplete", "Initiated deletion of child resources")
 	return ctrl.Result{}, nil
 }
@@ -416,6 +491,10 @@ func projectRefOrGenerationChangedPredicate() predicate.Predicate {
 			}
 
 			if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {
+				return true
+			}
+			if e.ObjectOld.GetDeletionTimestamp().IsZero() &&
+				!e.ObjectNew.GetDeletionTimestamp().IsZero() {
 				return true
 			}
 

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
@@ -1271,6 +1271,7 @@ func TestReconciler_PatchTrackingLabelsError(t *testing.T) {
 	scheme := setupScheme()
 	coreTpl, cellTpl, shardTpl, baseCluster, clusterName, namespace := setupFixtures(t)
 	baseCluster.Labels = nil // trigger patch
+	baseCluster.Finalizers = []string{multigresv1alpha1.FinalizerClusterCleanup}
 
 	baseClient := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/pkg/resource-handler/controller/toposerver/statefulset.go
+++ b/pkg/resource-handler/controller/toposerver/statefulset.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// ComponentName is the component label value for toposerver resources
-	ComponentName = "toposerver"
+	ComponentName = metadata.ComponentTopoServer
 
 	// DefaultReplicas is the default number of etcd replicas
 	DefaultReplicas int32 = 3

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller.go
@@ -433,7 +433,9 @@ func (r *TopoServerReconciler) SetupWithManager(
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&multigresv1alpha1.TopoServer{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&multigresv1alpha1.TopoServer{}, builder.WithPredicates(
+			predicate.GenerationChangedPredicate{},
+		)).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		WithOptions(controllerOpts).

--- a/pkg/util/metadata/labels.go
+++ b/pkg/util/metadata/labels.go
@@ -53,6 +53,9 @@ const (
 	// ComponentGlobalTopo identifies the global-topo component.
 	ComponentGlobalTopo = "global-topo"
 
+	// ComponentTopoServer identifies the toposerver component.
+	ComponentTopoServer = "toposerver"
+
 	// ComponentCell identifies the cell component.
 	ComponentCell = "cell"
 

--- a/test/e2e/dedicated/deletion/deletion_test.go
+++ b/test/e2e/dedicated/deletion/deletion_test.go
@@ -4,6 +4,7 @@ package deletion_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +31,11 @@ func TestClusterDeletion(t *testing.T) {
 	// Load and create the minimal sample.
 	cr := framework.MustLoadCluster("config/samples/minimal.yaml", ns)
 	cr.Name = "delete-me" // distinct name for clarity in logs
+
+	cr.Spec.PVCDeletionPolicy = &multigresv1alpha1.PVCDeletionPolicy{
+		WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+		WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+	}
 	if err := c.Create(ctx, cr); err != nil {
 		t.Fatalf("create MultigresCluster: %v", err)
 	}
@@ -83,4 +89,39 @@ func TestClusterDeletion(t *testing.T) {
 		func(l *corev1.ServiceList) int { return len(l.Items) },
 		"Services", 3*time.Minute,
 	)
+
+	// Verify topo (etcd) PVCs are cleaned up. The MultigresCluster cleanup
+	// finalizer deletes topo PVCs regardless of the configured PVCDeletionPolicy
+	// (which this test forces to Retain above), so
+	// PVCs from the global topo StatefulSet should not survive the cluster.
+	framework.WaitForEmpty(t, c, ns,
+		&corev1.PersistentVolumeClaimList{},
+		func(l *corev1.PersistentVolumeClaimList) int {
+			count := 0
+			for _, pvc := range l.Items {
+				if strings.HasPrefix(pvc.Name, "data-"+cr.Name+"-") &&
+					strings.Contains(pvc.Name, "-topo-") {
+					count++
+				}
+			}
+			return count
+		},
+		"topo PVCs", 3*time.Minute,
+	)
+
+	// Verify data (non-topo) PVCs are retained under the Retain policy forced
+	// above, only topo PVCs are force-deleted by cluster cleanup.
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := c.List(ctx, pvcList, client.InNamespace(ns)); err != nil {
+		t.Fatalf("list PVCs: %v", err)
+	}
+	nonTopoCount := 0
+	for _, pvc := range pvcList.Items {
+		if !strings.Contains(pvc.Name, "-topo-") {
+			nonTopoCount++
+		}
+	}
+	if nonTopoCount == 0 {
+		t.Fatalf("expected at least one non-topo (data) PVC to survive cluster deletion under Retain, found none")
+	}
 }

--- a/test/e2e/shared/deletion/deletion_test.go
+++ b/test/e2e/shared/deletion/deletion_test.go
@@ -4,16 +4,19 @@ package deletion_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	"github.com/multigres/multigres-operator/test/e2e/framework"
 )
 
@@ -84,4 +87,226 @@ func TestClusterDeletion(t *testing.T) {
 		func(l *corev1.ServiceList) int { return len(l.Items) },
 		"Services", 3*time.Minute,
 	)
+}
+
+// TestClusterDeletionAfterSwitchingToExternalTopo verifies that retained PVCs
+// from a previously managed topology server are still cleaned up when the
+// cluster is later deleted. This covers the case where the TopoServer and its
+// StatefulSet no longer exist by the time cluster deletion starts.
+func TestClusterDeletionAfterSwitchingToExternalTopo(t *testing.T) {
+	t.Parallel()
+	ns := cluster.CreateNamespace(t)
+	c, err := cluster.CRClient()
+	if err != nil {
+		t.Fatalf("create CR client: %v", err)
+	}
+	ctx := context.Background()
+
+	cr := framework.MustLoadCluster("config/samples/minimal.yaml", ns)
+	cr.Name = "delete-after-external-topo"
+	cr.Spec.PVCDeletionPolicy = &multigresv1alpha1.PVCDeletionPolicy{
+		WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+		WhenScaled:  multigresv1alpha1.RetainPVCRetentionPolicy,
+	}
+	if err := c.Create(ctx, cr); err != nil {
+		t.Fatalf("create MultigresCluster: %v", err)
+	}
+
+	cluster.WaitForAllPodsReady(t, ns)
+	topoStatefulSet := framework.WaitForStatefulSet(t, c, ns, "etcd")
+
+	topoPVCNames := waitForBoundTopoPVCs(t, c, ns, cr.Name)
+	nonTopoPVCNames := listNonTopoPVCNames(t, c, ns, topoPVCNames)
+	if len(nonTopoPVCNames) == 0 {
+		t.Fatal("expected at least one non-topo PVC to verify the Retain policy")
+	}
+
+	// Patch directly instead of using framework.PatchCluster (the external
+	// endpoint is intentionally unreachable).
+	if err := c.Patch(ctx, cr, client.RawPatch(types.MergePatchType, []byte(`{
+		"spec": {
+			"globalTopoServer": {
+				"etcd": null,
+				"templateRef": null,
+				"external": {
+					"endpoints": ["http://external-etcd.invalid:2379"]
+				}
+			}
+		}
+	}`))); err != nil {
+		t.Fatalf("switch cluster to external topology: %v", err)
+	}
+
+	waitForObjectsDeleted(t, c, 3*time.Minute,
+		objectToDelete{
+			key:         client.ObjectKey{Namespace: ns, Name: topoStatefulSet.Name},
+			object:      &appsv1.StatefulSet{},
+			description: "managed topology StatefulSet",
+		},
+		objectToDelete{
+			key:         client.ObjectKey{Namespace: ns, Name: topoStatefulSet.Name},
+			object:      &multigresv1alpha1.TopoServer{},
+			description: "managed TopoServer",
+		},
+	)
+
+	// Retain must leave the old managed-topology PVCs behind during the switch.
+	for _, name := range topoPVCNames {
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, pvc); err != nil {
+			t.Fatalf("expected retained topo PVC %q after switching to external topo: %v", name, err)
+		}
+		if !pvc.DeletionTimestamp.IsZero() {
+			t.Fatalf("topo PVC %q is unexpectedly terminating after switching to external topo", name)
+		}
+	}
+
+	liveCluster := &multigresv1alpha1.MultigresCluster{}
+	clusterKey := client.ObjectKeyFromObject(cr)
+	if err := c.Get(ctx, clusterKey, liveCluster); err != nil {
+		t.Fatalf("get MultigresCluster before deletion: %v", err)
+	}
+	if err := c.Delete(ctx, liveCluster); err != nil {
+		t.Fatalf("delete MultigresCluster: %v", err)
+	}
+
+	objects := []objectToDelete{{
+		key:         clusterKey,
+		object:      &multigresv1alpha1.MultigresCluster{},
+		description: "MultigresCluster",
+	}}
+	for _, name := range topoPVCNames {
+		objects = append(objects, objectToDelete{
+			key:         client.ObjectKey{Namespace: ns, Name: name},
+			object:      &corev1.PersistentVolumeClaim{},
+			description: fmt.Sprintf("stale topo PVC %q", name),
+		})
+	}
+	waitForObjectsDeleted(t, c, 5*time.Minute, objects...)
+	framework.WaitForEmpty(t, c, ns,
+		&appsv1.StatefulSetList{},
+		func(l *appsv1.StatefulSetList) int { return len(l.Items) },
+		"StatefulSets", 3*time.Minute,
+	)
+
+	// Cluster cleanup must remain scoped to topology PVCs.
+	for _, name := range nonTopoPVCNames {
+		pvc := &corev1.PersistentVolumeClaim{}
+		if err := c.Get(
+			ctx,
+			client.ObjectKey{Namespace: ns, Name: name},
+			pvc,
+		); err != nil {
+			t.Errorf("expected retained non-topo PVC %q after cluster deletion: %v", name, err)
+			continue
+		}
+		if !pvc.DeletionTimestamp.IsZero() {
+			t.Errorf("retained non-topo PVC %q is unexpectedly terminating", name)
+		}
+	}
+}
+
+func waitForBoundTopoPVCs(
+	t testing.TB,
+	c client.Client,
+	ns string,
+	clusterName string,
+) []string {
+	t.Helper()
+	var names []string
+	pollCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	err := wait.PollUntilContextCancel(pollCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		list := &corev1.PersistentVolumeClaimList{}
+		if err := c.List(
+			ctx,
+			list,
+			client.InNamespace(ns),
+			client.MatchingLabels{
+				metadata.LabelMultigresCluster: clusterName,
+				metadata.LabelAppComponent:     metadata.ComponentTopoServer,
+			},
+		); err != nil {
+			return false, nil
+		}
+		if len(list.Items) == 0 {
+			return false, nil
+		}
+		currentNames := make([]string, 0, len(list.Items))
+		for _, pvc := range list.Items {
+			if pvc.Status.Phase != corev1.ClaimBound {
+				return false, nil
+			}
+			currentNames = append(currentNames, pvc.Name)
+		}
+		names = currentNames
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("timed out waiting for bound managed-topology PVCs: %v", err)
+	}
+	return names
+}
+
+func listNonTopoPVCNames(
+	t testing.TB,
+	c client.Client,
+	ns string,
+	topoPVCNames []string,
+) []string {
+	t.Helper()
+	topoPVCs := make(map[string]struct{}, len(topoPVCNames))
+	for _, name := range topoPVCNames {
+		topoPVCs[name] = struct{}{}
+	}
+
+	list := &corev1.PersistentVolumeClaimList{}
+	if err := c.List(context.Background(), list, client.InNamespace(ns)); err != nil {
+		t.Fatalf("list PVCs: %v", err)
+	}
+	var names []string
+	for _, pvc := range list.Items {
+		if _, isTopo := topoPVCs[pvc.Name]; !isTopo {
+			names = append(names, pvc.Name)
+		}
+	}
+	return names
+}
+
+type objectToDelete struct {
+	key         client.ObjectKey
+	object      client.Object
+	description string
+}
+
+func waitForObjectsDeleted(
+	t testing.TB,
+	c client.Client,
+	timeout time.Duration,
+	objects ...objectToDelete,
+) {
+	t.Helper()
+	pollCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := wait.PollUntilContextCancel(pollCtx, 2*time.Second, true, func(ctx context.Context) (bool, error) {
+		for _, object := range objects {
+			if err := c.Get(ctx, object.key, object.object.DeepCopyObject().(client.Object)); !apierrors.IsNotFound(err) {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		pending := make([]string, 0, len(objects))
+		for _, object := range objects {
+			if err := c.Get(
+				context.Background(),
+				object.key,
+				object.object.DeepCopyObject().(client.Object),
+			); !apierrors.IsNotFound(err) {
+				pending = append(pending, object.description)
+			}
+		}
+		t.Fatalf("timed out waiting for deletion of %v: %v", pending, err)
+	}
 }


### PR DESCRIPTION
Topo etcd data is coordination state rebuilt on cluster creation, so retaining its PVCs after a MultigresCluster is deleted only leaves orphaned volumes behind.

What this change introduce, gate TopoServer deletion with a finalizer so rebuildable etcd volumes are removed when the owning MultigresCluster is terminating or gone. Reconcile deletion-timestamp transitions explicitly and preserve data-plane PVCs under Retain.