### PR TITLE
fix(cert): add per-pool wildcard SANs to pgbackrest server cert

### DIFF
--- a/pkg/cert/manager.go
+++ b/pkg/cert/manager.go
@@ -368,7 +368,7 @@ func (m *CertRotator) ensureServerCert(
 		return m.ensureServerCert(ctx, ca, depth+1)
 	}
 
-	// Check if near expiry OR if CA changed
+	// Check if near expiry OR if CA changed OR if desired DNS SANs changed
 	needsRotation := time.Until(cert.NotAfter) < RotationThreshold
 	if !needsRotation {
 		// Check if signed by current CA
@@ -376,6 +376,11 @@ func (m *CertRotator) ensureServerCert(
 			log.FromContext(ctx).Info("server cert was not signed by current CA, rotating")
 			needsRotation = true
 		}
+	}
+	if !needsRotation && !dnsNameSetsEqual(cert.DNSNames, dnsNames) {
+		log.FromContext(ctx).Info("server cert are out of date, rotating",
+			"current", cert.DNSNames, "desired", dnsNames)
+		needsRotation = true
 	}
 
 	if needsRotation {
@@ -398,6 +403,28 @@ func (m *CertRotator) ensureServerCert(
 	}
 
 	return secret.Data["tls.crt"], nil
+}
+
+// dnsNameSetsEqual reports whether a and b contain the same DNS names,
+// ignoring order and duplicates.
+func dnsNameSetsEqual(a, b []string) bool {
+	toSet := func(names []string) map[string]struct{} {
+		set := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			set[n] = struct{}{}
+		}
+		return set
+	}
+	setA, setB := toSet(a), toSet(b)
+	if len(setA) != len(setB) {
+		return false
+	}
+	for n := range setA {
+		if _, ok := setB[n]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *CertRotator) waitForProjection(ctx context.Context, expectedCertPEM []byte) error {

--- a/pkg/cert/manager_test.go
+++ b/pkg/cert/manager_test.go
@@ -180,6 +180,66 @@ func TestManager_EnsureCerts(t *testing.T) {
 			checkFiles:    true,
 			wantGenerated: true,
 		},
+		"Rotation: DNS SANs Changed": {
+			existingObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: testCASecretName, Namespace: namespace},
+					Data: map[string][]byte{
+						"ca.crt": validCABytes,
+						"ca.key": validCAKeyBytes,
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: testServerSecretName, Namespace: namespace},
+					Data: map[string][]byte{
+						// validCert only has expectedDNSName as a SAN; the
+						// AdditionalDNSNames below add a new one, so the
+						// existing cert is stale and must be rotated.
+						"tls.crt": validCert,
+						"tls.key": []byte("key"),
+					},
+				},
+			},
+			customOptions: &Options{
+				CASecretName:       testCASecretName,
+				ServerSecretName:   testServerSecretName,
+				WaitForProjection:  true,
+				AdditionalDNSNames: []string{"*.extra-pool.test-ns.svc.cluster.local"},
+			},
+			checkFiles:    true,
+			wantGenerated: true,
+		},
+		"Idempotency: Same DNS SANs (with AdditionalDNSNames)": {
+			existingObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: testCASecretName, Namespace: namespace},
+					Data: map[string][]byte{
+						"ca.crt": validCABytes,
+						"ca.key": validCAKeyBytes,
+					},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: testServerSecretName, Namespace: namespace},
+					Data: map[string][]byte{
+						"tls.crt": generateSignedCertPEM(
+							t,
+							ca,
+							time.Now().Add(365*24*time.Hour),
+							[]string{expectedDNSName, "*.extra-pool.test-ns.svc.cluster.local"},
+						),
+						"tls.key": []byte("key"),
+					},
+				},
+			},
+			customOptions: &Options{
+				CASecretName:       testCASecretName,
+				ServerSecretName:   testServerSecretName,
+				WaitForProjection:  true,
+				AdditionalDNSNames: []string{"*.extra-pool.test-ns.svc.cluster.local"},
+			},
+			checkFiles:    true,
+			wantGenerated: false,
+		},
 		"Rotation: Corrupt Cert Body": {
 			existingObjects: []client.Object{
 				&corev1.Secret{
@@ -1078,6 +1138,31 @@ func TestManager_ExtKeyUsages(t *testing.T) {
 			t.Errorf("Expected default [ServerAuth], got %v", cert.ExtKeyUsage)
 		}
 	})
+}
+
+func TestDNSNameSetsEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		a, b []string
+		want bool
+	}{
+		"both empty":          {nil, nil, true},
+		"same order":          {[]string{"a", "b"}, []string{"a", "b"}, true},
+		"different order":     {[]string{"a", "b"}, []string{"b", "a"}, true},
+		"with duplicates":     {[]string{"a", "a", "b"}, []string{"a", "b"}, true},
+		"different length":    {[]string{"a"}, []string{"a", "b"}, false},
+		"same length, differ": {[]string{"a", "b"}, []string{"a", "c"}, false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := dnsNameSetsEqual(tc.a, tc.b); got != tc.want {
+				t.Errorf("dnsNameSetsEqual(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestManager_Misc(t *testing.T) {

--- a/pkg/resource-handler/controller/shard/reconcile_shared_infra.go
+++ b/pkg/resource-handler/controller/shard/reconcile_shared_infra.go
@@ -146,12 +146,31 @@ func (r *ShardReconciler) reconcilePgBackRestCerts(
 		ExtKeyUsages: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth,
 		},
-		Organization:  "Multigres",
-		Owner:         shard,
-		ComponentName: "pgbackrest",
-		Labels:        metadata.BuildStandardLabels(clusterName, "pgbackrest-tls"),
+		Organization:       "Multigres",
+		Owner:              shard,
+		ComponentName:      "pgbackrest",
+		Labels:             metadata.BuildStandardLabels(clusterName, "pgbackrest-tls"),
+		AdditionalDNSNames: pgBackRestPoolDNSNames(shard),
 	})
 	return rotator.Bootstrap(ctx)
+}
+
+// pgBackRestPoolDNSNames returns the DNS SANs needed for the pgBackRest server
+// cert to be validated when pgbackrest clients connect to a specific replica
+// pod for pg2 (standby) backups. Those connections target the pod's per-pool,
+// per-cell headless-Service FQDN (<pod>.<headless-svc>.<ns>.svc[.cluster.local]).
+func pgBackRestPoolDNSNames(shard *multigresv1alpha1.Shard) []string {
+	var dnsNames []string
+	for poolName, poolSpec := range shard.Spec.Pools {
+		for _, cellName := range poolSpec.Cells {
+			headlessName := buildPoolHeadlessServiceName(shard, string(poolName), string(cellName))
+			dnsNames = append(dnsNames,
+				fmt.Sprintf("*.%s.%s.svc", headlessName, shard.Namespace),
+				fmt.Sprintf("*.%s.%s.svc.cluster.local", headlessName, shard.Namespace),
+			)
+		}
+	}
+	return dnsNames
 }
 
 // reconcileBackupCipherSecret validates the pgBackRest backup encryption

--- a/pkg/resource-handler/controller/shard/reconcile_shared_infra_test.go
+++ b/pkg/resource-handler/controller/shard/reconcile_shared_infra_test.go
@@ -1,0 +1,105 @@
+package shard
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+func TestPgBackRestPoolDNSNames(t *testing.T) {
+	baseShard := func() *multigresv1alpha1.Shard {
+		return &multigresv1alpha1.Shard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-shard",
+				Namespace: "test-ns",
+				Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+			},
+			Spec: multigresv1alpha1.ShardSpec{
+				DatabaseName:   "testdb",
+				TableGroupName: "default",
+			},
+		}
+	}
+
+	t.Run("no pools yields no DNS names", func(t *testing.T) {
+		shard := baseShard()
+		if got := pgBackRestPoolDNSNames(shard); len(got) != 0 {
+			t.Errorf("expected no DNS names, got %v", got)
+		}
+	})
+
+	t.Run("single pool, single cell yields a scoped wildcard for that svc", func(t *testing.T) {
+		shard := baseShard()
+		shard.Spec.Pools = map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+			"primary": {Cells: []multigresv1alpha1.CellName{"zone1"}},
+		}
+
+		headlessName := buildPoolHeadlessServiceName(shard, "primary", "zone1")
+		want := []string{
+			fmt.Sprintf("*.%s.%s.svc", headlessName, shard.Namespace),
+			fmt.Sprintf("*.%s.%s.svc.cluster.local", headlessName, shard.Namespace),
+		}
+
+		got := pgBackRestPoolDNSNames(shard)
+		assertSameStringSet(t, got, want)
+	})
+
+	t.Run("multiple pools and cells yield one scoped wildcard pair each", func(t *testing.T) {
+		shard := baseShard()
+		shard.Spec.Pools = map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+			"primary": {Cells: []multigresv1alpha1.CellName{"zone1", "zone2"}},
+			"replica": {Cells: []multigresv1alpha1.CellName{"zone1"}},
+		}
+
+		var want []string
+		for poolName, cellNames := range map[string][]string{
+			"primary": {"zone1", "zone2"},
+			"replica": {"zone1"},
+		} {
+			for _, cellName := range cellNames {
+				headlessName := buildPoolHeadlessServiceName(shard, poolName, cellName)
+				want = append(want,
+					fmt.Sprintf("*.%s.%s.svc", headlessName, shard.Namespace),
+					fmt.Sprintf("*.%s.%s.svc.cluster.local", headlessName, shard.Namespace),
+				)
+			}
+		}
+
+		got := pgBackRestPoolDNSNames(shard)
+		assertSameStringSet(t, got, want)
+	})
+
+	t.Run("pool with no cells contributes no DNS names", func(t *testing.T) {
+		shard := baseShard()
+		shard.Spec.Pools = map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+			"empty": {},
+		}
+
+		if got := pgBackRestPoolDNSNames(shard); len(got) != 0 {
+			t.Errorf("expected no DNS names for a pool with no cells, got %v", got)
+		}
+	})
+}
+
+// assertSameStringSet fails the test if got and want don't contain the same
+// elements, ignoring order.
+func assertSameStringSet(t *testing.T, got, want []string) {
+	t.Helper()
+	gotSorted := append([]string(nil), got...)
+	wantSorted := append([]string(nil), want...)
+	sort.Strings(gotSorted)
+	sort.Strings(wantSorted)
+
+	if len(gotSorted) != len(wantSorted) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range gotSorted {
+		if gotSorted[i] != wantSorted[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
pgbackrest clients connect to a replica pod's per pooler, per-cell headless-Service FQDN (<pod>.<headless-svc>.<ns>.svc.cluster.local) for pg2 backups, but the server cert only had the generic pgbackrest.<ns>.svc[.cluster.local] SANs, causing TLS hostname verification to fail with:

```
[CryptoError] unable to find hostname
'...' in certificate common name or subject alternative names.
```

Retrieve each pool/cell's headless Service and add a scoped wildcard SAN per one (a single *.<ns>.svc... wildcard can't match since the headless-svc name is an extra label). Also rotate the server cert when desired DNS SANs drift from what's issued (not just on expiry/CA change), so existing deployments self-heal.