### PR TITLE
feat(shard): add custom queries to the postgres_exporter sidecar

### DIFF
--- a/pkg/resource-handler/controller/shard/configmap.go
+++ b/pkg/resource-handler/controller/shard/configmap.go
@@ -19,6 +19,15 @@ import (
 //go:embed templates/pg_hba_template.conf
 var DefaultPgHbaTemplate string
 
+// DefaultPostgresExporterQueries is the custom queries file served by the
+// postgres_exporter sidecar via --extend.query-path, alongside the default
+// collectors. It adds instance-level metrics commonly needed by monitoring
+// dashboards (database/WAL size, replication lag, backends, per-role
+// connections, max_connections).
+//
+//go:embed templates/postgres_exporter_queries.yml
+var DefaultPostgresExporterQueries string
+
 // BuildPgHbaConfigMap creates a ConfigMap containing the pg_hba.conf template.
 // This ConfigMap is shared across all pools in a shard and mounted into postgres containers.
 func BuildPgHbaConfigMap(
@@ -40,6 +49,36 @@ func BuildPgHbaConfigMap(
 		},
 		Data: map[string]string{
 			"pg_hba_template.conf": template,
+		},
+	}
+
+	if err := ctrl.SetControllerReference(shard, cm, scheme); err != nil {
+		return nil, fmt.Errorf("failed to set controller reference: %w", err)
+	}
+
+	return cm, nil
+}
+
+// BuildPostgresExporterQueriesConfigMap creates the operator-owned ConfigMap
+// holding the custom postgres_exporter queries for a shard. It is shared
+// across all pools in the shard and mounted into every pool pod's exporter
+// sidecar.
+func BuildPostgresExporterQueriesConfigMap(
+	shard *multigresv1alpha1.Shard,
+	scheme *runtime.Scheme,
+) (*corev1.ConfigMap, error) {
+	clusterName := shard.Labels["multigres.com/cluster"]
+	labels := metadata.BuildStandardLabels(clusterName, "postgres-exporter-queries")
+	labels = metadata.MergeLabels(labels, shard.GetObjectMeta().GetLabels())
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PostgresExporterQueriesConfigMapName(shard.Name),
+			Namespace: shard.Namespace,
+			Labels:    labels,
+		},
+		Data: map[string]string{
+			PostgresExporterQueriesConfigMapKey: DefaultPostgresExporterQueries,
 		},
 	}
 

--- a/pkg/resource-handler/controller/shard/configmap_test.go
+++ b/pkg/resource-handler/controller/shard/configmap_test.go
@@ -163,6 +163,77 @@ func TestBuildPostgresConfigMap(t *testing.T) {
 	})
 }
 
