### PR TITLE
fix: check if shard is healthy before reconciling pool

### DIFF
--- a/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
+++ b/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
@@ -318,28 +318,39 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// isPoolHealthy returns true if all non-draining, non-terminating, non-DRAINED
-// pods that will remain after scale-down are Ready. Extra pods (index >=
-// effectiveReplicas) are excluded so an unhealthy extra pod does not block its
-// own removal. DRAINED pods are excluded because they are expected to be
-// unhealthy and should not block scale-down of stand-in pods.
+// isPoolHealthy returns true if the pool/cell has at least effectiveReplicas
+// pods, and all of them — except extras (index >= effectiveReplicas) and
+// DRAINED/QUARANTINED pods — are Ready, with none draining or terminating.
+// Extra pods are excluded so an unhealthy extra pod does not block its own
+// removal. DRAINED and QUARANTINED pods are excluded because they are
+// expected to be unhealthy and should not block scale-down of stand-in pods.
+//
+// The count check matters because a pod drained all the way to deletion
+// disappears from existingPods entirely — there is nothing left for the
+// per-pod checks below to flag as unhealthy. Without it, a pool/cell sitting
+// at zero pods for a slot (deleted, replacement not yet created) would look
+// indistinguishable from a pool that was never touched.
 func isPoolHealthy(
 	existingPods map[string]*corev1.Pod,
 	effectiveReplicas int32,
 	shard *multigresv1alpha1.Shard,
 ) bool {
+	//nolint:gosec // pod count will never exceed int32 capacity
+	if int32(len(existingPods)) < effectiveReplicas {
+		return false
+	}
 	for _, pod := range existingPods {
-		if pod.Annotations[metadata.AnnotationDrainState] != "" || !pod.DeletionTimestamp.IsZero() {
-			continue
-		}
 		if idx, ok := resolvePodIndex(pod.Name); !ok || idx >= int(effectiveReplicas) {
 			continue
 		}
-		// DRAINED and QUARANTINED pods are expected to be unhealthy (the latter is
-		// being replaced by quarantine remediation); they must not block
-		// scale-down of other pods.
 		if role := resolvePodRole(shard, pod.Name); role == "DRAINED" || role == "QUARANTINED" {
 			continue
+		}
+		if !pod.DeletionTimestamp.IsZero() {
+			return false
+		}
+		if pod.Annotations[metadata.AnnotationDrainState] != "" {
+			return false
 		}
 		if !isPodReady(pod) {
 			return false
@@ -348,9 +359,8 @@ func isPoolHealthy(
 	return true
 }
 
-// isShardHealthy reports whether every pool pod across the whole shard — not
-// just the pool/cell currently being reconciled — is Ready, with none
-// draining or terminating
+// isShardHealthy reports whether every declared pool/cell across the whole
+// shard is healthy per isPoolHealthy
 func (r *ShardReconciler) isShardHealthy(
 	ctx context.Context,
 	shard *multigresv1alpha1.Shard,
@@ -372,23 +382,31 @@ func (r *ShardReconciler) isShardHealthy(
 		return false, fmt.Errorf("listing pool pods for shard health check: %w", err)
 	}
 
+	// Group every pod by pool/cell
+	podsByPoolCell := make(map[string]map[string]*corev1.Pod, len(shard.Spec.Pools))
 	for i := range podList.Items {
 		pod := &podList.Items[i]
-		// DRAINED and QUARANTINED pods are expected to be unhealthy and must
-		// not block other pods from rolling.
-		if role := resolvePodRole(shard, pod.Name); role == "DRAINED" || role == "QUARANTINED" {
-			continue
+		key := pod.Labels[metadata.LabelMultigresPool] + "/" + pod.Labels[metadata.LabelMultigresCell]
+		if podsByPoolCell[key] == nil {
+			podsByPoolCell[key] = map[string]*corev1.Pod{}
 		}
-		if !pod.DeletionTimestamp.IsZero() {
-			return false, nil
-		}
-		if pod.Annotations[metadata.AnnotationDrainState] != "" {
-			return false, nil
-		}
-		if !isPodReady(pod) {
-			return false, nil
+		podsByPoolCell[key][pod.Name] = pod
+	}
+
+	for poolName, pool := range shard.Spec.Pools {
+		for _, cell := range pool.Cells {
+			replicas := DefaultPoolReplicas
+			if pool.ReplicasPerCell != nil {
+				replicas = *pool.ReplicasPerCell
+			}
+			group := podsByPoolCell[string(poolName)+"/"+string(cell)]
+			effectiveReplicas := replicas + countDrainedPods(shard, group)
+			if !isPoolHealthy(group, effectiveReplicas, shard) {
+				return false, nil
+			}
 		}
 	}
+
 	return true, nil
 }
 

--- a/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
+++ b/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
@@ -346,6 +346,50 @@ func isPoolHealthy(
 	return true
 }
 
+// isShardHealthy reports whether every pool pod across the whole shard — not
+// just the pool/cell currently being reconciled — is Ready, with none
+// draining or terminating
+func (r *ShardReconciler) isShardHealthy(
+	ctx context.Context,
+	shard *multigresv1alpha1.Shard,
+) (bool, error) {
+	lbls := map[string]string{
+		metadata.LabelMultigresCluster:    shard.Labels[metadata.LabelMultigresCluster],
+		metadata.LabelMultigresDatabase:   string(shard.Spec.DatabaseName),
+		metadata.LabelMultigresTableGroup: string(shard.Spec.TableGroupName),
+		metadata.LabelMultigresShard:      string(shard.Spec.ShardName),
+		metadata.LabelAppComponent:        PoolComponentName,
+	}
+	podList := &corev1.PodList{}
+	if err := r.List(
+		ctx,
+		podList,
+		client.InNamespace(shard.Namespace),
+		client.MatchingLabels(lbls),
+	); err != nil {
+		return false, fmt.Errorf("listing pool pods for shard health check: %w", err)
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		// DRAINED and QUARANTINED pods are expected to be unhealthy and must
+		// not block other pods from rolling.
+		if role := resolvePodRole(shard, pod.Name); role == "DRAINED" || role == "QUARANTINED" {
+			continue
+		}
+		if !pod.DeletionTimestamp.IsZero() {
+			return false, nil
+		}
+		if pod.Annotations[metadata.AnnotationDrainState] != "" {
+			return false, nil
+		}
+		if !isPodReady(pod) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 // handleExternalDeletion handles a pod that has been deleted externally (e.g. kubectl delete).
 // Unscheduled pods are allowed to terminate; scheduled pods enter the drain state machine.
 func (r *ShardReconciler) handleExternalDeletion(
@@ -552,6 +596,14 @@ func (r *ShardReconciler) handleRollingUpdates(
 	}
 
 	if actionTaken || isAnyPodDraining || driftedCount == 0 {
+		return nil
+	}
+
+	// Refuse to start a new drain if some other pool/cell in this shard is
+	// already mid-rollout or has not yet come back Ready.
+	if healthy, err := r.isShardHealthy(ctx, shard); err != nil {
+		return err
+	} else if !healthy {
 		return nil
 	}
 

--- a/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
+++ b/pkg/resource-handler/controller/shard/reconcile_pool_pods.go
@@ -32,6 +32,7 @@ func (r *ShardReconciler) reconcilePoolPods(
 	poolName string,
 	cellName string,
 	poolSpec multigresv1alpha1.PoolSpec,
+	rollout *shardRolloutTracker,
 ) error {
 	logger := log.FromContext(ctx)
 	logger.V(1).Info("reconcilePoolPods started", "pool", poolName, "cell", cellName)
@@ -113,6 +114,7 @@ func (r *ShardReconciler) reconcilePoolPods(
 		driftedCount,
 		actionTaken,
 		inProgress,
+		rollout,
 	); err != nil {
 		return err
 	}
@@ -554,6 +556,22 @@ func (r *ShardReconciler) handleScaleDown(
 	return actionTaken, inProgress, nil
 }
 
+// shardRolloutTracker records, within a single Shard reconcile pass, whether
+// any pool has already initiated a drain. handleRollingUpdates checks this
+// before starting a new one so that a pool reconciled later in the same pass
+// doesn't rely on isShardHealthy's cached read having caught up
+type shardRolloutTracker struct {
+	started bool
+}
+
+func (t *shardRolloutTracker) HasStarted() bool {
+	return t.started
+}
+
+func (t *shardRolloutTracker) SetStarted() {
+	t.started = true
+}
+
 // handleRollingUpdates drains drifted pods one at a time (replicas first, primary last).
 func (r *ShardReconciler) handleRollingUpdates(
 	ctx context.Context,
@@ -563,6 +581,7 @@ func (r *ShardReconciler) handleRollingUpdates(
 	existingPods map[string]*corev1.Pod,
 	driftedCount int,
 	actionTaken, isAnyPodDraining bool,
+	rollout *shardRolloutTracker,
 ) error {
 	logger := log.FromContext(ctx)
 
@@ -599,8 +618,19 @@ func (r *ShardReconciler) handleRollingUpdates(
 		return nil
 	}
 
-	// Refuse to start a new drain if some other pool/cell in this shard is
-	// already mid-rollout or has not yet come back Ready.
+	// Prevent a new drain if some other pool in this shard already
+	// started one earlier in this same reconcile pass. Checked before
+	// isShardHealthy because that check reads through the controller cache,
+	// which may not yet reflect a drain another pool just initiated moments
+	// ago in this same pass.
+	if rollout.HasStarted() {
+		return nil
+	}
+
+	// Prevent a new drain if some other pool/cell in this shard is
+	// already mid-rollout or has not yet come back Ready (from an earlier
+	// reconcile pass — real wall-clock time since then means the cache has
+	// had time to catch up).
 	if healthy, err := r.isShardHealthy(ctx, shard); err != nil {
 		return err
 	} else if !healthy {
@@ -635,6 +665,7 @@ func (r *ShardReconciler) handleRollingUpdates(
 			if err := r.initiateDrain(ctx, pod); err != nil {
 				return fmt.Errorf("failed to initiate drain for drifted pod %s: %w", pod.Name, err)
 			}
+			rollout.SetStarted()
 			logger.Info(
 				"Initiated drain for drifted replica pod during rolling update",
 				"pod",
@@ -661,6 +692,7 @@ func (r *ShardReconciler) handleRollingUpdates(
 				err,
 			)
 		}
+		rollout.SetStarted()
 		logger.Info("Requested switchover for primary pod rolling update", "pod", waitPrimary.Name)
 		r.Recorder.Eventf(
 			shard,

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -368,8 +368,12 @@ func (r *ShardReconciler) Reconcile(
 
 	{
 		ctx, childSpan := monitoring.StartChildSpan(ctx, "Shard.ReconcilePools")
+		// Shared across every pool in this reconcile pass so that once one
+		// pool initiates a drain, no other pool starts one too in the same
+		// pass
+		rollout := &shardRolloutTracker{}
 		for poolName, pool := range shard.Spec.Pools {
-			if err := r.reconcilePool(ctx, shard, string(poolName), pool); err != nil {
+			if err := r.reconcilePool(ctx, shard, string(poolName), pool, rollout); err != nil {
 				monitoring.RecordSpanError(childSpan, err)
 				childSpan.End()
 				logger.Error(err, "Failed to reconcile pool", "poolName", poolName)
@@ -430,6 +434,7 @@ func (r *ShardReconciler) reconcilePool(
 	shard *multigresv1alpha1.Shard,
 	poolName string,
 	poolSpec multigresv1alpha1.PoolSpec,
+	rollout *shardRolloutTracker,
 ) error {
 	// Pools must have cells specified
 	if len(poolSpec.Cells) == 0 {
@@ -444,7 +449,7 @@ func (r *ShardReconciler) reconcilePool(
 		cellName := string(cell)
 
 		// Reconcile pool Pods and PVCs for this cell
-		if err := r.reconcilePoolPods(ctx, shard, poolName, cellName, poolSpec); err != nil {
+		if err := r.reconcilePoolPods(ctx, shard, poolName, cellName, poolSpec, rollout); err != nil {
 			return fmt.Errorf("failed to reconcile pool pods for cell %s: %w", cellName, err)
 		}
 

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -449,7 +449,14 @@ func (r *ShardReconciler) reconcilePool(
 		cellName := string(cell)
 
 		// Reconcile pool Pods and PVCs for this cell
-		if err := r.reconcilePoolPods(ctx, shard, poolName, cellName, poolSpec, rollout); err != nil {
+		if err := r.reconcilePoolPods(
+			ctx,
+			shard,
+			poolName,
+			cellName,
+			poolSpec,
+			rollout,
+		); err != nil {
 			return fmt.Errorf("failed to reconcile pool pods for cell %s: %w", cellName, err)
 		}
 

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -2914,6 +2914,7 @@ func TestHandleRollingUpdates(t *testing.T) {
 		err := r.handleRollingUpdates(
 			context.Background(), shard, poolName, cellName, poolSpec,
 			map[string]*corev1.Pod{}, 0, false, false,
+			&shardRolloutTracker{},
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -2952,6 +2953,7 @@ func TestHandleRollingUpdates(t *testing.T) {
 		err := r.handleRollingUpdates(
 			context.Background(), shard, poolName, cellName, poolSpec,
 			map[string]*corev1.Pod{podName: pod}, 1, true, false,
+			&shardRolloutTracker{},
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -2990,6 +2992,7 @@ func TestHandleRollingUpdates(t *testing.T) {
 		err := r.handleRollingUpdates(
 			context.Background(), shard, poolName, cellName, poolSpec,
 			map[string]*corev1.Pod{podName: pod}, 1, false, true,
+			&shardRolloutTracker{},
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -3029,6 +3032,7 @@ func TestHandleRollingUpdates(t *testing.T) {
 		err := r.handleRollingUpdates(
 			context.Background(), shard, poolName, cellName, poolSpec,
 			map[string]*corev1.Pod{podName: pod}, 1, false, false,
+			&shardRolloutTracker{},
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -3070,6 +3074,7 @@ func TestHandleRollingUpdates(t *testing.T) {
 		err := r.handleRollingUpdates(
 			context.Background(), shard, poolName, cellName, poolSpec,
 			map[string]*corev1.Pod{podName: pod}, 1, false, false,
+			&shardRolloutTracker{},
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -3118,6 +3123,7 @@ func TestHandleRollingUpdates(t *testing.T) {
 		err := r.handleRollingUpdates(
 			context.Background(), shard, poolName, cellName, poolSpec,
 			map[string]*corev1.Pod{podName0: pod0, podName1: pod1}, 2, false, false,
+			&shardRolloutTracker{},
 		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -3175,6 +3181,7 @@ func TestHandleRollingUpdates(t *testing.T) {
 		err := r.handleRollingUpdates(
 			context.Background(), shard, poolName, cellName, poolSpec,
 			map[string]*corev1.Pod{podName: pod}, 1, false, false,
+			&shardRolloutTracker{},
 		)
 		if err == nil {
 			t.Error("expected error when drain initiation fails")
@@ -3204,11 +3211,81 @@ func TestHandleRollingUpdates(t *testing.T) {
 		err := r.handleRollingUpdates(
 			context.Background(), shard, poolName, cellName, poolSpec,
 			map[string]*corev1.Pod{podName: pod}, 1, false, false,
+			&shardRolloutTracker{},
 		)
 		if err == nil {
 			t.Error("expected error when primary drain initiation fails")
 		}
 	})
+}
+
+// TestHandleRollingUpdates_RolloutTrackerBlocksSameShardPass verifies that a
+// rollout tracker already marked started blocks a new drain even when
+// isShardHealthy would otherwise say the shard is healthy.
+func TestHandleRollingUpdates_RolloutTrackerBlocksSameShardPass(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-shard",
+			Namespace: "default",
+			Labels:    map[string]string{metadata.LabelMultigresCluster: "test-cluster"},
+		},
+		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:   "db",
+			TableGroupName: "tg",
+			ShardName:      "s1",
+		},
+	}
+	poolSpec := multigresv1alpha1.PoolSpec{
+		Storage: multigresv1alpha1.StorageSpec{Size: "10Gi"},
+	}
+	podName := BuildPoolPodName(shard, "pool-2", "zone2", 0)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/component":  "shard-pool",
+				metadata.LabelMultigresCluster: "test-cluster",
+			},
+			Annotations: map[string]string{
+				metadata.AnnotationSpecHash: "old-hash",
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	// No other pods exist, so isShardHealthy alone would report the shard
+	// healthy (nothing draining or unready) and let this drain proceed.
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard, pod).Build()
+	r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	rollout := &shardRolloutTracker{}
+	rollout.SetStarted()
+
+	err := r.handleRollingUpdates(
+		context.Background(), shard, "pool-2", "zone2", poolSpec,
+		map[string]*corev1.Pod{podName: pod}, 1, false, false,
+		rollout,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &corev1.Pod{}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(pod), updated); err != nil {
+		t.Fatalf("failed to get pod: %v", err)
+	}
+	if updated.Annotations[metadata.AnnotationDrainState] != "" {
+		t.Error("drain annotation should not be set when the rollout tracker already started this pass")
+	}
 }
 
 func TestReconcileSharedBackupPVC(t *testing.T) {
@@ -3547,7 +3624,7 @@ func TestReconcilePoolPods_ErrorPaths(t *testing.T) {
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
 
-		err := r.reconcilePoolPods(context.Background(), shard, "primary", "zone1", poolSpec)
+		err := r.reconcilePoolPods(context.Background(), shard, "primary", "zone1", poolSpec, &shardRolloutTracker{})
 		if err == nil {
 			t.Error("expected error on pod list failure")
 		}
@@ -3566,7 +3643,7 @@ func TestReconcilePoolPods_ErrorPaths(t *testing.T) {
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
 
-		err := r.reconcilePoolPods(context.Background(), shard, "primary", "zone1", poolSpec)
+		err := r.reconcilePoolPods(context.Background(), shard, "primary", "zone1", poolSpec, &shardRolloutTracker{})
 		if err == nil {
 			t.Error("expected error on PVC list failure")
 		}
@@ -3884,7 +3961,7 @@ func TestReconcilePoolPods_ErrorPropagation(t *testing.T) {
 			},
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec)
+		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec, &shardRolloutTracker{})
 		if err == nil {
 			t.Fatal("expected error from createMissingResources")
 		}
@@ -3944,7 +4021,7 @@ func TestReconcilePoolPods_ErrorPropagation(t *testing.T) {
 			},
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec)
+		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec, &shardRolloutTracker{})
 		if err == nil {
 			t.Fatal("expected error from handleScaleDown")
 		}
@@ -3985,7 +4062,7 @@ func TestReconcilePoolPods_ErrorPropagation(t *testing.T) {
 			},
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec)
+		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec, &shardRolloutTracker{})
 		if err == nil {
 			t.Fatal("expected error from handleRollingUpdates")
 		}
@@ -4243,6 +4320,7 @@ func TestHandleRollingUpdates_SkipsUpToDatePods(t *testing.T) {
 	err := r.handleRollingUpdates(
 		t.Context(), shard, poolName, cellName, poolSpec,
 		existingPods, 1, false, false,
+		&shardRolloutTracker{},
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -4404,7 +4482,7 @@ func TestReconcilePool_PDBError(t *testing.T) {
 		},
 	})
 	r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-	err := r.reconcilePool(t.Context(), shard, "primary", poolSpec)
+	err := r.reconcilePool(t.Context(), shard, "primary", poolSpec, &shardRolloutTracker{})
 	if err == nil {
 		t.Fatal("expected error from PDB reconciliation")
 	}
@@ -4565,7 +4643,7 @@ func TestReconcilePool_PoolPodsError(t *testing.T) {
 	})
 	r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
 
-	err := r.reconcilePool(t.Context(), shard, "primary", poolSpec)
+	err := r.reconcilePool(t.Context(), shard, "primary", poolSpec, &shardRolloutTracker{})
 	if err == nil {
 		t.Fatal("expected error from reconcilePoolPods within reconcilePool")
 	}
@@ -5856,7 +5934,7 @@ func TestReconcilePoolPods_AdditionalErrorPaths(t *testing.T) {
 		})
 
 		r := &ShardReconciler{Client: fails, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-		err := r.reconcilePoolPods(context.Background(), shard, "main", "z1", poolSpec)
+		err := r.reconcilePoolPods(context.Background(), shard, "main", "z1", poolSpec, &shardRolloutTracker{})
 		if err == nil || !strings.Contains(err.Error(), "failed to create PVC") {
 			t.Fatalf("expected PVC creation error, got %v", err)
 		}

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -3284,7 +3284,9 @@ func TestHandleRollingUpdates_RolloutTrackerBlocksSameShardPass(t *testing.T) {
 		t.Fatalf("failed to get pod: %v", err)
 	}
 	if updated.Annotations[metadata.AnnotationDrainState] != "" {
-		t.Error("drain annotation should not be set when the rollout tracker already started this pass")
+		t.Error(
+			"drain annotation should not be set when the rollout tracker already started this pass",
+		)
 	}
 }
 
@@ -3624,7 +3626,14 @@ func TestReconcilePoolPods_ErrorPaths(t *testing.T) {
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
 
-		err := r.reconcilePoolPods(context.Background(), shard, "primary", "zone1", poolSpec, &shardRolloutTracker{})
+		err := r.reconcilePoolPods(
+			context.Background(),
+			shard,
+			"primary",
+			"zone1",
+			poolSpec,
+			&shardRolloutTracker{},
+		)
 		if err == nil {
 			t.Error("expected error on pod list failure")
 		}
@@ -3643,7 +3652,14 @@ func TestReconcilePoolPods_ErrorPaths(t *testing.T) {
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
 
-		err := r.reconcilePoolPods(context.Background(), shard, "primary", "zone1", poolSpec, &shardRolloutTracker{})
+		err := r.reconcilePoolPods(
+			context.Background(),
+			shard,
+			"primary",
+			"zone1",
+			poolSpec,
+			&shardRolloutTracker{},
+		)
 		if err == nil {
 			t.Error("expected error on PVC list failure")
 		}
@@ -3961,7 +3977,14 @@ func TestReconcilePoolPods_ErrorPropagation(t *testing.T) {
 			},
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec, &shardRolloutTracker{})
+		err := r.reconcilePoolPods(
+			t.Context(),
+			shard,
+			poolName,
+			cellName,
+			poolSpec,
+			&shardRolloutTracker{},
+		)
 		if err == nil {
 			t.Fatal("expected error from createMissingResources")
 		}
@@ -4021,7 +4044,14 @@ func TestReconcilePoolPods_ErrorPropagation(t *testing.T) {
 			},
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec, &shardRolloutTracker{})
+		err := r.reconcilePoolPods(
+			t.Context(),
+			shard,
+			poolName,
+			cellName,
+			poolSpec,
+			&shardRolloutTracker{},
+		)
 		if err == nil {
 			t.Fatal("expected error from handleScaleDown")
 		}
@@ -4062,7 +4092,14 @@ func TestReconcilePoolPods_ErrorPropagation(t *testing.T) {
 			},
 		})
 		r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-		err := r.reconcilePoolPods(t.Context(), shard, poolName, cellName, poolSpec, &shardRolloutTracker{})
+		err := r.reconcilePoolPods(
+			t.Context(),
+			shard,
+			poolName,
+			cellName,
+			poolSpec,
+			&shardRolloutTracker{},
+		)
 		if err == nil {
 			t.Fatal("expected error from handleRollingUpdates")
 		}
@@ -5934,7 +5971,14 @@ func TestReconcilePoolPods_AdditionalErrorPaths(t *testing.T) {
 		})
 
 		r := &ShardReconciler{Client: fails, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
-		err := r.reconcilePoolPods(context.Background(), shard, "main", "z1", poolSpec, &shardRolloutTracker{})
+		err := r.reconcilePoolPods(
+			context.Background(),
+			shard,
+			"main",
+			"z1",
+			poolSpec,
+			&shardRolloutTracker{},
+		)
 		if err == nil || !strings.Contains(err.Error(), "failed to create PVC") {
 			t.Fatalf("expected PVC creation error, got %v", err)
 		}

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -2665,13 +2665,19 @@ func TestIsPoolHealthy(t *testing.T) {
 		},
 	}
 
-	t.Run("empty pool is healthy", func(t *testing.T) {
-		if !isPoolHealthy(map[string]*corev1.Pod{}, 1, shard) {
-			t.Error("expected empty pool to be healthy")
+	t.Run("empty pool is unhealthy when replicas are expected", func(t *testing.T) {
+		if isPoolHealthy(map[string]*corev1.Pod{}, 1, shard) {
+			t.Error("expected empty pool with 1 expected replica to be unhealthy")
 		}
 	})
 
-	t.Run("draining pod is excluded from health check", func(t *testing.T) {
+	t.Run("empty pool is healthy when no replicas are expected", func(t *testing.T) {
+		if !isPoolHealthy(map[string]*corev1.Pod{}, 0, shard) {
+			t.Error("expected empty pool with 0 expected replicas to be healthy")
+		}
+	})
+
+	t.Run("draining pod makes pool unhealthy", func(t *testing.T) {
 		pods := map[string]*corev1.Pod{
 			"pod-0": {
 				ObjectMeta: metav1.ObjectMeta{
@@ -2687,12 +2693,12 @@ func TestIsPoolHealthy(t *testing.T) {
 				},
 			},
 		}
-		if !isPoolHealthy(pods, 1, shard) {
-			t.Error("draining pod should be excluded from health check")
+		if isPoolHealthy(pods, 1, shard) {
+			t.Error("draining pod should make the pool unhealthy")
 		}
 	})
 
-	t.Run("pod being deleted is excluded from health check", func(t *testing.T) {
+	t.Run("pod being deleted makes pool unhealthy", func(t *testing.T) {
 		now := metav1.Now()
 		pods := map[string]*corev1.Pod{
 			"pod-0": {
@@ -2708,8 +2714,8 @@ func TestIsPoolHealthy(t *testing.T) {
 				},
 			},
 		}
-		if !isPoolHealthy(pods, 1, shard) {
-			t.Error("terminating pod should be excluded from health check")
+		if isPoolHealthy(pods, 1, shard) {
+			t.Error("terminating pod should make the pool unhealthy")
 		}
 	})
 
@@ -3286,6 +3292,77 @@ func TestHandleRollingUpdates_RolloutTrackerBlocksSameShardPass(t *testing.T) {
 	if updated.Annotations[metadata.AnnotationDrainState] != "" {
 		t.Error(
 			"drain annotation should not be set when the rollout tracker already started this pass",
+		)
+	}
+}
+
+// TestIsShardHealthy_MissingPodCountsAsUnhealthy verifies that a pool/cell
+// with fewer pods than its declared ReplicasPerCell is treated as unhealthy,
+// even though every pod that does exist is Ready. A pod drained all the way
+// to deletion disappears from the pod list entirely — there is nothing left
+// for a per-pod check to flag — so isShardHealthy must also compare pod
+// counts against shard.Spec.Pools, not just judge the pods it happens to
+// find.
+func TestIsShardHealthy_MissingPodCountsAsUnhealthy(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-shard",
+			Namespace: "default",
+			Labels:    map[string]string{metadata.LabelMultigresCluster: "test-cluster"},
+		},
+		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:   "db",
+			TableGroupName: "tg",
+			ShardName:      "s1",
+			Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				// pool-1/zone1 is declared but has no pod at all — as if its
+				// only replica was drained all the way to deletion and the
+				// replacement hasn't been created yet.
+				"pool-1": {
+					ReplicasPerCell: ptr.To(int32(1)),
+					Cells:           []multigresv1alpha1.CellName{"zone1"},
+				},
+				"pool-2": {
+					ReplicasPerCell: ptr.To(int32(1)),
+					Cells:           []multigresv1alpha1.CellName{"zone2"},
+				},
+			},
+		},
+	}
+
+	healthyPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BuildPoolPodName(shard, "pool-2", "zone2", 0),
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/component":  "shard-pool",
+				metadata.LabelMultigresCluster: "test-cluster",
+				metadata.LabelMultigresPool:    "pool-2",
+				metadata.LabelMultigresCell:    "zone2",
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shard, healthyPod).Build()
+	r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	healthy, err := r.isShardHealthy(context.Background(), shard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if healthy {
+		t.Error(
+			"isShardHealthy should be false when pool-1/zone1 has no pod at all, " +
+				"even though the only pod that exists (pool-2/zone2) is Ready",
 		)
 	}
 }

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -2015,9 +2015,17 @@ func TestRollingUpdateOrder(t *testing.T) {
 					metadata.AnnotationSpecHash: "old-hash",
 				},
 			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
 		}
 		if err := c.Create(context.Background(), pod); err != nil {
 			t.Fatalf("failed to create pod: %v", err)
+		}
+		if err := c.Status().Update(context.Background(), pod); err != nil {
+			t.Fatalf("failed to set pod status: %v", err)
 		}
 	}
 
@@ -2051,6 +2059,115 @@ func TestRollingUpdateOrder(t *testing.T) {
 	}
 	if drainCount != 1 {
 		t.Errorf("Expected exactly 1 pod to have drain-requested annotation, got %d", drainCount)
+	}
+}
+
+// TestRollingUpdateWaitsForSiblingCell verifies that a pool does not start
+// draining its drifted pod while a *different* pool/cell in the same shard
+// has a pod that is not yet Ready. Each pool is reconciled independently (one
+// per cell), so without a shard-wide health check every pool could each
+// decide it is safe to drain at the same time, taking down every cell at
+// once.
+func TestRollingUpdateWaitsForSiblingCell(t *testing.T) {
+	t.Parallel()
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	poolSpec := multigresv1alpha1.PoolSpec{
+		ReplicasPerCell: ptr.To(int32(1)),
+		Storage:         multigresv1alpha1.StorageSpec{Size: "10Gi"},
+	}
+
+	shardObj := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-shard", Namespace: "default",
+			Labels: map[string]string{metadata.LabelMultigresCluster: "test-cluster"},
+		},
+		Spec: multigresv1alpha1.ShardSpec{
+			DatabaseName:   "db",
+			TableGroupName: "tg",
+			ShardName:      "s1",
+		},
+	}
+
+	baseLabels := func(pool, cell string) map[string]string {
+		return map[string]string{
+			"app.kubernetes.io/component":     "shard-pool",
+			"app.kubernetes.io/instance":      "test-cluster",
+			metadata.LabelMultigresCluster:    "test-cluster",
+			metadata.LabelMultigresDatabase:   "db",
+			metadata.LabelMultigresTableGroup: "tg",
+			metadata.LabelMultigresShard:      "s1",
+			metadata.LabelMultigresPool:       pool,
+			metadata.LabelMultigresCell:       cell,
+		}
+	}
+
+	// zone1's pod is not draining or deleted, but has no Ready condition —
+	// e.g. it was just recreated by an earlier rollout step and is still
+	// starting up. Its spec hash is irrelevant here: isShardHealthy only
+	// looks at drain state, deletion, and readiness.
+	zone1Pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BuildPoolPodName(shardObj, "pool-1", "zone1", 0),
+			Namespace: "default",
+			Labels:    baseLabels("pool-1", "zone1"),
+		},
+	}
+
+	// zone2's pod is drifted (old spec hash) and otherwise healthy — a normal
+	// candidate for the rolling update.
+	zone2Pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BuildPoolPodName(shardObj, "pool-2", "zone2", 0),
+			Namespace: "default",
+			Labels:    baseLabels("pool-2", "zone2"),
+			Annotations: map[string]string{
+				metadata.AnnotationSpecHash: "old-hash",
+			},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shardObj).Build()
+	r := &ShardReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
+
+	for _, pod := range []*corev1.Pod{zone1Pod, zone2Pod} {
+		if err := c.Create(context.Background(), pod); err != nil {
+			t.Fatalf("failed to create pod %s: %v", pod.Name, err)
+		}
+		if err := c.Status().Update(context.Background(), pod); err != nil {
+			t.Fatalf("failed to set status for pod %s: %v", pod.Name, err)
+		}
+	}
+
+	if err := r.reconcilePoolPods(
+		context.Background(),
+		shardObj,
+		"pool-2",
+		"zone2",
+		poolSpec,
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var updated corev1.Pod
+	if err := c.Get(
+		context.Background(),
+		client.ObjectKeyFromObject(zone2Pod),
+		&updated,
+	); err != nil {
+		t.Fatalf("failed to get pod: %v", err)
+	}
+	if updated.Annotations[metadata.AnnotationDrainState] != "" {
+		t.Error(
+			"pool-2 should not drain its drifted pod while pool-1's pod in zone1 is not Ready",
+		)
 	}
 }
 

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -2102,6 +2102,16 @@ func TestRollingUpdateWaitsForSiblingCell(t *testing.T) {
 			DatabaseName:   "db",
 			TableGroupName: "tg",
 			ShardName:      "s1",
+			Pools: map[multigresv1alpha1.PoolName]multigresv1alpha1.PoolSpec{
+				"pool-1": {
+					ReplicasPerCell: ptr.To(int32(1)),
+					Cells:           []multigresv1alpha1.CellName{"zone1"},
+				},
+				"pool-2": {
+					ReplicasPerCell: ptr.To(int32(1)),
+					Cells:           []multigresv1alpha1.CellName{"zone2"},
+				},
+			},
 		},
 	}
 

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -1688,7 +1688,7 @@ func TestScaleDown_ExternallyDeletedExtraPod(t *testing.T) {
 	}
 
 	// 1. Run reconcile loop
-	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec)
+	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec, &shardRolloutTracker{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2030,7 +2030,7 @@ func TestRollingUpdateOrder(t *testing.T) {
 	}
 
 	// Run reconcile loop
-	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec)
+	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec, &shardRolloutTracker{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2152,6 +2152,7 @@ func TestRollingUpdateWaitsForSiblingCell(t *testing.T) {
 		"pool-2",
 		"zone2",
 		poolSpec,
+		&shardRolloutTracker{},
 	); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2237,7 +2238,7 @@ func TestDrainedPodReplacement(t *testing.T) {
 	}
 
 	// Run reconcile loop
-	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec)
+	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec, &shardRolloutTracker{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/resource-handler/controller/shard/shard_controller_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_test.go
@@ -1688,7 +1688,14 @@ func TestScaleDown_ExternallyDeletedExtraPod(t *testing.T) {
 	}
 
 	// 1. Run reconcile loop
-	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec, &shardRolloutTracker{})
+	err := r.reconcilePoolPods(
+		context.Background(),
+		shardObj,
+		"primary",
+		"zone1",
+		poolSpec,
+		&shardRolloutTracker{},
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2030,7 +2037,14 @@ func TestRollingUpdateOrder(t *testing.T) {
 	}
 
 	// Run reconcile loop
-	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec, &shardRolloutTracker{})
+	err := r.reconcilePoolPods(
+		context.Background(),
+		shardObj,
+		"primary",
+		"zone1",
+		poolSpec,
+		&shardRolloutTracker{},
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2238,7 +2252,14 @@ func TestDrainedPodReplacement(t *testing.T) {
 	}
 
 	// Run reconcile loop
-	err := r.reconcilePoolPods(context.Background(), shardObj, "primary", "zone1", poolSpec, &shardRolloutTracker{})
+	err := r.reconcilePoolPods(
+		context.Background(),
+		shardObj,
+		"primary",
+		"zone1",
+		poolSpec,
+		&shardRolloutTracker{},
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
* When the pool is reconciled (e.g. due to a change in the postgres image version), rolling updates need to consider the overall shard health before rolling the next pod. `isShardHealthy` reports whether every pool pod across the whole shard is Ready, and does not let more than 1 pool pod in the shard be unhealthy. This guards against the following cases:
  1. when `replicasPerCell = 1` across pools, it can lead to all pools being potentially reconciled all at once
  2. when `replicasPerCell > 1` across pools, it can lead to pods being cycled through in back-to-back reconciles without waiting for the previous replacement to actually become healthy, resulting in more than one replica in the same pool down at overlapping times

* We could potentially make it more efficient in the future by allowing multiple pools to be reconciled independently at once, but that extra overhead in complexity is not worth the tradeoff at this stage