### PR TITLE
chore(multigres): bump images and module to 300f673

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -5,25 +5,25 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-54b4c18"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-300f673"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiadminImage is the default container image for the Multiadmin component.
-	DefaultMultiadminImage = "ghcr.io/multigres/multigres:sha-54b4c18"
+	DefaultMultiadminImage = "ghcr.io/multigres/multigres:sha-300f673"
 
 	// DefaultMultiadminWebImage is the default container image for the MultiadminWeb component.
-	DefaultMultiadminWebImage = "ghcr.io/multigres/multiadmin-web:sha-95eb327"
+	DefaultMultiadminWebImage = "ghcr.io/multigres/multiadmin-web:sha-64da1ab"
 
 	// DefaultMultiorchImage is the default container image for the Multiorch component.
-	DefaultMultiorchImage = "ghcr.io/multigres/multigres:sha-54b4c18"
+	DefaultMultiorchImage = "ghcr.io/multigres/multigres:sha-300f673"
 
 	// DefaultMultipoolerImage is the default container image for the Multipooler component.
-	DefaultMultipoolerImage = "ghcr.io/multigres/multigres:sha-54b4c18"
+	DefaultMultipoolerImage = "ghcr.io/multigres/multigres:sha-300f673"
 
 	// DefaultMultigatewayImage is the default container image for the Multigateway component.
-	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-54b4c18"
+	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-300f673"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
 	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
-	github.com/multigres/multigres v0.0.0-20260722000357-54b4c18f6f5f
+	github.com/multigres/multigres v0.0.0-20260731210621-300f673c63ee
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/multigres/multigres v0.0.0-20260722000357-54b4c18f6f5f h1:mTx1pTjg88onPCpIeqtafei5PdpsojyNEnE5IosIZkI=
-github.com/multigres/multigres v0.0.0-20260722000357-54b4c18f6f5f/go.mod h1:QV8N0aZ4DUoBJPgt1pj5d28D0Pa8JgImWjVzvXH/wLU=
+github.com/multigres/multigres v0.0.0-20260731210621-300f673c63ee h1:LVFvJTLSWlo1hs5PHCaGzY8C+mP8a/i8ZpkUc6rKC7k=
+github.com/multigres/multigres v0.0.0-20260731210621-300f673c63ee/go.mod h1:QV8N0aZ4DUoBJPgt1pj5d28D0Pa8JgImWjVzvXH/wLU=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=


### PR DESCRIPTION
## What

Bumps the default upstream images and the `github.com/multigres/multigres` module to `300f673`.

| Constant | Image | Old | New |
|---|---|---|---|
| `DefaultPostgresImage` | `ghcr.io/multigres/pgctld` | `sha-54b4c18` | `sha-300f673` |
| `DefaultMultiadminImage` | `ghcr.io/multigres/multigres` | `sha-54b4c18` | `sha-300f673` |
| `DefaultMultiorchImage` | `ghcr.io/multigres/multigres` | `sha-54b4c18` | `sha-300f673` |
| `DefaultMultipoolerImage` | `ghcr.io/multigres/multigres` | `sha-54b4c18` | `sha-300f673` |
| `DefaultMultigatewayImage` | `ghcr.io/multigres/multigres` | `sha-54b4c18` | `sha-300f673` |
| `DefaultMultiadminWebImage` | `ghcr.io/multigres/multiadmin-web` | `sha-95eb327` | `sha-64da1ab` |

Module: `v0.0.0-20260722000357-54b4c18f6f5f` → `v0.0.0-20260731210621-300f673c63ee`. `DefaultEtcdImage` and `DefaultPostgresExporterImage` are untouched.

Tags verified present in GHCR before pinning:

```
ghcr.io/multigres/multigres:sha-300f673      sha256:66d20d1253ae87829574cc490f076665b02ec03130f7e0c901e7fff67d2681e7
ghcr.io/multigres/pgctld:sha-300f673         sha256:2257013afddbe9a7beff4cb792df91aa18f6c306872cad6fe9f808c207330daa
ghcr.io/multigres/multiadmin-web:sha-64da1ab sha256:019506ce9c004d3af0461dd3cdbea7c6aaef8ae0b043a74ff6764599be0aee5d
```

**multiadmin-web has no `sha-300f673` build.** `64da1ab` is the newest commit touching `web/multiadmin/` at or before `300f673c` (the following nine commits are Go-only, docs, or CI), so it is the correct web-side equivalent. The module is pinned to `300f673` to match the core images.

## Operator impact

No operator code changes are required. Findings from the `pin_upstream_images` audit over `54b4c18..300f673c` (50 upstream commits):

