### PR TITLE
chore: Bump default images to sha-66d2310

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -5,25 +5,25 @@ package v1alpha1
 const (
 	// DefaultPostgresImage is the default container image for PostgreSQL instances.
 	// Uses the pgctld image which bundles PostgreSQL, pgctld, and pgbackrest.
-	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-0dd4af9"
+	DefaultPostgresImage = "ghcr.io/multigres/pgctld:sha-66d2310"
 
 	// DefaultEtcdImage is the default container image for the managed Etcd cluster.
 	DefaultEtcdImage = "gcr.io/etcd-development/etcd:v3.6.7"
 
 	// DefaultMultiadminImage is the default container image for the Multiadmin component.
-	DefaultMultiadminImage = "ghcr.io/multigres/multigres:sha-0dd4af9"
+	DefaultMultiadminImage = "ghcr.io/multigres/multigres:sha-66d2310"
 
 	// DefaultMultiadminWebImage is the default container image for the MultiadminWeb component.
 	DefaultMultiadminWebImage = "ghcr.io/multigres/multiadmin-web:sha-64da1ab"
 
 	// DefaultMultiorchImage is the default container image for the Multiorch component.
-	DefaultMultiorchImage = "ghcr.io/multigres/multigres:sha-0dd4af9"
+	DefaultMultiorchImage = "ghcr.io/multigres/multigres:sha-66d2310"
 
 	// DefaultMultipoolerImage is the default container image for the Multipooler component.
-	DefaultMultipoolerImage = "ghcr.io/multigres/multigres:sha-0dd4af9"
+	DefaultMultipoolerImage = "ghcr.io/multigres/multigres:sha-66d2310"
 
 	// DefaultMultigatewayImage is the default container image for the Multigateway component.
-	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-0dd4af9"
+	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-66d2310"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
 	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.6
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
-	github.com/multigres/multigres v0.0.0-20260817113750-0dd4af92ad32
+	github.com/multigres/multigres v0.0.0-20260818083145-66d23106d645
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/multigres/multigres v0.0.0-20260817113750-0dd4af92ad32 h1:m9zv/Nli5nBCHX0o+/llqaMzpzF6OWq0rTpyR25G9qA=
-github.com/multigres/multigres v0.0.0-20260817113750-0dd4af92ad32/go.mod h1:QV8N0aZ4DUoBJPgt1pj5d28D0Pa8JgImWjVzvXH/wLU=
+github.com/multigres/multigres v0.0.0-20260818083145-66d23106d645 h1:bUmKZzhYemy997S87ZR2hNYlQuIq9jB2F7e0VwotDQk=
+github.com/multigres/multigres v0.0.0-20260818083145-66d23106d645/go.mod h1:QV8N0aZ4DUoBJPgt1pj5d28D0Pa8JgImWjVzvXH/wLU=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=


### PR DESCRIPTION
Bumping after passing the nightly compatibility check: https://github.com/multigres/multigres-operator/actions/runs/32233438365/job/96008191638