### PR TITLE
feat(monitoring): add object identity to reconcile error metric

### DIFF
--- a/config/monitoring/prometheus-rules.yaml
+++ b/config/monitoring/prometheus-rules.yaml
@@ -12,7 +12,7 @@ spec:
         # ── Errors ────────────────────────────────────────────────
 
         - alert: MultigresClusterReconcileErrors
-          expr: rate(controller_runtime_reconcile_errors_total{controller=~"multigrescluster|tablegroup|shard|cell|toposerver"}[5m]) > 0
+          expr: rate(multigres_operator_reconcile_errors_total[5m]) > 0
           for: 5m
           labels:
             severity: warning
@@ -20,7 +20,8 @@ spec:
             summary: "MultigresCluster controller is failing reconciles"
             description: >-
               Controller {{ $labels.controller }} has had a non-zero reconcile
-              error rate for the last 5 minutes (current: {{ $value | humanize }}/s).
+              error rate for {{ $labels.namespace }}/{{ $labels.name }} over the
+              last 5 minutes (current: {{ $value | humanize }}/s).
             runbook_url: "https://github.com/multigres/multigres-operator/blob/main/docs/monitoring/runbooks/MultigresClusterReconcileErrors.md"
 
         - alert: MultigresClusterDegraded

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -54,7 +54,7 @@ type MultigresClusterReconciler struct {
 func (r *MultigresClusterReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
-) (ctrl.Result, error) {
+) (result ctrl.Result, err error) {
 	start := time.Now()
 	ctx, span := monitoring.StartReconcileSpan(
 		ctx,
@@ -64,13 +64,14 @@ func (r *MultigresClusterReconciler) Reconcile(
 		"MultigresCluster",
 	)
 	defer span.End()
+	defer func() { monitoring.RecordReconcileError(err, "multigrescluster", req.Name, req.Namespace) }()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 
 	l := log.FromContext(ctx)
 	l.V(1).Info("reconcile started")
 
 	cluster := &multigresv1alpha1.MultigresCluster{}
-	err := r.Get(ctx, req.NamespacedName, cluster)
+	err = r.Get(ctx, req.NamespacedName, cluster)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
+++ b/pkg/cluster-handler/controller/tablegroup/tablegroup_controller.go
@@ -39,7 +39,7 @@ type TableGroupReconciler struct {
 func (r *TableGroupReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
-) (ctrl.Result, error) {
+) (result ctrl.Result, err error) {
 	start := time.Now()
 	ctx, span := monitoring.StartReconcileSpan(
 		ctx,
@@ -49,6 +49,7 @@ func (r *TableGroupReconciler) Reconcile(
 		"TableGroup",
 	)
 	defer span.End()
+	defer func() { monitoring.RecordReconcileError(err, "tablegroup", req.Name, req.Namespace) }()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 
 	l := log.FromContext(ctx)

--- a/pkg/monitoring/metrics.go
+++ b/pkg/monitoring/metrics.go
@@ -107,6 +107,14 @@ var (
 		},
 		[]string{"cluster", "shard", "pool", "cell", "namespace"},
 	)
+
+	reconcileErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "multigres_operator_reconcile_errors_total",
+			Help: "Total number of reconcile errors, keyed by the object that failed to reconcile.",
+		},
+		[]string{"controller", "name", "namespace"},
+	)
 )
 
 func init() {
@@ -123,6 +131,7 @@ func init() {
 		lastBackupAgeSeconds,
 		drainOperationsTotal,
 		rollingUpdateInProgress,
+		reconcileErrorsTotal,
 	)
 }
 
@@ -142,5 +151,16 @@ func Collectors() []prometheus.Collector {
 		lastBackupAgeSeconds,
 		drainOperationsTotal,
 		rollingUpdateInProgress,
+		reconcileErrorsTotal,
 	}
+}
+
+// RecordReconcileError increments the per-object reconcile error counter.
+// It is a no-op when err is nil, so callers can defer it unconditionally
+// over a named error return value.
+func RecordReconcileError(err error, controller, name, namespace string) {
+	if err == nil {
+		return
+	}
+	reconcileErrorsTotal.WithLabelValues(controller, name, namespace).Inc()
 }

--- a/pkg/resource-handler/controller/cell/cell_controller.go
+++ b/pkg/resource-handler/controller/cell/cell_controller.go
@@ -46,7 +46,10 @@ type CellReconciler struct {
 }
 
 // Reconcile manages the Multigateway deployment and per-cell services for a Cell.
-func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *CellReconciler) Reconcile(
+	ctx context.Context,
+	req ctrl.Request,
+) (result ctrl.Result, err error) {
 	start := time.Now()
 	ctx, span := monitoring.StartReconcileSpan(
 		ctx,
@@ -56,6 +59,7 @@ func (r *CellReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		"Cell",
 	)
 	defer span.End()
+	defer func() { monitoring.RecordReconcileError(err, "cell", req.Name, req.Namespace) }()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 
 	logger := log.FromContext(ctx)

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -78,7 +78,7 @@ type ShardReconciler struct {
 func (r *ShardReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
-) (ctrl.Result, error) {
+) (result ctrl.Result, err error) {
 	start := time.Now()
 	ctx, span := monitoring.StartReconcileSpan(
 		ctx,
@@ -88,6 +88,7 @@ func (r *ShardReconciler) Reconcile(
 		"Shard",
 	)
 	defer span.End()
+	defer func() { monitoring.RecordReconcileError(err, "shard", req.Name, req.Namespace) }()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 
 	logger := log.FromContext(ctx)
@@ -387,7 +388,7 @@ func (r *ShardReconciler) Reconcile(
 	// this shard and leave observedGeneration stale.
 	dataPlaneCtx, dataPlaneCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer dataPlaneCancel()
-	result, err := r.reconcileDataPlane(dataPlaneCtx, shard)
+	result, err = r.reconcileDataPlane(dataPlaneCtx, shard)
 	if err != nil || result.RequeueAfter > 0 {
 		return result, err
 	}

--- a/pkg/resource-handler/controller/toposerver/toposerver_controller.go
+++ b/pkg/resource-handler/controller/toposerver/toposerver_controller.go
@@ -43,7 +43,7 @@ type TopoServerReconciler struct {
 func (r *TopoServerReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
-) (ctrl.Result, error) {
+) (result ctrl.Result, err error) {
 	start := time.Now()
 	ctx, span := monitoring.StartReconcileSpan(
 		ctx,
@@ -53,6 +53,7 @@ func (r *TopoServerReconciler) Reconcile(
 		"TopoServer",
 	)
 	defer span.End()
+	defer func() { monitoring.RecordReconcileError(err, "toposerver", req.Name, req.Namespace) }()
 	ctx = monitoring.EnrichLoggerWithTrace(ctx)
 
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
## Description

`controller_runtime_reconcile_errors_total` only carries a `controller` label, so the `MultigresClusterReconcileErrors` alert can't tell which object is failing. 

## Changes

Add `multigres_operator_reconcile_errors_total` with controller/name/namespace labels, incremented via defer in each reconciler, and point the alert at it.