### PR TITLE
fix(ci): make govulncheck failures actionable

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -5,6 +5,7 @@ on:
     - cron: '0 6 * * *' # daily at 06:00 UTC
   pull_request:
     paths:
+      - '.github/workflows/govulncheck.yaml'
       - 'go.mod'
       - 'go.sum'
   workflow_dispatch: {}
@@ -26,20 +27,60 @@ jobs:
           go-version-file: ./go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: Run govulncheck (SARIF)
         id: scan
-        continue-on-error: true
-        run: govulncheck -format sarif ./... > govulncheck.sarif
+        shell: bash
+        run: |
+          status=0
+          govulncheck -format sarif ./... \
+            > govulncheck.sarif \
+            2> govulncheck.stderr || status=$?
+
+          sarif_valid=false
+          result=error
+          if jq -e '
+            .version == "2.1.0" and
+            (.runs | type == "array") and
+            ([.runs[].results? // []] | all(type == "array"))
+          ' govulncheck.sarif > /dev/null; then
+            sarif_valid=true
+            if jq -e '
+              [.runs[].results[]? | select(.level == "error")] |
+              length > 0
+            ' govulncheck.sarif > /dev/null; then
+              result=vulnerabilities
+            elif [[ "$status" -eq 0 ]]; then
+              result=clean
+            fi
+          fi
+
+          {
+            echo "exit_code=$status"
+            echo "sarif_valid=$sarif_valid"
+            echo "result=$result"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload SARIF file
+        if: ${{ steps.scan.outputs.sarif_valid == 'true' }}
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           sarif_file: govulncheck.sarif
 
-      - name: Run govulncheck (text)
-        if: ${{ steps.scan.outcome == 'failure' }}
+      - name: Report govulncheck result
+        if: ${{ always() && steps.scan.outputs.result != 'clean' }}
+        env:
+          RESULT: ${{ steps.scan.outputs.result }}
+          EXIT_CODE: ${{ steps.scan.outputs.exit_code }}
+        shell: bash
         run: |
-          echo "::error::govulncheck found vulnerabilities in Go dependencies"
-          govulncheck ./...
+          if [[ "$RESULT" == "vulnerabilities" ]]; then
+            echo "::error::govulncheck found reachable vulnerabilities in Go dependencies"
+          else
+            echo "::error::govulncheck could not complete the analysis (exit code ${EXIT_CODE:-unknown})"
+            if [[ -s govulncheck.stderr ]]; then
+              cat govulncheck.stderr >&2
+            fi
+          fi
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Containerfile for multigres-operator
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/multigres/multigres-operator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/tools/observer/Dockerfile
+++ b/tools/observer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/tools/observer/go.mod
+++ b/tools/observer/go.mod
@@ -1,12 +1,12 @@
 module github.com/multigres/multigres-operator/tools/observer
 
-go 1.26.5
+go 1.26.6
 
 // Keep the observer compiled against the operator API in this repository.
 replace github.com/multigres/multigres-operator => ../..
 
 require (
-	github.com/jackc/pgx/v5 v5.8.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/prometheus/client_golang v1.23.2
 	google.golang.org/grpc v1.82.1
 	k8s.io/api v0.35.0

--- a/tools/observer/go.sum
+++ b/tools/observer/go.sum
@@ -72,8 +72,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
-github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=


### PR DESCRIPTION
## Description

this PR makes the `govulncheck` workflow report actionable failures instead of masking scanner and package-loading errors as vulnerabilities or invalid SARIF uploads.

The previous version of this workflow uploaded SARIF unconditionally and treated every nonzero scanner exit as “vulnerabilities found.” A compilation or package-loading failure could therefore produce an empty or malformed SARIF file, fail during upload with an unrelated JSON error, and then rerun the complete scan.

## Main changes

- Pins `govulncheck` to `v1.7.0` instead of installing `latest`.
- Runs the scanner once and captures SARIF and stderr separately.
- Validates SARIF before uploading it to GitHub code scanning.
- Distinguishes reachable vulnerabilities from scanner, compilation, and package-loading failures.
- Uploads valid findings before failing the workflow and skips uploads for unusable output.
- Removes the duplicate text-mode scan.

## Testing

Exercised the pinned scanner locally against both an analysis failure, which produced no usable SARIF, and a completed scan with valid SARIF findings. 

Depends on https://github.com/multigres/multigres-operator/pull/584
Closes #579