### PR TITLE
fix(postgresconfig): enable hot_standby_feedback for read replicas

### DIFF
--- a/pkg/postgresconfig/templates/postgresql.conf.tmpl
+++ b/pkg/postgresconfig/templates/postgresql.conf.tmpl
@@ -69,6 +69,11 @@ max_replication_slots = {{.MaxReplicationSlots}}	# (change requires restart)
 # lose its slot at checkpoint and require resynchronization.
 max_slot_wal_keep_size = {{.MaxSlotWalKeepSize}}   # in megabytes; -1 disables
 
+# - Standby Servers -
+# Lets a replica report its oldest needed xmin back to the primary so
+# autovacuum does not remove rows a replica query still has open.
+hot_standby_feedback = on
+
 #------------------------------------------------------------------------------
 # QUERY TUNING
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Enables `hot_standby_feedback = on` in the operator's rendered `postgresql.conf` baseline, so a standby reports its oldest needed xmin back to the primary.
- Without this, autovacuum on the primary can remove a row a replica's in-flight query still needs, and PostgreSQL resolves the conflict by cancelling the query on the replica.
- Relevant because replica reads are a first-class routing target in multigres (a dedicated replica port routes long-lived reads to standbys), not an occasional fallback.
- Applies uniformly to every pod in a shard (primary and replicas alike), since the setting is a no-op on whichever pod currently holds the primary role. No per-role branching needed in the render path.
- Companion change in `multigres/multigres` (pgctld's equivalent template): https://github.com/multigres/multigres/pull/1417