### PR TITLE
test(postgres-config): cover config value/formatting corner cases

### DIFF
--- a/pkg/postgresconfig/classify_test.go
+++ b/pkg/postgresconfig/classify_test.go
@@ -82,7 +82,7 @@ func TestRequiresRestartMatchesCatalogContext(t *testing.T) {
 		}
 	}
 	if total < 300 {
-		t.Fatalf("catalog has %d entries, expected the full PG17 set (389)", total)
+		t.Fatalf("catalog has %d entries, expected the full PG17 set", total)
 	}
 	// The majority of PG17 GUCs are reload-safe (sighup/user/superuser); if the
 	// context column were missing this would be ~0.

--- a/pkg/postgresconfig/hash_test.go
+++ b/pkg/postgresconfig/hash_test.go
@@ -101,6 +101,42 @@ work_mem = '8MB'
 	}
 }
 
+// TestSplitHashesValueFormatting documents how the reload-hash treats value
+// formatting. The hash is over the raw file token (with the renderer's quotes
+// undone), not PostgreSQL's normalized value:
+//
+//   - Quoting is transparent: '4MB' and 4MB unquote to the same token, so a
+//     quote-only edit does NOT move the hash and does NOT trigger a reload.
+//   - Whitespace inside the value IS significant: '4 MB' is a different token
+//     from '4MB', so it moves the hash and triggers a reload. PostgreSQL treats
+//     the two as equal, so this reload is redundant — but it is a plain SIGHUP
+//     with no restart and no dropped connections, so a redundant reload is
+//     harmless. Normalizing to PostgreSQL's canonical value would mean
+//     reimplementing its unit parser (and would still have to leave string GUCs
+//     like log_line_prefix, whose spaces are meaningful, untouched); that is out
+//     of scope here.
+func TestSplitHashesValueFormatting(t *testing.T) {
+	reloadHashOf := func(conf string) string {
+		_, split := StampAndSplit(conf)
+		return split.ReloadHash
+	}
+
+	// Quote-only difference: must NOT change the hash (no spurious reload).
+	if q, u := reloadHashOf("work_mem = '4MB'\n"), reloadHashOf("work_mem = 4MB\n"); q != u {
+		t.Errorf(
+			"quoting moved the reload-hash: '4MB'=%s vs 4MB=%s (a quote-only edit must not reload)",
+			q,
+			u,
+		)
+	}
+
+	// Internal whitespace: token-based hashing treats '4 MB' as distinct from
+	// '4MB'. This documents the known (harmless) redundant-reload behavior.
+	if s, q := reloadHashOf("work_mem = '4 MB'\n"), reloadHashOf("work_mem = '4MB'\n"); s == q {
+		t.Errorf("expected '4 MB' to hash differently from '4MB' under token-based comparison")
+	}
+}
+
 func TestStripInlineComment(t *testing.T) {
 	tests := []struct {
 		in, want string
@@ -113,11 +149,42 @@ func TestStripInlineComment(t *testing.T) {
 		{"'a#b'", "'a#b'"},
 		// escaped '' inside a quoted value does not end the string.
 		{"'it''s #1' # trailer", "'it''s #1' "},
+
+		// Malformed inputs must be handled without panicking. An unterminated
+		// quote leaves the parser "inside" the string, so any later '#' is treated
+		// as part of the value and the whole line is returned unchanged.
+		{"'4MB", "'4MB"},
+		{"'4MB # comment and no trailing quote", "'4MB # comment and no trailing quote"},
+		// A properly closed quote still strips the trailing comment; the stray ''
+		// after the '#' is never reached.
+		{"'4MB' # comment with '' inside", "'4MB' "},
+		// Trailing escaped '' keeps the parser inside the (unterminated) string.
+		{"'just a test ''", "'just a test ''"},
 	}
 	for _, tt := range tests {
 		if got := stripInlineComment(tt.in); got != tt.want {
 			t.Errorf("stripInlineComment(%q) = %q, want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+// TestSplitMalformedValuesNoPanic feeds a rendered config whose values are
+// malformed (unterminated quotes, stray doubled quotes) through the full
+// parse+split path. The point is robustness: a bad value must never panic or
+// wedge the reconcile — it is parsed to some deterministic token and hashed like
+// any other, and PostgreSQL is left to reject it at reload (surfaced as a
+// not-applied mismatch, never as a false "current").
+func TestSplitMalformedValuesNoPanic(t *testing.T) {
+	const malformed = `work_mem = '4MB
+maintenance_work_mem = '2MB # comment and no trailing quote
+random_page_cost = 'just a test ''
+log_line_prefix = '%h %m [%p] '		# ok, for contrast
+`
+	// Deterministic: the same malformed input always hashes the same way.
+	r1, s1 := StampAndSplit(malformed)
+	r2, s2 := StampAndSplit(malformed)
+	if s1.ReloadHash != s2.ReloadHash || s1.RestartHash != s2.RestartHash || r1 != r2 {
+		t.Errorf("split of malformed config is not deterministic")
 	}
 }
 

--- a/pkg/postgresconfig/validate_test.go
+++ b/pkg/postgresconfig/validate_test.go
@@ -108,7 +108,7 @@ func TestValidate_AggregatesAllProblems(t *testing.T) {
 func TestCatalogLoaded(t *testing.T) {
 	// The embedded catalog must be non-trivial and contain well-known params.
 	if len(catalog) < 300 {
-		t.Errorf("catalog has %d entries, expected the full PG17 set (389)", len(catalog))
+		t.Errorf("catalog has %d entries, expected the full PG17 set", len(catalog))
 	}
 	for name, want := range map[string]gucType{
 		"max_connections":  gucInteger,


### PR DESCRIPTION
## Summary

- Follow-up test coverage from the review of #572 (already merged) — adds the corner cases reviewers asked for and de-brittles one assertion. Test-only; no production behavior changes.
- Value formatting: pins that quoting is transparent (`'4MB'` and `4MB` hash identically, so a quote-only edit does not trigger a reload) while internal whitespace is significant (`'4 MB'` differs from `'4MB'`) — both documented, including why full unit-normalization (reimplementing PostgreSQL's unit parser) is out of scope.
- Malformed inputs (unterminated quotes, stray doubled quotes) are covered end to end: they never panic and stay deterministic through the parse+split path. An invalid value that passes our intentionally-lenient validation is left for PostgreSQL to reject at reload, surfaced as a not-applied mismatch rather than a false "current".
- Drops the hardcoded catalog entry count from the assertion messages in `validate_test.go` and `classify_test.go` so they do not churn as the PG catalog grows (the `< 300` floor is the real guard).

## Description

`StampAndSplit`/`SplitConfig` behavior is unchanged — the new tests lock in the current, intended behavior around config value parsing and hashing, and answer the "how is an invalid value handled?" question from the review: validation is deliberately lenient (it does not verify a unit is real or correctly-cased), PostgreSQL is the final arbiter at reload, and the pooler's applied-check keeps an errored value from ever being reported as applied.