### PR TITLE
chore(pvc): change default multigrescluster pvc retain policy

### DIFF
--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -92,9 +92,9 @@ type MultigresClusterSpec struct {
 	Databases []DatabaseConfig `json:"databases,omitempty"`
 
 	// PVCDeletionPolicy controls PVC lifecycle management for all stateful components.
-	// Defaults to Retain/Delete — PVCs are kept on cluster deletion but removed on scale-down.
+	// Defaults to Delete/Delete — PVC lifecycle is handled by the operator.
 	// +optional
-	// +kubebuilder:default={whenDeleted: "Retain", whenScaled: "Delete"}
+	// +kubebuilder:default={whenDeleted: "Delete", whenScaled: "Delete"}
 	PVCDeletionPolicy *PVCDeletionPolicy `json:"pvcDeletionPolicy,omitempty"`
 
 	// Observability configures OpenTelemetry for data-plane components.

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -10631,11 +10631,11 @@ spec:
                 type: string
               pvcDeletionPolicy:
                 default:
-                  whenDeleted: Retain
+                  whenDeleted: Delete
                   whenScaled: Delete
                 description: |-
                   PVCDeletionPolicy controls PVC lifecycle management for all stateful components.
-                  Defaults to Retain/Delete — PVCs are kept on cluster deletion but removed on scale-down.
+                  Defaults to Delete/Delete — PVC lifecycle is handled by the operator.
                 properties:
                   whenDeleted:
                     default: Retain

--- a/pkg/cluster-handler/controller/multigrescluster/integration_resolution_enforcement_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_resolution_enforcement_test.go
@@ -370,7 +370,7 @@ func TestMultigresCluster_ResolutionLogic(t *testing.T) {
 					},
 				},
 				PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-					WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+					WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 					WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 				},
 				Backup: &multigresv1alpha1.BackupConfig{
@@ -674,9 +674,9 @@ func TestMultigresCluster_TemplateOverrides(t *testing.T) {
 					},
 				},
 			},
-			// TG/Cluster level defaults (Retain/Retain)
+			// TG/Cluster level defaults (Delete/Delete)
 			PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-				WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+				WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 				WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 			},
 			Backup: &multigresv1alpha1.BackupConfig{

--- a/pkg/cluster-handler/controller/multigrescluster/integration_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_test.go
@@ -273,7 +273,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 							Resources: resolver.DefaultResourcesEtcd(),
 						},
 						PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-							WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+							WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 							WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 						},
 					},
@@ -581,7 +581,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 							},
 						},
 						PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-							WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+							WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 							WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 						},
 						Backup: &multigresv1alpha1.BackupConfig{
@@ -636,7 +636,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 							Resources: resolver.DefaultResourcesEtcd(),
 						},
 						PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-							WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+							WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 							WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 						},
 					},
@@ -945,7 +945,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 							},
 						},
 						PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-							WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+							WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 							WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 						},
 						Backup: &multigresv1alpha1.BackupConfig{
@@ -995,7 +995,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 							Resources: resolver.DefaultResourcesEtcd(),
 						},
 						PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-							WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+							WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 							WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 						},
 					},
