### PR TITLE
fix(deps): update vulnerable Go dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Containerfile for multigres-operator
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/multigres/multigres-operator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/tools/observer/Dockerfile
+++ b/tools/observer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.23 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/tools/observer/go.mod
+++ b/tools/observer/go.mod
@@ -1,12 +1,12 @@
 module github.com/multigres/multigres-operator/tools/observer
 
-go 1.26.5
+go 1.26.6
 
 // Keep the observer compiled against the operator API in this repository.
 replace github.com/multigres/multigres-operator => ../..
 
 require (
-	github.com/jackc/pgx/v5 v5.8.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/prometheus/client_golang v1.23.2
 	google.golang.org/grpc v1.82.1
 	k8s.io/api v0.35.0

--- a/tools/observer/go.sum
+++ b/tools/observer/go.sum
@@ -72,8 +72,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
-github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=


### PR DESCRIPTION
## Description

this PR updates the Go toolchain and `pgx` dependency to patched releases after `govulncheck` identified reachable vulnerabilities in both the operator and observer modules.

The operator was built with Go 1.26.5, which contains the standard-library vulnerabilities surfaced by #583. The observer also used `pgx` v5.8.0, which is affected by a reachable SQL injection vulnerability. The builder images are updated alongside the module versions so local, CI, and container builds use the same patched releases.

## Main changes

- Bumps both Go modules from Go 1.26.5 to 1.26.6.
- Updates the operator and observer builder images to Go 1.26.6.
- Updates the observer from `pgx` v5.8.0 to v5.9.2.
