### PR TITLE
fix(drain): CAS-fence cohort removal requests

### DIFF
--- a/pkg/data-handler/drain/drain.go
+++ b/pkg/data-handler/drain/drain.go
@@ -162,14 +162,14 @@ func ExecuteDrainStateMachine(
 					)
 					return true, nil
 				} else {
-					req := &multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-						Operation:  multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
-						StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
-					}
-					_, rpcErr := rpcClient.UpdateConsensusRule(ctx, primary, req)
-					if rpcErr != nil {
+					if err := removeStandbyFromConsensus(
+						ctx,
+						rpcClient,
+						primary,
+						myPooler.Id,
+					); err != nil {
 						logger.Error(
-							rpcErr,
+							err,
 							"Failed to remove pod from synchronous standby list",
 							"pod",
 							pod.Name,
@@ -216,14 +216,14 @@ func ExecuteDrainStateMachine(
 					)
 					return true, nil
 				} else {
-					req := &multipoolermanagerdatapb.UpdateConsensusRuleRequest{
-						Operation:  multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
-						StandbyIds: []*clustermetadatapb.ID{myPooler.Id},
-					}
-					_, rpcErr := rpcClient.UpdateConsensusRule(ctx, primary, req)
-					if rpcErr != nil {
+					if err := removeStandbyFromConsensus(
+						ctx,
+						rpcClient,
+						primary,
+						myPooler.Id,
+					); err != nil {
 						logger.Error(
-							rpcErr,
+							err,
 							"Standby removal verification failed, will retry",
 							"pod",
 							pod.Name,
@@ -249,6 +249,49 @@ func ExecuteDrainStateMachine(
 	}
 
 	return false, nil
+}
+
+// removeStandbyFromConsensus removes standbyID using the primary's current
+// decided rule as a compare-and-swap guard.
+func removeStandbyFromConsensus(
+	ctx context.Context,
+	rpcClient rpcclient.MultipoolerClient,
+	primary *clustermetadatapb.Multipooler,
+	standbyID *clustermetadatapb.ID,
+) error {
+	status, err := rpcClient.Status(
+		ctx,
+		primary,
+		&multipoolermanagerdatapb.StatusRequest{},
+	)
+	if err != nil {
+		return fmt.Errorf("reading primary consensus status: %w", err)
+	}
+	if status == nil || status.GetConsensusStatus() == nil {
+		return fmt.Errorf("primary status is missing consensus status")
+	}
+
+	position := status.GetConsensusStatus().GetCurrentPosition().GetPosition()
+	decision := position.GetDecision()
+	if decision == nil || decision.GetRuleNumber() == nil {
+		return fmt.Errorf("primary consensus status is missing a decided rule")
+	}
+	proposalRule := position.GetProposal().GetRuleNumber()
+	if proposalRule.GetCoordinatorTerm() != 0 || proposalRule.GetLeaderSubterm() != 0 {
+		return fmt.Errorf("primary consensus status has an undecided proposal")
+	}
+
+	request := &multipoolermanagerdatapb.UpdateConsensusRuleRequest{
+		Operation:            multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE,
+		StandbyIds:           []*clustermetadatapb.ID{standbyID},
+		ExpectedOutgoingRule: decision.GetRuleNumber(),
+		// CoordinatorId is intentionally omitted. The multipooler applies its
+		// documented server-side coordinator identity default.
+	}
+	if _, err := rpcClient.UpdateConsensusRule(ctx, primary, request); err != nil {
+		return fmt.Errorf("updating primary consensus rule: %w", err)
+	}
+	return nil
 }
 
 // UpdateDrainState patches a pod's drain state annotation.

--- a/pkg/data-handler/drain/drain_test.go
+++ b/pkg/data-handler/drain/drain_test.go
@@ -51,6 +51,18 @@ func (m *mockTopoStore) UnregisterMultipooler(ctx context.Context, id *clusterme
 type mockMultipoolerClient struct {
 	rpcclient.MultipoolerClient
 	UpdateConsensusRuleFunc func(ctx context.Context, pooler *clustermetadata.Multipooler, req *multipoolermanagerdata.UpdateConsensusRuleRequest) (*multipoolermanagerdata.UpdateConsensusRuleResponse, error)
+	StatusFunc              func(ctx context.Context, pooler *clustermetadata.Multipooler, req *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error)
+}
+
+func (m *mockMultipoolerClient) Status(
+	ctx context.Context,
+	pooler *clustermetadata.Multipooler,
+	req *multipoolermanagerdata.StatusRequest,
+) (*multipoolermanagerdata.StatusResponse, error) {
+	if m.StatusFunc != nil {
+		return m.StatusFunc(ctx, pooler, req)
+	}
+	return nil, fmt.Errorf("unexpected Status call")
 }
 
 func (m *mockMultipoolerClient) UpdateConsensusRule(
@@ -61,7 +73,155 @@ func (m *mockMultipoolerClient) UpdateConsensusRule(
 	if m.UpdateConsensusRuleFunc != nil {
 		return m.UpdateConsensusRuleFunc(ctx, pooler, req)
 	}
-	return nil, nil
+	return nil, fmt.Errorf("unexpected UpdateConsensusRule call")
+}
+
+func TestReplicaDrainConsensusStatusGuards(t *testing.T) {
+	t.Parallel()
+
+	undecided := decidedStatusResponse()
+	undecided.ConsensusStatus.CurrentPosition.Position.Proposal = &clustermetadata.ShardRule{
+		RuleNumber: &clustermetadata.RuleNumber{
+			CoordinatorTerm: 1,
+			LeaderSubterm:   2,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		status func(context.Context, *clustermetadata.Multipooler, *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error)
+	}{
+		{
+			name: "status RPC fails",
+			status: func(context.Context, *clustermetadata.Multipooler, *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error) {
+				return nil, fmt.Errorf("status unavailable")
+			},
+		},
+		{
+			name: "nil status response",
+			status: func(context.Context, *clustermetadata.Multipooler, *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error) {
+				return nil, nil
+			},
+		},
+		{
+			name: "missing consensus status",
+			status: func(context.Context, *clustermetadata.Multipooler, *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error) {
+				return &multipoolermanagerdata.StatusResponse{}, nil
+			},
+		},
+		{
+			name: "missing decided rule",
+			status: func(context.Context, *clustermetadata.Multipooler, *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error) {
+				return &multipoolermanagerdata.StatusResponse{
+					ConsensusStatus: &clustermetadata.ConsensusStatus{
+						CurrentPosition: &clustermetadata.PoolerPosition{
+							Position: &clustermetadata.RulePosition{},
+						},
+					},
+				}, nil
+			},
+		},
+		{
+			name: "undecided proposal",
+			status: func(context.Context, *clustermetadata.Multipooler, *multipoolermanagerdata.StatusRequest) (*multipoolermanagerdata.StatusResponse, error) {
+				return undecided, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := runtime.NewScheme()
+			if err := multigresv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add Multigres scheme: %v", err)
+			}
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add core scheme: %v", err)
+			}
+
+			shard := &multigresv1alpha1.Shard{
+				ObjectMeta: metav1.ObjectMeta{Name: "shard", Namespace: "default"},
+				Spec: multigresv1alpha1.ShardSpec{
+					Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+						"default": {Cells: []multigresv1alpha1.CellName{"cell1"}},
+					},
+				},
+			}
+			replicaPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "replica",
+					Namespace: "default",
+					Labels:    map[string]string{metadata.LabelMultigresCell: "cell1"},
+					Annotations: map[string]string{
+						metadata.AnnotationDrainState: metadata.DrainStateRequested,
+					},
+				},
+			}
+			primaryPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "primary", Namespace: "default"},
+			}
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(replicaPod, primaryPod).
+				Build()
+
+			replicaInfo := &topoclient.MultipoolerInfo{Multipooler: &clustermetadata.Multipooler{
+				Id:           &clustermetadata.ID{Cell: "cell1", Name: "replica"},
+				RoutingState: routingState(clustermetadata.RoutingRole_ROUTING_ROLE_REPLICA),
+			}}
+			primaryInfo := &topoclient.MultipoolerInfo{Multipooler: &clustermetadata.Multipooler{
+				Id:           &clustermetadata.ID{Cell: "cell1", Name: "primary"},
+				RoutingState: routingState(clustermetadata.RoutingRole_ROUTING_ROLE_PRIMARY),
+			}}
+			store := &mockTopoStore{
+				getMultipoolersByCellFunc: func(context.Context, string, *topoclient.GetMultipoolersByCellOptions) ([]*topoclient.MultipoolerInfo, error) {
+					return []*topoclient.MultipoolerInfo{replicaInfo, primaryInfo}, nil
+				},
+			}
+
+			updateCalled := false
+			rpc := &mockMultipoolerClient{
+				StatusFunc: tt.status,
+				UpdateConsensusRuleFunc: func(context.Context, *clustermetadata.Multipooler, *multipoolermanagerdata.UpdateConsensusRuleRequest) (*multipoolermanagerdata.UpdateConsensusRuleResponse, error) {
+					updateCalled = true
+					return &multipoolermanagerdata.UpdateConsensusRuleResponse{}, nil
+				},
+			}
+
+			requeue, err := drain.ExecuteDrainStateMachine(
+				context.Background(),
+				k8sClient,
+				rpc,
+				nil,
+				store,
+				shard,
+				replicaPod,
+			)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !requeue {
+				t.Fatal("expected drain to requeue")
+			}
+			if updateCalled {
+				t.Fatal("UpdateConsensusRule must not be called without a decided rule")
+			}
+
+			updated := &corev1.Pod{}
+			if err := k8sClient.Get(
+				context.Background(),
+				client.ObjectKeyFromObject(replicaPod),
+				updated,
+			); err != nil {
+				t.Fatalf("read replica pod: %v", err)
+			}
+			if got := updated.Annotations[metadata.AnnotationDrainState]; got != metadata.DrainStateRequested {
+				t.Fatalf("drain advanced on invalid consensus status: %q", got)
+			}
+		})
+	}
 }
 
 func TestUpdateDrainState_NilAnnotations(t *testing.T) {

--- a/pkg/data-handler/drain/execute_test.go
+++ b/pkg/data-handler/drain/execute_test.go
@@ -34,6 +34,15 @@ type mockRPCClient struct {
 	rpcclient.MultipoolerClient
 
 	updateConsensusRuleCalled bool
+	lastUpdateConsensusRule   *multipoolermanagerdatapb.UpdateConsensusRuleRequest
+}
+
+func (m *mockRPCClient) Status(
+	ctx context.Context,
+	pooler *clustermetadata.Multipooler,
+	request *multipoolermanagerdatapb.StatusRequest,
+) (*multipoolermanagerdatapb.StatusResponse, error) {
+	return decidedStatusResponse(), nil
 }
 
 func (m *mockRPCClient) UpdateConsensusRule(
@@ -42,7 +51,25 @@ func (m *mockRPCClient) UpdateConsensusRule(
 	request *multipoolermanagerdatapb.UpdateConsensusRuleRequest,
 ) (*multipoolermanagerdatapb.UpdateConsensusRuleResponse, error) {
 	m.updateConsensusRuleCalled = true
+	m.lastUpdateConsensusRule = request
 	return &multipoolermanagerdatapb.UpdateConsensusRuleResponse{}, nil
+}
+
+func decidedStatusResponse() *multipoolermanagerdatapb.StatusResponse {
+	return &multipoolermanagerdatapb.StatusResponse{
+		ConsensusStatus: &clustermetadata.ConsensusStatus{
+			CurrentPosition: &clustermetadata.PoolerPosition{
+				Position: &clustermetadata.RulePosition{
+					Decision: &clustermetadata.ShardRule{
+						RuleNumber: &clustermetadata.RuleNumber{
+							CoordinatorTerm: 1,
+							LeaderSubterm:   1,
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func (m *mockRPCClient) ExpireBackups(
@@ -148,6 +175,12 @@ func TestReplicaDrainFlow(t *testing.T) {
 	}
 	if !rpcMock.updateConsensusRuleCalled {
 		t.Fatalf("expected UpdateConsensusRule to be called")
+	}
+	if rpcMock.lastUpdateConsensusRule.GetExpectedOutgoingRule() == nil {
+		t.Fatalf("expected UpdateConsensusRule request to include ExpectedOutgoingRule")
+	}
+	if got := rpcMock.lastUpdateConsensusRule.GetOperation(); got != multipoolermanagerdatapb.RuleOperation_RULE_OPERATION_COHORT_REMOVE {
+		t.Fatalf("unexpected update operation: %v", got)
 	}
 
 	// Step 2: Draining -> Acknowledged


### PR DESCRIPTION
## Description

this PR fixes replica draining by adding the compare-and-swap guard required by `UpdateConsensusRule`.

The operator previously sent cohort-removal requests without `ExpectedOutgoingRule`, so the Multipooler rejected them and the drain retried until the emergency force-unregister timeout. The operator now reads the selected primary’s current consensus status, uses its decided rule to fence the removal request, and retries safely when the rule cannot be used.

## Main changes

- Reads `Status` from the selected primary and populates `ExpectedOutgoingRule` from its current decided consensus rule.
- Requeues without advancing the drain state when consensus status is missing, malformed, or contains an undecided proposal.
- Fetches a fresh rule on every reconciliation so RPC and compare-and-swap failures retry safely.
- Consolidates the duplicated standby-removal logic used by the `Requested` and `Draining` states.
- Leaves `CoordinatorId` unset intentionally so the Multipooler applies its server-side default.
- Tightens the drain mocks and tests so incomplete removal requests and unexpected RPC calls fail immediately.

## Testing

The tests cover successful CAS-fenced removal, status RPC failures, nil or incomplete consensus status, undecided proposals, and prevention of drain-state advancement on invalid status.

Closes #576