@@ -1304,7 +1304,7 @@ func TestMultigresCluster_HappyPath(t *testing.T) {
 							},
 						},
 						PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-							WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+							WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 							WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 						},
 						Backup: &multigresv1alpha1.BackupConfig{

--- a/pkg/resolver/cluster.go
+++ b/pkg/resolver/cluster.go
@@ -69,7 +69,7 @@ func (r *Resolver) PopulateClusterDefaults(
 
 	if cluster.Spec.PVCDeletionPolicy == nil {
 		cluster.Spec.PVCDeletionPolicy = &multigresv1alpha1.PVCDeletionPolicy{
-			WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+			WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 			WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 		}
 	}

--- a/pkg/resolver/cluster_test.go
+++ b/pkg/resolver/cluster_test.go
@@ -69,7 +69,7 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						Multigateway: DefaultLogLevel,
 					},
 					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 						WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 					},
 					Backup: &multigresv1alpha1.BackupConfig{
@@ -135,7 +135,7 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						Multigateway: DefaultLogLevel,
 					},
 					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 						WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 					},
 					Backup: &multigresv1alpha1.BackupConfig{
@@ -209,7 +209,7 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						Multigateway: DefaultLogLevel,
 					},
 					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 						WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 					},
 					Backup: &multigresv1alpha1.BackupConfig{
@@ -296,7 +296,7 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						Multigateway: DefaultLogLevel,
 					},
 					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 						WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 					},
 					Backup: &multigresv1alpha1.BackupConfig{
@@ -378,7 +378,7 @@ func TestResolver_PopulateClusterDefaults(t *testing.T) {
 						Multigateway: DefaultLogLevel,
 					},
 					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 						WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 					},
 					Backup: &multigresv1alpha1.BackupConfig{

--- a/pkg/resource-handler/controller/toposerver/statefulset.go
+++ b/pkg/resource-handler/controller/toposerver/statefulset.go
@@ -39,7 +39,16 @@ func BuildStatefulSet(
 	toposerver *multigresv1alpha1.TopoServer,
 	scheme *runtime.Scheme,
 ) (*appsv1.StatefulSet, error) {
-	pvcPolicy := toposerver.Spec.PVCDeletionPolicy
+	// Topo PVCs are only ever removed via the MultigresCluster deletion
+	// finalizer (handleDeletion), never via the StatefulSet's native
+	// retention policy, deleting or recreating just this StatefulSet must
+	// never drop etcd data. WhenScaled still follows the resolved policy.
+	stsRetentionPolicy := &multigresv1alpha1.PVCDeletionPolicy{
+		WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+	}
+	if toposerver.Spec.PVCDeletionPolicy != nil {
+		stsRetentionPolicy.WhenScaled = toposerver.Spec.PVCDeletionPolicy.WhenScaled
+	}
 	replicas := DefaultReplicas
 	if toposerver.Spec.Etcd != nil && toposerver.Spec.Etcd.Replicas != nil {
 		replicas = *toposerver.Spec.Etcd.Replicas
@@ -134,7 +143,7 @@ func BuildStatefulSet(
 				},
 			},
 			VolumeClaimTemplates:                 buildVolumeClaimTemplates(toposerver),
-			PersistentVolumeClaimRetentionPolicy: pvc.BuildRetentionPolicy(pvcPolicy),
+			PersistentVolumeClaimRetentionPolicy: pvc.BuildRetentionPolicy(stsRetentionPolicy),
 		},
 	}
 

--- a/pkg/webhook/handlers/defaulter_test.go
+++ b/pkg/webhook/handlers/defaulter_test.go
@@ -176,7 +176,7 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 					},
 					DurabilityPolicy: "AT_LEAST_2",
 					PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-						WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+						WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 						WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 					},
 					Backup: &multigresv1alpha1.BackupConfig{
@@ -479,7 +479,7 @@ func TestMultigresClusterDefaulter_Handle(t *testing.T) {
 						},
 						DurabilityPolicy: "AT_LEAST_2",
 						PVCDeletionPolicy: &multigresv1alpha1.PVCDeletionPolicy{
-							WhenDeleted: multigresv1alpha1.RetainPVCRetentionPolicy,
+							WhenDeleted: multigresv1alpha1.DeletePVCRetentionPolicy,
 							WhenScaled:  multigresv1alpha1.DeletePVCRetentionPolicy,
 						},
 						Backup: &multigresv1alpha1.BackupConfig{


### PR DESCRIPTION
MultigresCluster now owns the volumes lifecycle policy, but the ownership is only honoured when the retain policy is set to "Delete".

- data volumes are kept (orphaned) to a max set by pvcOrphanReplicasThreshold
- topo volumes are deleted with the multigresCluster CR (note: they survive to a toposerver statefulset removal)