### PR TITLE
fix(shard): debounce incomplete posture observations

### DIFF
--- a/pkg/resource-handler/controller/shard/reconcile_data_plane.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane.go
@@ -293,11 +293,16 @@ func (r *ShardReconciler) reconcilePosture(
 		)
 	}
 
-	strikes := r.recordPostureObservation(shard, inconsistent)
+	// A single flaky RPC (dial error, EOF, stale pod) must not be enough to
+	// drop a shard out of Healthy any more than a single role mismatch is.
+	// Both inconsistent and merely-incomplete observations share the same
+	// strike counter and debounce window.
+	unsettled := inconsistent || result.Incomplete
+	strikes := r.recordPostureObservation(shard, unsettled)
 
 	prevFalse := status.IsConditionFalse(shard.Status.Conditions, posture.ConditionConsistent)
 
-	if !inconsistent || strikes >= postureStrikeThreshold {
+	if !unsettled || strikes >= postureStrikeThreshold {
 		posture.Apply(shard, result)
 	} else {
 		shard.Status.PodPostures = result.Postures
@@ -311,7 +316,7 @@ func (r *ShardReconciler) reconcilePosture(
 		r.Recorder.Eventf(shard, "Warning", reason, result.Message)
 	}
 
-	return inconsistent && strikes < postureStrikeThreshold, nil
+	return unsettled && strikes < postureStrikeThreshold, nil
 }
 
 func withPostureRequeue(result ctrl.Result, pending bool) ctrl.Result {
@@ -323,7 +328,7 @@ func withPostureRequeue(result ctrl.Result, pending bool) ctrl.Result {
 
 func (r *ShardReconciler) recordPostureObservation(
 	shard *multigresv1alpha1.Shard,
-	inconsistent bool,
+	unsettled bool,
 ) int {
 	key := fmt.Sprintf("%s/%s", shard.Namespace, shard.Name)
 
@@ -332,7 +337,7 @@ func (r *ShardReconciler) recordPostureObservation(
 	if r.postureStrikes == nil {
 		r.postureStrikes = make(map[string]int)
 	}
-	if inconsistent {
+	if unsettled {
 		r.postureStrikes[key]++
 	} else {
 		r.postureStrikes[key] = 0

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane_posture_internal_test.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane_posture_internal_test.go
@@ -2,6 +2,7 @@ package shard
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -223,6 +224,63 @@ func TestReconcilePostureDebouncesFirstInconsistency(t *testing.T) {
 	}
 }
 
+func TestReconcilePostureDebouncesFirstIncompleteObservation(t *testing.T) {
+	shard := postureTestShard()
+	shard.Status.Conditions = []metav1.Condition{{
+		Type:               posture.ConditionConsistent,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Consistent",
+		Message:            "postures consistent with topology roles",
+		LastTransitionTime: metav1.Now(),
+	}}
+	store, poolerID := postureTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	rpc := rpcclient.NewFakeClient()
+	rpc.Errors[poolerID] = errors.New("connection error: EOF")
+	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
+
+	pending, err := r.reconcilePosture(t.Context(), store, shard)
+	if err != nil {
+		t.Fatalf("first reconcilePosture() error = %v", err)
+	}
+	if !pending {
+		t.Error("first incomplete posture observation did not request a requeue")
+	}
+	if got := withPostureRequeue(
+		ctrl.Result{},
+		pending,
+	).RequeueAfter; got != postureDebounceRequeueDelay {
+		t.Errorf("first requeue delay = %v, want %v", got, postureDebounceRequeueDelay)
+	}
+	if !conditionIsTrue(shard.Status.Conditions, posture.ConditionConsistent) {
+		t.Errorf(
+			"conditions = %#v, want prior consistent condition preserved on first blip",
+			shard.Status.Conditions,
+		)
+	}
+
+	pending, err = r.reconcilePosture(t.Context(), store, shard)
+	if err != nil {
+		t.Fatalf("second reconcilePosture() error = %v", err)
+	}
+	if pending {
+		t.Error("second incomplete posture observation requested another debounce requeue")
+	}
+	for _, condition := range shard.Status.Conditions {
+		if condition.Type != posture.ConditionConsistent {
+			continue
+		}
+		if condition.Status != metav1.ConditionUnknown ||
+			condition.Reason != "ObservationIncomplete" {
+			t.Errorf(
+				"condition = %#v, want Unknown/ObservationIncomplete on second blip",
+				condition,
+			)
+		}
+	}
+}
+
 func TestReconcileDataPlaneRequeuesFirstPostureStrike(t *testing.T) {
 	shard := postureTestShard()
 	store, poolerID := postureTestStore(t)
@@ -274,6 +332,15 @@ func TestWithPostureRequeueKeepsEarlierRequeue(t *testing.T) {
 func conditionIsFalse(conditions []metav1.Condition, conditionType string) bool {
 	for _, condition := range conditions {
 		if condition.Type == conditionType && condition.Status == metav1.ConditionFalse {
+			return true
+		}
+	}
+	return false
+}
+
+func conditionIsTrue(conditions []metav1.Condition, conditionType string) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType && condition.Status == metav1.ConditionTrue {
 			return true
 		}
 	}


### PR DESCRIPTION
A single transient RPC failure (EOF, no route to host) flipped PostureConsistent to `Unknown` and the Shard to `Progressing` immediately, since only inconsistent observations were debounced. Fold Incomplete into the same strike counter so both need two consecutive bad observations before the condition changes.