### PR TITLE
chore: Bump postgres-exporter image

### DIFF
--- a/api/v1alpha1/image_defaults.go
+++ b/api/v1alpha1/image_defaults.go
@@ -26,5 +26,5 @@ const (
 	DefaultMultigatewayImage = "ghcr.io/multigres/multigres:sha-66d2310"
 
 	// DefaultPostgresExporterImage is the default container image for postgres_exporter sidecars.
-	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.18.1"
+	DefaultPostgresExporterImage = "quay.io/prometheuscommunity/postgres-exporter:v0.20.1"
 )


### PR DESCRIPTION
Set v0.20.1 as default.

Comes with https://github.com/prometheus-community/postgres_exporter/pull/1327