### PR TITLE
fix: allow keep alive pings for multipooler grpc server

### DIFF
--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -557,6 +557,10 @@ func buildMultipoolerContainer(
 			DefaultMultipoolerConnPoolAdminCapacity,
 		),
 		"--log-level=" + string(shard.Spec.LogLevels.Multipooler),
+		// Without this flag, multipooler's default gRPC keepalive enforcement policy
+		// rejects pings sent with no active RPC stream, and tears down the connection
+		// after a few strikes
+		"--grpc-server-keepalive-enforcement-policy-permit-without-stream=true",
 	}
 
 	if shard.Spec.Backup != nil {

--- a/pkg/resource-handler/controller/shard/containers_test.go
+++ b/pkg/resource-handler/controller/shard/containers_test.go
@@ -72,6 +72,7 @@ func TestBuildMultipoolerContainer(t *testing.T) {
 					"--connpool-global-capacity=40",
 					"--connpool-admin-capacity=5",
 					"--log-level=info",
+					"--grpc-server-keepalive-enforcement-policy-permit-without-stream=true",
 				},
 				Ports:     buildMultipoolerContainerPorts(),
 				Resources: corev1.ResourceRequirements{},
@@ -181,6 +182,7 @@ func TestBuildMultipoolerContainer(t *testing.T) {
 					"--connpool-global-capacity=40",
 					"--connpool-admin-capacity=5",
 					"--log-level=info",
+					"--grpc-server-keepalive-enforcement-policy-permit-without-stream=true",
 				},
 				Ports:     buildMultipoolerContainerPorts(),
 				Resources: corev1.ResourceRequirements{},
@@ -297,6 +299,7 @@ func TestBuildMultipoolerContainer(t *testing.T) {
 					"--connpool-global-capacity=40",
 					"--connpool-admin-capacity=5",
 					"--log-level=info",
+					"--grpc-server-keepalive-enforcement-policy-permit-without-stream=true",
 				},
 				Ports: buildMultipoolerContainerPorts(),
 				Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
## Summary
* We set the [following configs](https://github.com/multigres/multigres/blob/b0d11a0125275333187a1502e952c2655c594b0f/go/common/rpcclient/conn_cache.go#L346-L353) on the operator's rpc client but not on the multipooler rpc server 
* This results in `ReloadConfig` to failing since multipooler is effectively killing any connection made to it because it doesn't allow for keep alive pings.

## What's removed
NA

## No behavior change for live paths
NA