+func TestBuildPostgresExporterQueriesConfigMap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-shard",
+			Namespace: "default",
+			UID:       "test-uid",
+			Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+		},
+	}
+
+	t.Run("stores embedded queries under the queries key with an owner ref", func(t *testing.T) {
+		cm, err := BuildPostgresExporterQueriesConfigMap(shard, scheme)
+		if err != nil {
+			t.Fatalf("BuildPostgresExporterQueriesConfigMap() error = %v", err)
+		}
+		if cm.Name != PostgresExporterQueriesConfigMapName(shard.Name) {
+			t.Errorf(
+				"name = %q, want %q",
+				cm.Name,
+				PostgresExporterQueriesConfigMapName(shard.Name),
+			)
+		}
+		if cm.Namespace != shard.Namespace {
+			t.Errorf("namespace = %q, want %q", cm.Namespace, shard.Namespace)
+		}
+		if got := cm.Data[PostgresExporterQueriesConfigMapKey]; got != DefaultPostgresExporterQueries {
+			t.Errorf(
+				"Data[%q] doesn't match DefaultPostgresExporterQueries",
+				PostgresExporterQueriesConfigMapKey,
+			)
+		}
+		if len(cm.OwnerReferences) != 1 ||
+			cm.OwnerReferences[0].Name != shard.Name ||
+			cm.OwnerReferences[0].Kind != "Shard" {
+			t.Errorf("owner reference = %+v, want Shard/%s", cm.OwnerReferences, shard.Name)
+		}
+		if !ptr.Deref(cm.OwnerReferences[0].Controller, false) {
+			t.Error("expected owner reference to be controller")
+		}
+	})
+
+	t.Run("returns error on invalid scheme", func(t *testing.T) {
+		if _, err := BuildPostgresExporterQueriesConfigMap(shard, runtime.NewScheme()); err == nil {
+			t.Error("expected error with empty scheme")
+		}
+	})
+}
+
+func TestDefaultPostgresExporterQueriesEmbedded(t *testing.T) {
+	if DefaultPostgresExporterQueries == "" {
+		t.Fatal("DefaultPostgresExporterQueries is empty - go:embed may have failed")
+	}
+
+	// Each top-level key becomes the exporter's metric-name prefix.
+	for _, queryName := range []string{
+		"pg_database:",
+		"pg_wal:",
+		"pg_stat_database:",
+		"physical_replication_lag:",
+		"connection_stats:",
+		"max_connections:",
+	} {
+		if !strings.Contains(DefaultPostgresExporterQueries, "\n"+queryName) {
+			t.Errorf("DefaultPostgresExporterQueries missing query block %q", queryName)
+		}
+	}
+}
+
 func TestDefaultPgHbaTemplateEmbedded(t *testing.T) {
 	// Verify the embedded template is not empty
 	if DefaultPgHbaTemplate == "" {

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -120,6 +120,22 @@ const (
 	// ShardTLSCAFile is the mounted CA certificate path from the generated Secret.
 	ShardTLSCAFile = ShardTLSMountPath + "/ca.crt"
 
+	// PostgresExporterQueriesVolumeName is the volume for the custom
+	// postgres_exporter queries ConfigMap.
+	PostgresExporterQueriesVolumeName = "postgres-exporter-queries"
+
+	// PostgresExporterQueriesMountPath is where the custom queries file is
+	// mounted in the postgres-exporter container.
+	PostgresExporterQueriesMountPath = "/etc/postgres-exporter"
+
+	// PostgresExporterQueriesConfigMapKey is the key under which the operator
+	// stores the custom queries in its per-shard ConfigMap.
+	PostgresExporterQueriesConfigMapKey = "queries.yml"
+
+	// PostgresExporterQueriesFilePath is the full path passed to the exporter
+	// via --extend.query-path.
+	PostgresExporterQueriesFilePath = PostgresExporterQueriesMountPath + "/" + PostgresExporterQueriesConfigMapKey
+
 	// DefaultMultipoolerConnPoolGlobalCapacity keeps multipooler below pgctld's
 	// small default max_connections so admin and internal connections have headroom.
 	DefaultMultipoolerConnPoolGlobalCapacity = 40
@@ -139,6 +155,13 @@ func PgHbaConfigMapName(shardName string) string {
 // shard-level and not per-pool).
 func PostgresConfigMapName(shardName string) string {
 	return shardName + "-postgres-config"
+}
+
+// PostgresExporterQueriesConfigMapName returns the per-shard ConfigMap name
+// for the custom postgres_exporter queries. Shared across all pools in the
+// shard and mounted into every pool pod's exporter sidecar.
+func PostgresExporterQueriesConfigMapName(shardName string) string {
+	return shardName + "-exporter-queries"
 }
 
 func postgresPasswordSecretRef(shard *multigresv1alpha1.Shard) (name, key string) {
@@ -384,12 +407,13 @@ func buildPostgresExporterContainer(
 		Image: multigresv1alpha1.DefaultPostgresExporterImage,
 		Args: []string{
 			"--web.listen-address=:9187",
+			"--extend.query-path=" + PostgresExporterQueriesFilePath,
 		},
 		Ports: buildPostgresExporterContainerPorts(),
 		Env: []corev1.EnvVar{
 			{
 				Name:  "DATA_SOURCE_URI",
-				Value: "localhost:5432/postgres?sslmode=disable",
+				Value: "localhost:5432/postgres?sslmode=disable&connect_timeout=5&options=-c%20statement_timeout%3D8s",
 			},
 			{
 				Name:  "DATA_SOURCE_USER",
@@ -406,6 +430,11 @@ func buildPostgresExporterContainer(
 		),
 		VolumeMounts: []corev1.VolumeMount{
 			postgresPasswordVolumeMount(),
+			{
+				Name:      PostgresExporterQueriesVolumeName,
+				MountPath: PostgresExporterQueriesMountPath,
+				ReadOnly:  true,
+			},
 		},
 	}
 }
@@ -701,6 +730,21 @@ func buildPostgresConfigVolume(shard *multigresv1alpha1.Shard) corev1.Volume {
 	}
 }
 
+// buildPostgresExporterQueriesVolume projects the operator-owned custom
+// queries ConfigMap into the pod for the postgres-exporter sidecar.
+func buildPostgresExporterQueriesVolume(shard *multigresv1alpha1.Shard) corev1.Volume {
+	return corev1.Volume{
+		Name: PostgresExporterQueriesVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: PostgresExporterQueriesConfigMapName(shard.Name),
+				},
+			},
+		},
+	}
+}
+
 func buildPoolVolumes(shard *multigresv1alpha1.Shard, cellName string) []corev1.Volume {
 	volumes := []corev1.Volume{
 		buildSharedBackupVolume(shard, cellName),
@@ -708,6 +752,7 @@ func buildPoolVolumes(shard *multigresv1alpha1.Shard, cellName string) []corev1.
 		buildPgHbaVolume(shard.Name),
 		buildPostgresPasswordVolume(shard),
 		buildPostgresConfigVolume(shard),
+		buildPostgresExporterQueriesVolume(shard),
 	}
 	if certVol := buildPgBackRestCertVolume(shard); certVol != nil {
 		volumes = append(volumes, *certVol)

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -394,12 +394,13 @@ func TestBuildPostgresExporterContainer(t *testing.T) {
 		Image: multigresv1alpha1.DefaultPostgresExporterImage,
 		Args: []string{
 			"--web.listen-address=:9187",
+			"--extend.query-path=" + PostgresExporterQueriesFilePath,
 		},
 		Ports: buildPostgresExporterContainerPorts(),
 		Env: []corev1.EnvVar{
 			{
 				Name:  "DATA_SOURCE_URI",
-				Value: "localhost:5432/postgres?sslmode=disable",
+				Value: "localhost:5432/postgres?sslmode=disable&connect_timeout=5&options=-c%20statement_timeout%3D8s",
 			},
 			{
 				Name:  "DATA_SOURCE_USER",
@@ -419,6 +420,11 @@ func TestBuildPostgresExporterContainer(t *testing.T) {
 			{
 				Name:      PostgresPasswordVolumeName,
 				MountPath: PostgresPasswordMountPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      PostgresExporterQueriesVolumeName,
+				MountPath: PostgresExporterQueriesMountPath,
 				ReadOnly:  true,
 			},
 		},

--- a/pkg/resource-handler/controller/shard/reconcile_shared_infra.go
+++ b/pkg/resource-handler/controller/shard/reconcile_shared_infra.go
@@ -41,6 +41,33 @@ func (r *ShardReconciler) reconcilePgHbaConfigMap(
 	return nil
 }
 
+// reconcilePostgresExporterQueriesConfigMap creates or updates the custom
+// postgres_exporter queries ConfigMap for a shard. Shared across all pools and
+// mounted into every pool pod's exporter sidecar via --extend.query-path.
+func (r *ShardReconciler) reconcilePostgresExporterQueriesConfigMap(
+	ctx context.Context,
+	shard *multigresv1alpha1.Shard,
+) error {
+	desired, err := BuildPostgresExporterQueriesConfigMap(shard, r.Scheme)
+	if err != nil {
+		return fmt.Errorf("failed to build postgres_exporter queries ConfigMap: %w", err)
+	}
+
+	// Server Side Apply
+	desired.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
+	if err := r.Patch(
+		ctx,
+		desired,
+		client.Apply,
+		client.ForceOwnership,
+		client.FieldOwner("multigres-operator"),
+	); err != nil {
+		return fmt.Errorf("failed to apply postgres_exporter queries ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
 // reconcilePostgresPasswordSecret validates the referenced postgres password Secret.
 func (r *ShardReconciler) reconcilePostgresPasswordSecret(
 	ctx context.Context,

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -158,6 +158,21 @@ func (r *ShardReconciler) Reconcile(
 		return ctrl.Result{}, err
 	}
 
+	// Reconcile the postgres_exporter custom queries ConfigMap (mounted by the
+	// exporter sidecar in every pool pod).
+	if err := r.reconcilePostgresExporterQueriesConfigMap(ctx, shard); err != nil {
+		monitoring.RecordSpanError(span, err)
+		logger.Error(err, "Failed to reconcile postgres_exporter queries ConfigMap")
+		r.Recorder.Eventf(
+			shard,
+			"Warning",
+			"ConfigError",
+			"Failed to generate postgres_exporter queries: %v",
+			err,
+		)
+		return ctrl.Result{}, err
+	}
+
 	// Reconcile postgres password Secret (required by pgctld and multipooler)
 	if err := r.reconcilePostgresPasswordSecret(ctx, shard); err != nil {
 		monitoring.RecordSpanError(span, err)

--- a/pkg/resource-handler/controller/shard/templates/postgres_exporter_queries.yml
+++ b/pkg/resource-handler/controller/shard/templates/postgres_exporter_queries.yml
@@ -1,0 +1,108 @@
+# Custom postgres_exporter queries served via --extend.query-path.
+#
+# These extend the exporter's default collectors with instance-level metrics
+# commonly needed by monitoring dashboards: database disk size, WAL disk size,
+# physical replication lag, total backends, per-role connection breakdown, and
+# the configured max_connections cap. Metric names are chosen to not collide
+# with the default collectors.
+
+# Emitted as pg_database_size_mb.
+pg_database:
+  master: true
+  cache_seconds: 60
+  query: "SELECT SUM(pg_database_size(pg_database.datname)) / (1024 * 1024) as size_mb FROM pg_database"
+  metrics:
+    - size_mb:
+        usage: "GAUGE"
+        description: "Disk space used by the database"
+
+# Emitted as pg_wal_size_mb.
+pg_wal:
+  master: true
+  cache_seconds: 60
+  query: "SELECT SUM(size)/(1024 * 1024) as size_mb FROM pg_ls_waldir();"
+  metrics:
+    - size_mb:
+        usage: "GAUGE"
+        description: "Disk space used by WAL files"
+
+# Emitted as pg_stat_database_num_backends. The default pg_stat_database
+# collector emits per-database pg_stat_database_numbackends, this is the
+# cluster-wide sum.
+pg_stat_database:
+  master: true
+  cache_seconds: 60
+  query: "SELECT sum(numbackends) as num_backends FROM pg_stat_database"
+  metrics:
+    - num_backends:
+        usage: "GAUGE"
+        description: "The number of active backends"
+
+# For checking replication lag (physical_replication_lag_seconds) we first
+# check if the replica is connected to its primary and if the last WAL
+# received is equivalent to the last WAL replayed, if so return 0, otherwise
+# calculate replication lag as per usual.
+#
+# Additionally, we always return 0 lag if pg is not in recovery. Even though
+# pg_last_xact_replay_timestamp() is supposed to be null when we're not in
+# recovery (per the docs), in practice this does not seem to be the case,
+# resulting in non-zero results for primaries (even when there are no
+# replicas present).
+physical_replication_lag:
+  master: true
+  cache_seconds: 60
+  query: |
+    select case
+               when (select count(*) from pg_stat_wal_receiver) = 1 and pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn()
+                   then 0
+               when (not pg_is_in_recovery()) then 0
+               else coalesce(extract(epoch from now() - pg_last_xact_replay_timestamp()), 0)
+               end                                     as physical_replication_lag_seconds,
+           case
+               when pg_is_in_recovery()
+                   then case when pg_is_wal_replay_paused() = false then 0 else 1 end
+               else 0
+               end                                     as is_wal_replay_paused,
+           (select count(*) from pg_stat_wal_receiver) as is_connected_to_primary
+  metrics:
+    - physical_replication_lag_seconds:
+        usage: "GAUGE"
+        description: "Physical replication lag in seconds"
+    - is_wal_replay_paused:
+        usage: "GAUGE"
+        description: "Check if WAL replay has been paused"
+    - is_connected_to_primary:
+        usage: "GAUGE"
+        description: "Monitor connection to the primary database"
+
+# Emitted as connection_stats_connection_count{username=...}: client backends
+# grouped by role, so dashboards can break connections down per user.
+connection_stats:
+  master: true
+  cache_seconds: 60
+  query: |
+    SELECT usename AS username, COUNT(*) AS connection_count
+    FROM pg_stat_activity
+    WHERE backend_type = 'client backend'
+    GROUP BY usename
+  metrics:
+    - username:
+        usage: "LABEL"
+        description: "User making the connection"
+    - connection_count:
+        usage: "GAUGE"
+        description: "Number of active connections"
+
+# Emitted as max_connections_connection_count: Postgres's own configured cap,
+# distinct from the pooler-layer mg_pooler_config_max_server_connections.
+max_connections:
+  master: true
+  cache_seconds: 60
+  query: |
+    SELECT setting as connection_count
+    FROM pg_settings
+    WHERE name = 'max_connections';
+  metrics:
+    - connection_count:
+        usage: "GAUGE"
+        description: "Maximum allowed connections"


### PR DESCRIPTION
Serve a custom queries file via --extend.query-path, alongside the default collectors. Adds instance-level metrics commonly needed by monitoring dashboards: database disk size, WAL disk size, physical replication lag, total backends, per-role connection breakdown, and the configured max_connections cap.

The queries file is embedded in the operator, delivered as a per-shard ConfigMap (server-side applied, owner-ref'd), and mounted read-only into the exporter sidecar of every pool pod.

Updates on the ConfigMap won't trigger a rollout, this is a design decision to avoid unwanted pooler pod restarts.