### PR TITLE
chore(deps): bump multigres to 7482a35

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -5,25 +5,25 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-300f673"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-7482a35"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiadminImage is the default container image for the Multiadmin component.
-	DefaultMultiadminImage = "ghcr.io/multigres/multigres:sha-300f673"
+	DefaultMultiadminImage = "ghcr.io/multigres/multigres:sha-7482a35"
 
 	// DefaultMultiadminWebImage is the default container image for the MultiadminWeb component.
 	DefaultMultiadminWebImage = "ghcr.io/multigres/multiadmin-web:sha-64da1ab"
 
 	// DefaultMultiorchImage is the default container image for the Multiorch component.
-	DefaultMultiorchImage = "ghcr.io/multigres/multigres:sha-300f673"
+	DefaultMultiorchImage = "ghcr.io/multigres/multigres:sha-7482a35"
 
 	// DefaultMultipoolerImage is the default container image for the Multipooler component.
-	DefaultMultipoolerImage = "ghcr.io/multigres/multigres:sha-300f673"
+	DefaultMultipoolerImage = "ghcr.io/multigres/multigres:sha-7482a35"
 
 	// DefaultMultigatewayImage is the default container image for the Multigateway component.
-	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-300f673"
+	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-7482a35"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
 	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
-	github.com/multigres/multigres v0.0.0-20260731210621-300f673c63ee
+	github.com/multigres/multigres v0.0.0-20260806152226-7482a35d187c
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/multigres/multigres v0.0.0-20260731210621-300f673c63ee h1:LVFvJTLSWlo1hs5PHCaGzY8C+mP8a/i8ZpkUc6rKC7k=
-github.com/multigres/multigres v0.0.0-20260731210621-300f673c63ee/go.mod h1:QV8N0aZ4DUoBJPgt1pj5d28D0Pa8JgImWjVzvXH/wLU=
+github.com/multigres/multigres v0.0.0-20260806152226-7482a35d187c h1:8yse4gZ6AoFMiEqNzoJ3IpC3RQN4vQLiU/my7wwS9ZY=
+github.com/multigres/multigres v0.0.0-20260806152226-7482a35d187c/go.mod h1:QV8N0aZ4DUoBJPgt1pj5d28D0Pa8JgImWjVzvXH/wLU=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=


### PR DESCRIPTION
Manual sync of multigres/multigres@7482a35d187c386cfcf1566493a39ec4e300e339 (sets pgbackrest server tls-server-address to "::" for IPv6-only pods).

- go.mod bumped to 7482a35d187c386cfcf1566493a39ec4e300e339
- Default runtime image tags in image_defaults.go bumped to sha-7482a35