### PR TITLE
chore: bump multigres default images to sha-8f020ac tag

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -5,25 +5,25 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-7edf67a"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-8f020ac"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiadminImage is the default container image for the Multiadmin component.
-	DefaultMultiadminImage = "ghcr.io/multigres/multigres:sha-7edf67a"
+	DefaultMultiadminImage = "ghcr.io/multigres/multigres:sha-8f020ac"
 
 	// DefaultMultiadminWebImage is the default container image for the MultiadminWeb component.
 	DefaultMultiadminWebImage = "ghcr.io/multigres/multiadmin-web:sha-64da1ab"
 
 	// DefaultMultiorchImage is the default container image for the Multiorch component.
-	DefaultMultiorchImage = "ghcr.io/multigres/multigres:sha-7edf67a"
+	DefaultMultiorchImage = "ghcr.io/multigres/multigres:sha-8f020ac"
 
 	// DefaultMultipoolerImage is the default container image for the Multipooler component.
-	DefaultMultipoolerImage = "ghcr.io/multigres/multigres:sha-7edf67a"
+	DefaultMultipoolerImage = "ghcr.io/multigres/multigres:sha-8f020ac"
 
 	// DefaultMultigatewayImage is the default container image for the Multigateway component.
-	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-7edf67a"
+	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-8f020ac"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
 	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"


### PR DESCRIPTION
Bump Multigres default images to commit https://github.com/multigres/multigres/commit/8f020ac085ed1f66b9d6b1aad509277dda8321cb