### PR TITLE
fix(exporter): disable settings metrics to unblock custom queries

### DIFF
--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -408,6 +408,7 @@ func buildPostgresExporterContainer(
 		Args: []string{
 			"--web.listen-address=:9187",
 			"--extend.query-path=" + PostgresExporterQueriesFilePath,
+			"--disable-settings-metrics",
 		},
 		Ports: buildPostgresExporterContainerPorts(),
 		Env: []corev1.EnvVar{

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -395,6 +395,7 @@ func TestBuildPostgresExporterContainer(t *testing.T) {
 		Args: []string{
 			"--web.listen-address=:9187",
 			"--extend.query-path=" + PostgresExporterQueriesFilePath,
+			"--disable-settings-metrics",
 		},
 		Ports: buildPostgresExporterContainerPorts(),
 		Env: []corev1.EnvVar{


### PR DESCRIPTION
A GUC with a NULL short_desc in pg_settings crashes postgres_exporter's internal settings probe on every scrape ("Scan error on column index 3, name \"short_desc\""). That error aborts the scrape before --extend.query-path queries run.

Current error log:
```
level=ERROR source=postgres_exporter.go:684 msg="error scraping dsn" err="error retrieving settings: Error retrieving rows on \"localhost:5432\": pg sql: Scan error on column index 3, name \"short_desc\": converting NULL to string is unsupported" 
[...]
```