- **`RewindToSource` RPC removed** (`22d50ae2`) — dropped from `proto/multipoolermanagerdata.proto`, `consensusservice.proto`, and the `rpcclient` interface; diverged standbys now self-heal locally in multipooler. `grep -rn RewindToSource` over the operator returns nothing. **No impact.**
- **`POSTGRES_ACTION_REWIND = 4` removed** from the `PostgresAction` enum. The operator never references `PostgresAction`. **No impact.**
- **pgctld starts an existing PGDATA as a standby by default** (`06c2155b`) — `StartRequest.as_primary` now defaults to false, so a crashed former primary comes back in recovery mode and is only promoted through consensus-gated `pg_promote()`. The operator does not import `go/pb/pgctldservice` and never calls `Start` itself. **No impact**, but relevant when reading e2e failover timings: a hard-killed sole primary now stays read-only until multiorch promotes it.
- **pgctld live-includes extra postgresql.conf instead of copying at initdb** (`11675fd7`) — this one targets the operator's flow directly. `appendExtraConfFiles` now emits `include_if_exists '<abs path>'` at the end of `postgresql.conf` rather than copying bytes, so the ConfigMap the operator mounts and passes via `POSTGRES_INITDB_EXTRA_CONF` (`containers.go:276`, `PostgresConfigMountPath = /etc/pgctld/postgres-config`) is re-read on every start and `pg_reload_conf()` SIGHUP. Previously operator config edits were frozen at cluster creation. The env var name and absolute-path contract are unchanged, so **no operator change** — but note the caveat below.
- **Structured-logging refactor** (`4e311c15`, plus `c5c6b80b` quieting the health/replication paths) — 84 files, messages lowercased and attribute keys held to snake_case by `sloglint`. `buildHandler` in `go/common/servenv/logging.go` is a plain `slog.NewJSONHandler` with no `ReplaceAttr`, so the `level`/`msg` builtins are untouched. The observer's scanner (`tools/observer/pkg/observer/logs.go:200-205`) reads exactly `level`, `msg`, `error`, `problem_code` — `problem_code` is still emitted (`go/services/multiorch/recovery/recovery_grace_period.go:204`), and `isProbeNoise`'s two message strings (`startup failed`, `error handling message`) are unchanged in this range (`git log -S` over both returns nothing). **No impact.**
- **`eventlog.Emit` now uses the canonical event type as the record message** instead of the `multigres.event` sentinel. Nothing in this repo greps for that sentinel. **No impact.**
- **`StandbyReplicationStatus.last_receive_lsn_advance_time`** (`012077f5`) and **`PrimaryConnInfo.passfile`** (`64da1abd`) added; multiorch cohort-eligibility tightening (`57db243a`, `9111441c`), `SetPrimary` target caching (`300f673c`), and deferred repair on unknown replication status (`d78123d0`). The operator consumes none of these messages. **New feature opportunity**, not wired up here.
- `clustermetadata.proto` is unchanged across the whole range, so there is no repeat of the `PoolerType` deprecation handled in 4ec99a5. The `topoclient` changes in this range are log-message lowercasing only, no API surface change.

The only `multipoolermanagerdata` symbols the operator uses are `BackupMetadata`, `BackupMetadata_COMPLETE`, `BackupMetadata_INCOMPLETE`, `GetBackupsRequest/Response`, and `UpdateConsensusRuleRequest/Response` — none changed.

### Caveat: existing shards do not gain the config include directive

`GeneratePostgresServerConfig` is only called from `InitDataDirWithResult`, which early-returns when `IsDataDirInitialized()` is true (`go/cmd/pgctld/command/init.go:97-102`). Shards whose PGDATA was initialized by an older pgctld therefore keep the copied-bytes snapshot in `PGDATA/postgresql.conf` and no `include_if_exists` line, so the image bump alone does not make their mounted config live. Newly created shards get the new behavior. Worth knowing before anyone treats #554-style config propagation as fixed for existing clusters.

### Flag compatibility

All 38 `--flag` strings in `pkg/resource-handler/controller/shard/containers.go` still exist upstream at `300f673`. Two apparent misses are false positives: `--repo1-path` appears only in a comment about pgbackrest, and `--web.listen-address` belongs to `postgres-exporter`, not a multigres binary.

### Environment variable compatibility

`PGDATA` and `POSTGRES_PASSWORD_FILE` remain the only hard requirements, and both are set on each container that needs them — `buildPgctldSidecar` (`containers.go:262`, `:266`) and `buildMultipoolerContainer` (`:513`, `:517`). `buildMultiorchContainer` needs neither.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass, no failures.
- `go mod tidy` produced no transitive churn: `go.mod` changes by exactly one line.
- `tools/observer`: `go mod tidy` is a no-op, `go build ./...` and `go test ./...` pass.
- Not yet run: `make kind-redeploy` smoke test against a real cluster. Left to CI's e2e matrix, hence draft.

<sub>The branch name still reads `chore/bump-multigres-b713432` — it was retargeted from `b713432` to `300f673` in place, and GitHub does not allow changing a PR's head ref.</sub>
