### PR TITLE
fix(shard): dial multipoolers with mTLS when internalTLS is enabled

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -359,13 +359,16 @@ const (
 	// Component certificate names used for internal gRPC TLS/mTLS.
 	ComponentMultiAdminTLS   = "multiadmin"
 	ComponentMultiGatewayTLS = "multigateway"
+	ComponentMultiOrchTLS    = "multiorch"
+	ComponentMultiPoolerTLS  = "multipooler"
+	// ComponentOperatorTLS identifies the per-cluster client credential used by
+	// the operator when it calls that cluster's multipoolers.
+	ComponentOperatorTLS = "multigres-operator"
 
 	// InternalTLSIdentityDomain is the logical DNS suffix used for internal
 	// component identities. These names are verified through an explicit gRPC
 	// server-name override and are not expected to resolve through cluster DNS.
 	InternalTLSIdentityDomain = "multigres.internal"
-	ComponentMultiOrchTLS     = "multiorch"
-	ComponentMultiPoolerTLS   = "multipooler"
 )
 
 // ComponentCertSecretName returns the cert-manager Secret name for an internal

--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -54,6 +54,7 @@ import (
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	multigresclustercontroller "github.com/multigres/multigres-operator/pkg/cluster-handler/controller/multigrescluster"
 	tablegroupcontroller "github.com/multigres/multigres-operator/pkg/cluster-handler/controller/tablegroup"
+	"github.com/multigres/multigres-operator/pkg/data-handler/poolerclient"
 	"github.com/multigres/multigres-operator/pkg/images"
 	"github.com/multigres/multigres-operator/pkg/resolver"
 	cellcontroller "github.com/multigres/multigres-operator/pkg/resource-handler/controller/cell"
@@ -186,7 +187,6 @@ func main() {
 		"multigres-operator-webhook-service",
 		"Name of the Kubernetes Service for the webhook",
 	)
-
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -448,13 +448,32 @@ func main() {
 		mgr.GetClient(),
 		webhookServiceNamespace,
 	)
+	rpcClient := rpcclient.NewMultipoolerClient(
+		100,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	defer rpcClient.Close()
+
+	poolerClients, err := poolerclient.NewOperatorCertResolver(
+		mgr.GetAPIReader(),
+		poolerclient.Options{
+			Capacity: 100,
+			Insecure: rpcClient,
+		},
+	)
+	if err != nil {
+		setupLog.Error(err, "unable to create multipooler client resolver")
+		os.Exit(1)
+	}
+	defer poolerClients.Close()
 
 	if err = (&multigresclustercontroller.MultigresClusterReconciler{
-		Client:    mgr.GetClient(),
-		APIReader: mgr.GetAPIReader(),
-		Scheme:    mgr.GetScheme(),
-		Recorder:  mgr.GetEventRecorderFor("multigrescluster-controller"),
-		Images:    imagesConfig,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Recorder:          mgr.GetEventRecorderFor("multigrescluster-controller"),
+		APIReader:         mgr.GetAPIReader(),
+		Images:            imagesConfig,
+		PoolerClientCache: poolerClients,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MultigresCluster")
 		os.Exit(1)
@@ -478,12 +497,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	rpcClient := rpcclient.NewMultipoolerClient(
-		100,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	defer rpcClient.Close()
-
 	if err = (&toposervercontroller.TopoServerReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
@@ -494,11 +507,11 @@ func main() {
 	}
 
 	if err = (&shardcontroller.ShardReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Recorder:  mgr.GetEventRecorderFor("shard-controller"),
-		APIReader: mgr.GetAPIReader(),
-		RPCClient: rpcClient,
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorderFor("shard-controller"),
+		APIReader:     mgr.GetAPIReader(),
+		PoolerClients: poolerClients,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Shard")
 		os.Exit(1)

--- a/pkg/cluster-handler/controller/multigrescluster/certificate.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate.go
@@ -86,7 +86,7 @@ func buildInternalCertificates(
 		multigresv1alpha1.ComponentMultiOrchTLS,
 		multigresv1alpha1.ComponentMultiPoolerTLS,
 	}
-	built := make([]*unstructured.Unstructured, 0, len(components))
+	built := make([]*unstructured.Unstructured, 0, len(components)+1)
 	for _, component := range components {
 		cn := multigresv1alpha1.ComponentCertCommonName(
 			component,
@@ -125,6 +125,36 @@ func buildInternalCertificates(
 		}
 		built = append(built, cert)
 	}
+
+	// The operator gets a dedicated per-cluster client identity. Keeping it
+	// cluster-owned gives it the same issuer and lifecycle as the servers it
+	// calls, while allowing the client to verify the exact multipooler SAN.
+	operatorName := multigresv1alpha1.ComponentCertCommonName(
+		multigresv1alpha1.ComponentOperatorTLS,
+		cluster.Name,
+		cluster.Namespace,
+	)
+	operatorCert, err := buildCertificateFromSpec(cluster, scheme, certSpec{
+		name: operatorName,
+		secretName: multigresv1alpha1.ComponentCertSecretName(
+			multigresv1alpha1.ComponentOperatorTLS,
+			cluster.Name,
+			cluster.Namespace,
+		),
+		// The server currently authorizes this certificate by its issuer chain;
+		// keep the client subject stable and below the X.509 64-byte CN limit.
+		commonName: multigresv1alpha1.ComponentOperatorTLS,
+		dnsNames:   []any{},
+		usages: []any{
+			"digital signature",
+			"key encipherment",
+			"client auth",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	built = append(built, operatorCert)
 	return built, nil
 }
 
@@ -235,7 +265,7 @@ func (r *MultigresClusterReconciler) reconcileCertificate(
 		return err
 	}
 
-	desiredCerts := make([]*unstructured.Unstructured, 0, 6)
+	desiredCerts := make([]*unstructured.Unstructured, 0, 7)
 	if cluster.Spec.InternalTLS.IsEnabled() {
 		internalCerts, err := buildInternalCertificates(cluster, r.Scheme)
 		if err != nil {

--- a/pkg/cluster-handler/controller/multigrescluster/certificate.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate.go
@@ -141,9 +141,9 @@ func buildInternalCertificates(
 			cluster.Name,
 			cluster.Namespace,
 		),
-		// The server currently authorizes this certificate by its issuer chain;
-		// keep the client subject stable and below the X.509 64-byte CN limit.
-		commonName: multigresv1alpha1.ComponentOperatorTLS,
+		// Keep the client identity cluster-specific so subject authorization can
+		// be enabled later. certs.Build safely hash-truncates long common names.
+		commonName: operatorName,
 		dnsNames:   []any{},
 		usages: []any{
 			"digital signature",

--- a/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
@@ -249,9 +249,6 @@ func TestBuildInternalCertificates(t *testing.T) {
 			t.Errorf("secretName mismatch for %s (-want +got):\n%s", cert.GetName(), diff)
 		}
 		wantCommonName := cert.GetName()
-		if cert.GetName() == "multigres-operator.test-cluster.supabase.multigres.internal" {
-			wantCommonName = multigresv1alpha1.ComponentOperatorTLS
-		}
 		wantSubject := "C=US, ST=Delware, L=New Castle,O=Supabase Inc, CN=" + wantCommonName
 		if diff := cmp.Diff(wantSubject, spec["literalSubject"]); diff != "" {
 			t.Errorf("literalSubject mismatch for %s (-want +got):\n%s", cert.GetName(), diff)

--- a/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate_test.go
@@ -227,6 +227,11 @@ func TestBuildInternalCertificates(t *testing.T) {
 			cluster.Name,
 			cluster.Namespace,
 		),
+		"multigres-operator.test-cluster.supabase.multigres.internal": multigresv1alpha1.ComponentCertSecretName(
+			multigresv1alpha1.ComponentOperatorTLS,
+			cluster.Name,
+			cluster.Namespace,
+		),
 	}
 	if len(got) != len(want) {
 		t.Fatalf("got %d certs, want %d", len(got), len(want))
@@ -243,7 +248,11 @@ func TestBuildInternalCertificates(t *testing.T) {
 		if diff := cmp.Diff(secretName, spec["secretName"]); diff != "" {
 			t.Errorf("secretName mismatch for %s (-want +got):\n%s", cert.GetName(), diff)
 		}
-		wantSubject := "C=US, ST=Delware, L=New Castle,O=Supabase Inc, CN=" + cert.GetName()
+		wantCommonName := cert.GetName()
+		if cert.GetName() == "multigres-operator.test-cluster.supabase.multigres.internal" {
+			wantCommonName = multigresv1alpha1.ComponentOperatorTLS
+		}
+		wantSubject := "C=US, ST=Delware, L=New Castle,O=Supabase Inc, CN=" + wantCommonName
 		if diff := cmp.Diff(wantSubject, spec["literalSubject"]); diff != "" {
 			t.Errorf("literalSubject mismatch for %s (-want +got):\n%s", cert.GetName(), diff)
 		}
@@ -253,10 +262,20 @@ func TestBuildInternalCertificates(t *testing.T) {
 			"server auth",
 			"client auth",
 		}
+		if cert.GetName() == "multigres-operator.test-cluster.supabase.multigres.internal" {
+			wantUsages = []any{
+				"digital signature",
+				"key encipherment",
+				"client auth",
+			}
+		}
 		if diff := cmp.Diff(wantUsages, spec["usages"]); diff != "" {
 			t.Errorf("usages mismatch for %s (-want +got):\n%s", cert.GetName(), diff)
 		}
 		wantDNSNames := []any{cert.GetName()}
+		if cert.GetName() == "multigres-operator.test-cluster.supabase.multigres.internal" {
+			wantDNSNames = []any{}
+		}
 		if cert.GetName() == "multigateway.test-cluster.supabase.multigres.internal" {
 			// multigateway's cert also needs to verify against the logical
 			// MultiPooler identity used for gateway-to-gateway cancel forwarding.
@@ -363,12 +382,13 @@ func TestReconcileCertificate(t *testing.T) {
 	wantInternalCertificates := func(
 		cluster *multigresv1alpha1.MultigresCluster,
 	) map[string]string {
-		want := make(map[string]string, 4)
+		want := make(map[string]string, 5)
 		for _, component := range []string{
 			multigresv1alpha1.ComponentMultiAdminTLS,
 			multigresv1alpha1.ComponentMultiGatewayTLS,
 			multigresv1alpha1.ComponentMultiOrchTLS,
 			multigresv1alpha1.ComponentMultiPoolerTLS,
+			multigresv1alpha1.ComponentOperatorTLS,
 		} {
 			name := multigresv1alpha1.ComponentCertCommonName(
 				component,
@@ -652,8 +672,8 @@ func TestReconcileCertificate(t *testing.T) {
 		if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
 			t.Fatalf("first reconcile: %v", err)
 		}
-		if patchCount != 5 {
-			t.Fatalf("patchCount after first reconcile = %d, want 5", patchCount)
+		if patchCount != 6 {
+			t.Fatalf("patchCount after first reconcile = %d, want 6", patchCount)
 		}
 
 		// Reconciling again with the same spec should not re-patch any
@@ -661,9 +681,9 @@ func TestReconcileCertificate(t *testing.T) {
 		if err := r.reconcileCertificate(t.Context(), cluster); err != nil {
 			t.Fatalf("second reconcile: %v", err)
 		}
-		if patchCount != 5 {
+		if patchCount != 6 {
 			t.Errorf(
-				"patchCount after second reconcile = %d, want 5 (no new patches)",
+				"patchCount after second reconcile = %d, want 6 (no new patches)",
 				patchCount,
 			)
 		}

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -100,6 +100,9 @@ func (r *MultigresClusterReconciler) Reconcile(
 	err = r.Get(ctx, req.NamespacedName, cluster)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			if r.PoolerClientCache != nil {
+				r.PoolerClientCache.ForgetCluster(req.NamespacedName)
+			}
 			return ctrl.Result{}, nil
 		}
 		monitoring.RecordSpanError(span, err)

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -12,6 +12,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -32,11 +33,22 @@ import (
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
 
+// PoolerClientCache tracks which clusters may own cluster-scoped RPC clients
+// and releases those clients after cluster deletion.
+type PoolerClientCache interface {
+	ActivateCluster(types.NamespacedName)
+	ForgetCluster(types.NamespacedName)
+}
+
 // MultigresClusterReconciler reconciles a MultigresCluster object.
 type MultigresClusterReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+	// PoolerClientCache releases cluster-scoped RPC clients after cluster
+	// deletion. It is optional so controller tests and embedders that do not
+	// construct pooler clients need no special setup.
+	PoolerClientCache PoolerClientCache
 
 	// APIReader is an uncached client that reads directly from the API server.
 	// The cached client only sees tenant-namespace Secrets carrying the
@@ -123,6 +135,9 @@ func (r *MultigresClusterReconciler) Reconcile(
 
 	if !cluster.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, cluster)
+	}
+	if r.PoolerClientCache != nil {
+		r.PoolerClientCache.ActivateCluster(req.NamespacedName)
 	}
 	if err := r.ensureClusterFinalizer(ctx, cluster); err != nil {
 		return ctrl.Result{}, err
@@ -462,6 +477,13 @@ func (r *MultigresClusterReconciler) handleDeletion(
 				err,
 			)
 		}
+	}
+
+	if r.PoolerClientCache != nil {
+		r.PoolerClientCache.ForgetCluster(types.NamespacedName{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Name,
+		})
 	}
 
 	l.Info("Cluster cleanup complete")

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
@@ -344,6 +344,71 @@ func parseQty(s string) resource.Quantity {
 	return resource.MustParse(s)
 }
 
+type poolerClientCacheFunc func(types.NamespacedName)
+
+func (poolerClientCacheFunc) ActivateCluster(types.NamespacedName) {}
+
+func (f poolerClientCacheFunc) ForgetCluster(key types.NamespacedName) {
+	f(key)
+}
+
+func TestHandleDeletionReleasesPoolerClient(t *testing.T) {
+	clusterKey := types.NamespacedName{Name: "test-cluster", Namespace: "test-ns"}
+	deletionTimestamp := metav1.Now()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              clusterKey.Name,
+			Namespace:         clusterKey.Namespace,
+			DeletionTimestamp: &deletionTimestamp,
+		},
+	}
+
+	t.Run("after successful cleanup", func(t *testing.T) {
+		forgotten := make(chan types.NamespacedName, 1)
+		r := &MultigresClusterReconciler{
+			Client:   fake.NewClientBuilder().WithScheme(setupScheme()).Build(),
+			Recorder: record.NewFakeRecorder(1),
+			PoolerClientCache: poolerClientCacheFunc(func(key types.NamespacedName) {
+				forgotten <- key
+			}),
+		}
+
+		if _, err := r.handleDeletion(t.Context(), cluster.DeepCopy()); err != nil {
+			t.Fatalf("handleDeletion() error = %v", err)
+		}
+		select {
+		case got := <-forgotten:
+			if got != clusterKey {
+				t.Fatalf("forgot cluster %v, want %v", got, clusterKey)
+			}
+		default:
+			t.Fatal("pooler client cache was not notified")
+		}
+	})
+
+	t.Run("not when cleanup fails", func(t *testing.T) {
+		baseClient := fake.NewClientBuilder().WithScheme(setupScheme()).Build()
+		failingClient := testutil.NewFakeClientWithFailures(baseClient, &testutil.FailureConfig{
+			OnList: testutil.FailObjListAfterNCalls(0, errors.New("list failed")),
+		})
+		forgotten := false
+		r := &MultigresClusterReconciler{
+			Client:   failingClient,
+			Recorder: record.NewFakeRecorder(1),
+			PoolerClientCache: poolerClientCacheFunc(func(types.NamespacedName) {
+				forgotten = true
+			}),
+		}
+
+		if _, err := r.handleDeletion(t.Context(), cluster.DeepCopy()); err == nil {
+			t.Fatal("handleDeletion() error = nil, want cleanup error")
+		}
+		if forgotten {
+			t.Fatal("pooler client cache notified after failed cleanup")
+		}
+	})
+}
+
 // ============================================================================
 // Main Controller Logic & Lifecycle Tests
 // ============================================================================

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller_test.go
@@ -409,6 +409,29 @@ func TestHandleDeletionReleasesPoolerClient(t *testing.T) {
 	})
 }
 
+func TestReconcileNotFoundReleasesPoolerClient(t *testing.T) {
+	key := types.NamespacedName{Name: "missing", Namespace: "test-ns"}
+	forgotten := make(chan types.NamespacedName, 1)
+	r := &MultigresClusterReconciler{
+		Client: fake.NewClientBuilder().WithScheme(setupScheme()).Build(),
+		PoolerClientCache: poolerClientCacheFunc(func(got types.NamespacedName) {
+			forgotten <- got
+		}),
+	}
+
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key}); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	select {
+	case got := <-forgotten:
+		if got != key {
+			t.Fatalf("forgot cluster %v, want %v", got, key)
+		}
+	default:
+		t.Fatal("pooler client cache was not notified for missing cluster")
+	}
+}
+
 // ============================================================================
 // Main Controller Logic & Lifecycle Tests
 // ============================================================================

--- a/pkg/data-handler/poolerclient/resolver.go
+++ b/pkg/data-handler/poolerclient/resolver.go
@@ -144,14 +144,13 @@ func (r *OperatorCertResolver) ClientFor(
 	if err != nil {
 		return nil, err
 	}
+	if err := r.ensureClusterActive(ctx, clusterKey); err != nil {
+		return nil, err
+	}
 	r.mu.Lock()
 	if r.closed {
 		r.mu.Unlock()
 		return nil, fmt.Errorf("operator internal TLS resolver is closed")
-	}
-	if _, active := r.active[clusterKey]; !active {
-		r.mu.Unlock()
-		return nil, fmt.Errorf("cluster %s is not active", clusterKey)
 	}
 	state := r.states[clusterKey]
 	if state == nil {
@@ -283,6 +282,41 @@ func (r *OperatorCertResolver) ClientFor(
 		state.lastErr = nil
 		return state.tlsClient, nil
 	}
+}
+
+// ensureClusterActive validates an inactive cluster directly against the API.
+// Controller startup ordering is not guaranteed, so a shard may reconcile
+// before the cluster controller has populated the lifecycle registry.
+func (r *OperatorCertResolver) ensureClusterActive(
+	ctx context.Context,
+	key types.NamespacedName,
+) error {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return fmt.Errorf("operator internal TLS resolver is closed")
+	}
+	_, active := r.active[key]
+	r.mu.Unlock()
+	if active {
+		return nil
+	}
+
+	cluster := &multigresv1alpha1.MultigresCluster{}
+	if err := r.reader.Get(ctx, key, cluster); err != nil {
+		return fmt.Errorf("validating MultigresCluster %s: %w", key, err)
+	}
+	if !cluster.DeletionTimestamp.IsZero() {
+		return fmt.Errorf("MultigresCluster %s is being deleted", key)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return fmt.Errorf("operator internal TLS resolver is closed")
+	}
+	r.active[key] = struct{}{}
+	return nil
 }
 
 func clusterKeyForShard(shard *multigresv1alpha1.Shard) (types.NamespacedName, error) {

--- a/pkg/data-handler/poolerclient/resolver.go
+++ b/pkg/data-handler/poolerclient/resolver.go
@@ -1,0 +1,456 @@
+// Package poolerclient resolves the multipooler RPC client a shard must use:
+// a cluster-bound mTLS identity for InternalTLS clusters, insecure otherwise.
+package poolerclient
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/multigres/multigres/go/common/rpcclient"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+const (
+	defaultRefreshInterval = 5 * time.Minute
+	// Cache initial credential failures until the shard's normal retry. This
+	// prevents every shard in a cluster from repeating the same uncached Secret
+	// read while cert-manager is still issuing the certificate.
+	defaultFailureRetryInterval = 10 * time.Second
+	// Data-plane reconciles are bounded to 30 seconds. Keep the old generation
+	// alive for twice that deadline so rotation cannot interrupt an in-flight RPC.
+	defaultRetirementGracePeriod = time.Minute
+)
+
+// Resolver returns the multipooler RPC client appropriate for a shard.
+type Resolver interface {
+	ClientFor(
+		ctx context.Context,
+		shard *multigresv1alpha1.Shard,
+	) (rpcclient.MultipoolerClient, error)
+}
+
+type staticResolver struct {
+	client rpcclient.MultipoolerClient
+}
+
+func (s staticResolver) ClientFor(
+	context.Context,
+	*multigresv1alpha1.Shard,
+) (rpcclient.MultipoolerClient, error) {
+	return s.client, nil
+}
+
+// Static returns a Resolver that always yields c.
+func Static(c rpcclient.MultipoolerClient) Resolver {
+	return staticResolver{client: c}
+}
+
+// Options configures OperatorCertResolver.
+type Options struct {
+	Capacity int
+	Insecure rpcclient.MultipoolerClient
+}
+
+// OperatorCertResolver caches one mTLS MultipoolerClient per cluster. The
+// owning MultigresCluster controller creates and owns each client credential.
+type OperatorCertResolver struct {
+	reader client.Reader
+	opts   Options
+
+	refreshInterval time.Duration
+	failureRetry    time.Duration
+	retirementGrace time.Duration
+	newClient       func(*tls.Config) rpcclient.MultipoolerClient
+
+	mu     sync.Mutex
+	states map[types.NamespacedName]*clusterState
+	// active is maintained by the cluster reconciler. Requiring membership
+	// prevents shards delayed by garbage collection from recreating client
+	// state after their owning cluster was deleted, without retaining a
+	// tombstone for every deleted cluster name.
+	active map[types.NamespacedName]struct{}
+	closed bool
+}
+
+type clusterState struct {
+	mu              sync.Mutex
+	closed          bool
+	refreshing      bool
+	refreshDone     chan struct{}
+	tlsClient       rpcclient.MultipoolerClient
+	retiredClients  []*retiredClient
+	resourceVersion string
+	fetchedAt       time.Time
+	lastErr         error
+}
+
+type retiredClient struct {
+	client rpcclient.MultipoolerClient
+	timer  *time.Timer
+}
+
+// NewOperatorCertResolver creates a resolver. reader must be uncached because
+// cert-manager Secrets do not carry the label required by the filtered cache.
+func NewOperatorCertResolver(
+	reader client.Reader,
+	opts Options,
+) (*OperatorCertResolver, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("operator internal TLS resolver requires a Secret reader")
+	}
+	if opts.Insecure == nil {
+		return nil, fmt.Errorf("operator internal TLS resolver requires an insecure client")
+	}
+	r := &OperatorCertResolver{
+		reader:          reader,
+		opts:            opts,
+		refreshInterval: defaultRefreshInterval,
+		failureRetry:    defaultFailureRetryInterval,
+		retirementGrace: defaultRetirementGracePeriod,
+		states:          make(map[types.NamespacedName]*clusterState),
+		active:          make(map[types.NamespacedName]struct{}),
+	}
+	r.newClient = func(tlsConfig *tls.Config) rpcclient.MultipoolerClient {
+		return rpcclient.NewMultipoolerClient(
+			r.opts.Capacity,
+			grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
+		)
+	}
+	return r, nil
+}
+
+// ClientFor implements Resolver.
+func (r *OperatorCertResolver) ClientFor(
+	ctx context.Context,
+	shard *multigresv1alpha1.Shard,
+) (rpcclient.MultipoolerClient, error) {
+	if !shard.Spec.InternalTLS.IsEnabled() {
+		return r.opts.Insecure, nil
+	}
+
+	clusterKey, err := clusterKeyForShard(shard)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil, fmt.Errorf("operator internal TLS resolver is closed")
+	}
+	if _, active := r.active[clusterKey]; !active {
+		r.mu.Unlock()
+		return nil, fmt.Errorf("cluster %s is not active", clusterKey)
+	}
+	state := r.states[clusterKey]
+	if state == nil {
+		state = &clusterState{}
+		r.states[clusterKey] = state
+	}
+	r.mu.Unlock()
+
+	for {
+		state.mu.Lock()
+		if state.closed {
+			state.mu.Unlock()
+			return nil, fmt.Errorf("operator internal TLS resolver is closed")
+		}
+
+		now := time.Now()
+		hadClient := state.tlsClient != nil
+		if hadClient {
+			nextRefresh := r.refreshInterval
+			if state.lastErr != nil {
+				nextRefresh = r.failureRetry
+			}
+			if state.refreshing || now.Sub(state.fetchedAt) < nextRefresh {
+				current := state.tlsClient
+				state.mu.Unlock()
+				return current, nil
+			}
+			// Refresh outside the lock. Other reconciles can continue using the
+			// current generation while the uncached API read is in flight.
+			state.refreshing = true
+			state.refreshDone = make(chan struct{})
+			state.mu.Unlock()
+		} else {
+			if state.refreshing {
+				// Join the in-flight cold initialization. The first caller performs
+				// the API read; all other shard reconciles reuse its result.
+				done := state.refreshDone
+				state.mu.Unlock()
+				select {
+				case <-done:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				state.mu.Lock()
+				if state.closed {
+					state.mu.Unlock()
+					return nil, fmt.Errorf("operator internal TLS resolver is closed")
+				}
+				if state.tlsClient != nil {
+					current := state.tlsClient
+					state.mu.Unlock()
+					return current, nil
+				}
+				if state.lastErr != nil {
+					err := state.lastErr
+					state.mu.Unlock()
+					return nil, err
+				}
+				state.mu.Unlock()
+				// The initialization leader may have been canceled. Its context error
+				// is caller-local and must not poison healthy waiters, so compete to
+				// become the next leader instead of manufacturing a cached failure.
+				continue
+			}
+			if state.lastErr != nil && now.Sub(state.fetchedAt) < r.failureRetry {
+				err := state.lastErr
+				state.mu.Unlock()
+				return nil, err
+			}
+			state.refreshing = true
+			state.refreshDone = make(chan struct{})
+			state.mu.Unlock()
+		}
+
+		secretKey := types.NamespacedName{
+			Namespace: clusterKey.Namespace,
+			Name: multigresv1alpha1.ComponentCertSecretName(
+				multigresv1alpha1.ComponentOperatorTLS,
+				clusterKey.Name,
+				clusterKey.Namespace,
+			),
+		}
+		secret := &corev1.Secret{}
+		readErr := r.reader.Get(ctx, secretKey, secret)
+		readCompletedAt := time.Now()
+		state.mu.Lock()
+		state.refreshing = false
+		done := state.refreshDone
+		state.refreshDone = nil
+		defer close(done)
+		if state.closed {
+			state.mu.Unlock()
+			return nil, fmt.Errorf("operator internal TLS resolver is closed")
+		}
+		defer state.mu.Unlock()
+
+		if readErr != nil {
+			return r.keepExistingOrError(
+				ctx, state, readCompletedAt,
+				fmt.Errorf("reading operator internal TLS secret %s: %w", secretKey, readErr),
+			)
+		}
+
+		if state.tlsClient != nil && secret.ResourceVersion == state.resourceVersion {
+			state.fetchedAt = readCompletedAt
+			state.lastErr = nil
+			return state.tlsClient, nil
+		}
+
+		serverName := multigresv1alpha1.ComponentCertCommonName(
+			multigresv1alpha1.ComponentMultiPoolerTLS,
+			clusterKey.Name,
+			clusterKey.Namespace,
+		)
+		tlsConfig, err := buildTLSConfig(secret, serverName)
+		if err != nil {
+			return r.keepExistingOrError(
+				ctx, state, readCompletedAt,
+				fmt.Errorf("building TLS config from secret %s: %w", secretKey, err),
+			)
+		}
+
+		if state.tlsClient != nil {
+			r.retireClient(state, state.tlsClient)
+		}
+		state.tlsClient = r.newClient(tlsConfig)
+		state.resourceVersion = secret.ResourceVersion
+		state.fetchedAt = readCompletedAt
+		state.lastErr = nil
+		return state.tlsClient, nil
+	}
+}
+
+func clusterKeyForShard(shard *multigresv1alpha1.Shard) (types.NamespacedName, error) {
+	clusterName := shard.Labels[metadata.LabelMultigresCluster]
+	if clusterName == "" {
+		return types.NamespacedName{}, fmt.Errorf(
+			"internal TLS shard %s/%s has no %s label",
+			shard.Namespace,
+			shard.Name,
+			metadata.LabelMultigresCluster,
+		)
+	}
+	return types.NamespacedName{Namespace: shard.Namespace, Name: clusterName}, nil
+}
+
+// keepExistingOrError is called with state.mu held. Once a client has been
+// built, credential refresh is best-effort: transient reads or a temporarily
+// malformed rotating Secret must not interrupt working RPCs.
+func (r *OperatorCertResolver) keepExistingOrError(
+	ctx context.Context,
+	state *clusterState,
+	now time.Time,
+	err error,
+) (rpcclient.MultipoolerClient, error) {
+	if ctx.Err() != nil {
+		// Cancellation belongs to this reconcile. Do not cache it for another
+		// caller and do not delay a credential refresh by the normal interval.
+		if state.tlsClient != nil {
+			return state.tlsClient, nil
+		}
+		return nil, err
+	}
+	if state.tlsClient == nil {
+		state.fetchedAt = now
+		state.lastErr = err
+		return nil, err
+	}
+	// A working client remains usable, but retry the failed refresh on the
+	// short failure interval rather than waiting for the full refresh period.
+	state.fetchedAt = now
+	state.lastErr = err
+	log.FromContext(ctx).Error(
+		err,
+		"Unable to refresh operator internal TLS client; keeping current client",
+	)
+	return state.tlsClient, nil
+}
+
+// ActivateCluster allows a live cluster's shards to create client state. It is
+// deliberately separate from ClientFor so a stale shard reconcile after
+// deletion cannot undo ForgetCluster.
+func (r *OperatorCertResolver) ActivateCluster(key types.NamespacedName) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.closed {
+		r.active[key] = struct{}{}
+	}
+}
+
+// ForgetCluster removes a deleted cluster's cached client. The current client
+// receives the same grace period as a rotated client so deletion cannot cut
+// off an RPC that was already in flight.
+func (r *OperatorCertResolver) ForgetCluster(key types.NamespacedName) {
+	r.mu.Lock()
+	state := r.states[key]
+	delete(r.states, key)
+	delete(r.active, key)
+	r.mu.Unlock()
+	if state == nil {
+		return
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.closed {
+		return
+	}
+	state.closed = true
+	if state.tlsClient != nil {
+		r.retireClient(state, state.tlsClient)
+		state.tlsClient = nil
+	}
+}
+
+// Close releases all current and rotated mTLS clients. The insecure client is
+// owned by the caller.
+func (r *OperatorCertResolver) Close() {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.closed = true
+	states := make([]*clusterState, 0, len(r.states))
+	for _, state := range r.states {
+		states = append(states, state)
+	}
+	r.states = nil
+	r.active = nil
+	r.mu.Unlock()
+
+	for _, state := range states {
+		state.mu.Lock()
+		state.closed = true
+		if state.tlsClient != nil {
+			state.tlsClient.Close()
+			state.tlsClient = nil
+		}
+		for _, retired := range state.retiredClients {
+			retired.timer.Stop()
+			retired.client.Close()
+		}
+		state.retiredClients = nil
+		state.mu.Unlock()
+	}
+}
+
+// retireClient is called with state.mu held.
+func (r *OperatorCertResolver) retireClient(
+	state *clusterState,
+	client rpcclient.MultipoolerClient,
+) {
+	retired := &retiredClient{client: client}
+	retired.timer = time.AfterFunc(r.retirementGrace, func() {
+		state.mu.Lock()
+		defer state.mu.Unlock()
+		for i, candidate := range state.retiredClients {
+			if candidate != retired {
+				continue
+			}
+			candidate.client.Close()
+			state.retiredClients = append(
+				state.retiredClients[:i],
+				state.retiredClients[i+1:]...,
+			)
+			return
+		}
+	})
+	state.retiredClients = append(state.retiredClients, retired)
+}
+
+func buildTLSConfig(secret *corev1.Secret, serverName string) (*tls.Config, error) {
+	certPEM, ok := secret.Data[corev1.TLSCertKey]
+	if !ok || len(certPEM) == 0 {
+		return nil, fmt.Errorf("missing %q", corev1.TLSCertKey)
+	}
+	keyPEM, ok := secret.Data[corev1.TLSPrivateKeyKey]
+	if !ok || len(keyPEM) == 0 {
+		return nil, fmt.Errorf("missing %q", corev1.TLSPrivateKeyKey)
+	}
+	caPEM, ok := secret.Data[corev1.ServiceAccountRootCAKey]
+	if !ok || len(caPEM) == 0 {
+		return nil, fmt.Errorf("missing %q", corev1.ServiceAccountRootCAKey)
+	}
+
+	keyPair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parsing client key pair: %w", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("parsing %q", corev1.ServiceAccountRootCAKey)
+	}
+
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{keyPair},
+		RootCAs:      roots,
+		ServerName:   serverName,
+	}, nil
+}

--- a/pkg/data-handler/poolerclient/resolver_test.go
+++ b/pkg/data-handler/poolerclient/resolver_test.go
@@ -34,6 +34,9 @@ func testScheme(t *testing.T) *runtime.Scheme {
 	if err := clientgoscheme.AddToScheme(s); err != nil {
 		t.Fatalf("add scheme: %v", err)
 	}
+	if err := multigresv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("add Multigres scheme: %v", err)
+	}
 	return s
 }
 
@@ -783,8 +786,8 @@ func TestForgetClusterBlocksStaleShardUntilReactivated(t *testing.T) {
 
 	r.ForgetCluster(key)
 	if _, err := r.ClientFor(t.Context(), shard); err == nil ||
-		!strings.Contains(err.Error(), "not active") {
-		t.Fatalf("stale shard ClientFor() error = %v, want inactive cluster", err)
+		!strings.Contains(err.Error(), "not found") {
+		t.Fatalf("stale shard ClientFor() error = %v, want missing cluster", err)
 	}
 	r.mu.Lock()
 	_, stateRecreated := r.states[key]
@@ -810,6 +813,28 @@ func TestForgetClusterBlocksStaleShardUntilReactivated(t *testing.T) {
 	}
 	if after == first {
 		t.Fatal("reactivated cluster reused the forgotten client")
+	}
+}
+
+func TestClientForValidatesLiveClusterBeforeClusterControllerReconciles(t *testing.T) {
+	ca := newTestCA(t)
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+	}
+	r, insecure, _ := newResolver(t, cluster, operatorSecret(t, ca, "ns", "c", "1"))
+
+	got, err := r.ClientFor(t.Context(), testShard("s", "ns", "c", true))
+	if err != nil {
+		t.Fatalf("ClientFor() before cluster reconcile error = %v", err)
+	}
+	if got == nil || got == insecure {
+		t.Fatal("ClientFor() before cluster reconcile did not build an mTLS client")
+	}
+	r.mu.Lock()
+	_, active := r.active[types.NamespacedName{Namespace: "ns", Name: "c"}]
+	r.mu.Unlock()
+	if !active {
+		t.Fatal("live cluster was not added to lifecycle registry")
 	}
 }
 

--- a/pkg/data-handler/poolerclient/resolver_test.go
+++ b/pkg/data-handler/poolerclient/resolver_test.go
@@ -1,0 +1,900 @@
+package poolerclient
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/multigres/multigres/go/common/rpcclient"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	return s
+}
+
+func testShard(name, namespace, cluster string, tlsEnabled bool) *multigresv1alpha1.Shard {
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{metadata.LabelMultigresCluster: cluster},
+		},
+	}
+	if tlsEnabled {
+		enabled := true
+		shard.Spec.InternalTLS = &multigresv1alpha1.InternalTLSConfig{Enabled: &enabled}
+	}
+	return shard
+}
+
+func activeTLSShard(
+	r *OperatorCertResolver,
+	name,
+	namespace,
+	cluster string,
+) *multigresv1alpha1.Shard {
+	r.ActivateCluster(types.NamespacedName{Namespace: namespace, Name: cluster})
+	return testShard(name, namespace, cluster, true)
+}
+
+type testCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+	pem  []byte
+}
+
+func newTestCA(t *testing.T) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	return &testCA{
+		cert: cert,
+		key:  key,
+		pem:  pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+	}
+}
+
+func (ca *testCA) issue(
+	t *testing.T,
+	dnsNames []string,
+	usages ...x509.ExtKeyUsage,
+) (certPEM, keyPEM []byte, leaf *x509.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  usages,
+		DNSNames:     dnsNames,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	leaf, err = x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal leaf key: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), leaf
+}
+
+func operatorSecret(
+	t *testing.T,
+	ca *testCA,
+	namespace,
+	cluster,
+	resourceVersion string,
+) *corev1.Secret {
+	t.Helper()
+	certPEM, keyPEM, _ := ca.issue(t, nil, x509.ExtKeyUsageClientAuth)
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: multigresv1alpha1.ComponentCertSecretName(
+				multigresv1alpha1.ComponentOperatorTLS,
+				cluster,
+				namespace,
+			),
+			Namespace:       namespace,
+			ResourceVersion: resourceVersion,
+		},
+		Data: map[string][]byte{
+			corev1.TLSCertKey:              certPEM,
+			corev1.TLSPrivateKeyKey:        keyPEM,
+			corev1.ServiceAccountRootCAKey: ca.pem,
+		},
+	}
+}
+
+func newResolver(
+	t *testing.T,
+	objects ...client.Object,
+) (*OperatorCertResolver, rpcclient.MultipoolerClient, client.Client) {
+	t.Helper()
+	c := fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(objects...).Build()
+	insecure := rpcclient.NewFakeClient()
+	r, err := NewOperatorCertResolver(c, Options{Capacity: 10, Insecure: insecure})
+	if err != nil {
+		t.Fatalf("NewOperatorCertResolver() error = %v", err)
+	}
+	t.Cleanup(r.Close)
+	return r, insecure, c
+}
+
+func TestNewOperatorCertResolverValidatesDependencies(t *testing.T) {
+	insecure := rpcclient.NewFakeClient()
+	reader := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+	tests := []struct {
+		name   string
+		reader client.Reader
+		opts   Options
+		want   string
+	}{
+		{name: "missing reader", opts: Options{Insecure: insecure}, want: "Secret reader"},
+		{name: "missing insecure client", reader: reader, want: "insecure client"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewOperatorCertResolver(tt.reader, tt.opts); err == nil ||
+				!strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("NewOperatorCertResolver() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestStaticResolver(t *testing.T) {
+	want := rpcclient.NewFakeClient()
+	got, err := Static(want).ClientFor(t.Context(), testShard("s", "ns", "c", true))
+	if err != nil {
+		t.Fatalf("ClientFor() error = %v", err)
+	}
+	if got != want {
+		t.Error("Static resolver returned a different client")
+	}
+}
+
+func TestClientForTLSDisabledReturnsInsecure(t *testing.T) {
+	r, insecure, _ := newResolver(t)
+	got, err := r.ClientFor(t.Context(), testShard("s", "ns", "c", false))
+	if err != nil {
+		t.Fatalf("ClientFor() error = %v", err)
+	}
+	if got != insecure {
+		t.Error("TLS-disabled shard did not get the insecure client")
+	}
+}
+
+func TestClientForRequiresClusterLabel(t *testing.T) {
+	r, _, _ := newResolver(t)
+	_, err := r.ClientFor(t.Context(), testShard("s", "ns", "", true))
+	if err == nil || !strings.Contains(err.Error(), metadata.LabelMultigresCluster) {
+		t.Fatalf("ClientFor() error = %v, want missing label error", err)
+	}
+}
+
+func TestClientForSecretNotIssued(t *testing.T) {
+	r, _, _ := newResolver(t)
+	_, err := r.ClientFor(t.Context(), activeTLSShard(r, "s", "ns", "c"))
+	if err == nil || !strings.Contains(err.Error(), "reading operator internal TLS secret") {
+		t.Fatalf("ClientFor() error = %v, want missing Secret error", err)
+	}
+}
+
+type countingBlockingReader struct {
+	client.Reader
+
+	mu      sync.Mutex
+	gets    int
+	started chan struct{}
+	release chan struct{}
+}
+
+func (r *countingBlockingReader) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	r.mu.Lock()
+	r.gets++
+	r.mu.Unlock()
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+	select {
+	case <-r.release:
+		return r.Reader.Get(ctx, key, obj, opts...)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *countingBlockingReader) getCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.gets
+}
+
+func TestClientForCoalescesAndCachesInitialFailure(t *testing.T) {
+	r, _, reader := newResolver(t)
+	blocking := &countingBlockingReader{
+		Reader:  reader,
+		started: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	r.reader = blocking
+	r.failureRetry = time.Hour
+	shard := activeTLSShard(r, "s", "ns", "c")
+
+	const callers = 20
+	errs := make(chan error, callers)
+	for range callers {
+		go func() {
+			_, err := r.ClientFor(t.Context(), shard)
+			errs <- err
+		}()
+	}
+	select {
+	case <-blocking.started:
+	case <-time.After(time.Second):
+		t.Fatal("initial Secret read did not start")
+	}
+	// Give the other callers a chance to join the in-flight initialization.
+	time.Sleep(20 * time.Millisecond)
+	if got := blocking.getCount(); got != 1 {
+		t.Fatalf("concurrent initial Secret reads = %d, want 1", got)
+	}
+	close(blocking.release)
+	for range callers {
+		if err := <-errs; err == nil ||
+			!strings.Contains(err.Error(), "reading operator internal TLS secret") {
+			t.Errorf("ClientFor() error = %v, want missing Secret error", err)
+		}
+	}
+
+	if _, err := r.ClientFor(t.Context(), shard); err == nil {
+		t.Fatal("ClientFor() expected cached missing Secret error")
+	}
+	if got := blocking.getCount(); got != 1 {
+		t.Fatalf("Secret reads during failure cache = %d, want 1", got)
+	}
+}
+
+type cancelFirstReader struct {
+	client.Reader
+
+	mu      sync.Mutex
+	gets    int
+	started chan struct{}
+}
+
+func (r *cancelFirstReader) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	r.mu.Lock()
+	r.gets++
+	call := r.gets
+	r.mu.Unlock()
+	if call == 1 {
+		close(r.started)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
+func (r *cancelFirstReader) getCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.gets
+}
+
+func TestClientForCanceledColdLeaderDoesNotPoisonJoiner(t *testing.T) {
+	ca := newTestCA(t)
+	r, _, reader := newResolver(t, operatorSecret(t, ca, "ns", "c", "1"))
+	cancelReader := &cancelFirstReader{
+		Reader:  reader,
+		started: make(chan struct{}),
+	}
+	r.reader = cancelReader
+	shard := activeTLSShard(r, "s", "ns", "c")
+	leaderCtx, cancelLeader := context.WithCancel(t.Context())
+	leaderErr := make(chan error, 1)
+	go func() {
+		_, err := r.ClientFor(leaderCtx, shard)
+		leaderErr <- err
+	}()
+	select {
+	case <-cancelReader.started:
+	case <-time.After(time.Second):
+		t.Fatal("cold initialization did not start")
+	}
+
+	joinerResult := make(chan struct {
+		client rpcclient.MultipoolerClient
+		err    error
+	}, 1)
+	go func() {
+		client, err := r.ClientFor(t.Context(), shard)
+		joinerResult <- struct {
+			client rpcclient.MultipoolerClient
+			err    error
+		}{client: client, err: err}
+	}()
+	cancelLeader()
+	if err := <-leaderErr; err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("leader ClientFor() error = %v, want context cancellation", err)
+	}
+	select {
+	case result := <-joinerResult:
+		if result.err != nil || result.client == nil {
+			t.Fatalf("joiner ClientFor() = (%v, %v), want a client", result.client, result.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("healthy joiner did not retry canceled initialization")
+	}
+	if got := cancelReader.getCount(); got != 2 {
+		t.Fatalf("Secret reads = %d, want canceled read plus healthy retry", got)
+	}
+}
+
+func TestClientForCachesPerClusterAndBindsServerName(t *testing.T) {
+	ca := newTestCA(t)
+	r, insecure, _ := newResolver(t,
+		operatorSecret(t, ca, "ns-a", "cluster-a", "1"),
+		operatorSecret(t, ca, "ns-b", "cluster-b", "1"),
+	)
+	configs := make([]*tls.Config, 0, 2)
+	r.newClient = func(config *tls.Config) rpcclient.MultipoolerClient {
+		configs = append(configs, config)
+		return rpcclient.NewFakeClient()
+	}
+	r.ActivateCluster(types.NamespacedName{Namespace: "ns-a", Name: "cluster-a"})
+	r.ActivateCluster(types.NamespacedName{Namespace: "ns-b", Name: "cluster-b"})
+
+	a1, err := r.ClientFor(t.Context(), testShard("s1", "ns-a", "cluster-a", true))
+	if err != nil {
+		t.Fatalf("first cluster A ClientFor() error = %v", err)
+	}
+	a2, err := r.ClientFor(t.Context(), testShard("s2", "ns-a", "cluster-a", true))
+	if err != nil {
+		t.Fatalf("second cluster A ClientFor() error = %v", err)
+	}
+	b, err := r.ClientFor(t.Context(), testShard("s", "ns-b", "cluster-b", true))
+	if err != nil {
+		t.Fatalf("cluster B ClientFor() error = %v", err)
+	}
+	if a1 == insecure || b == insecure || a1 != a2 || a1 == b {
+		t.Error("clients were not cached independently per cluster")
+	}
+	if len(configs) != 2 {
+		t.Fatalf("created %d TLS configs, want 2", len(configs))
+	}
+	wantA := "multipooler.cluster-a.ns-a.multigres.internal"
+	wantB := "multipooler.cluster-b.ns-b.multigres.internal"
+	if configs[0].ServerName != wantA || configs[1].ServerName != wantB {
+		t.Errorf(
+			"ServerNames = %q, %q; want %q, %q",
+			configs[0].ServerName,
+			configs[1].ServerName,
+			wantA,
+			wantB,
+		)
+	}
+	if configs[0].InsecureSkipVerify || configs[0].VerifyConnection != nil {
+		t.Error("cluster client bypasses normal TLS hostname verification")
+	}
+}
+
+func TestClientForKeepsClientOnRefreshFailure(t *testing.T) {
+	ca := newTestCA(t)
+	secret := operatorSecret(t, ca, "ns", "c", "1")
+	r, _, c := newResolver(t, secret)
+	r.refreshInterval = 0
+	shard := activeTLSShard(r, "s", "ns", "c")
+
+	want, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("first ClientFor() error = %v", err)
+	}
+	if err := c.Delete(t.Context(), secret); err != nil {
+		t.Fatalf("delete secret: %v", err)
+	}
+	got, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("refresh ClientFor() error = %v", err)
+	}
+	if got != want {
+		t.Error("refresh failure replaced the working client")
+	}
+}
+
+type countingReader struct {
+	client.Reader
+	mu   sync.Mutex
+	gets int
+}
+
+func (r *countingReader) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	r.mu.Lock()
+	r.gets++
+	r.mu.Unlock()
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
+func (r *countingReader) getCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.gets
+}
+
+func TestClientForRetriesWarmRefreshFailureOnFailureInterval(t *testing.T) {
+	ca := newTestCA(t)
+	secret := operatorSecret(t, ca, "ns", "c", "1")
+	r, _, c := newResolver(t, secret)
+	reader := &countingReader{Reader: c}
+	r.reader = reader
+	r.refreshInterval = time.Hour
+	r.failureRetry = time.Minute
+	shard := activeTLSShard(r, "s", "ns", "c")
+
+	want, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("first ClientFor() error = %v", err)
+	}
+	state := r.states[types.NamespacedName{Namespace: "ns", Name: "c"}]
+	state.mu.Lock()
+	state.fetchedAt = time.Now().Add(-2 * r.refreshInterval)
+	state.mu.Unlock()
+	if err := c.Delete(t.Context(), secret); err != nil {
+		t.Fatalf("delete Secret: %v", err)
+	}
+	if got, err := r.ClientFor(t.Context(), shard); err != nil || got != want {
+		t.Fatalf("failed refresh ClientFor() = (%v, %v), want existing client", got, err)
+	}
+	if got := reader.getCount(); got != 2 {
+		t.Fatalf("Secret reads after failed refresh = %d, want 2", got)
+	}
+	if _, err := r.ClientFor(t.Context(), shard); err != nil {
+		t.Fatalf("ClientFor() during failure retry window error = %v", err)
+	}
+	if got := reader.getCount(); got != 2 {
+		t.Fatalf("Secret reads during failure retry window = %d, want 2", got)
+	}
+
+	replacement := operatorSecret(t, ca, "ns", "c", "")
+	if err := c.Create(t.Context(), replacement); err != nil {
+		t.Fatalf("recreate Secret: %v", err)
+	}
+	state.mu.Lock()
+	state.fetchedAt = time.Now().Add(-2 * r.failureRetry)
+	state.mu.Unlock()
+	if _, err := r.ClientFor(t.Context(), shard); err != nil {
+		t.Fatalf("ClientFor() after failure retry interval error = %v", err)
+	}
+	if got := reader.getCount(); got != 3 {
+		t.Fatalf("Secret reads after failure retry interval = %d, want 3", got)
+	}
+}
+
+func TestClientForCanceledWarmRefreshDoesNotDelayRetry(t *testing.T) {
+	ca := newTestCA(t)
+	secret := operatorSecret(t, ca, "ns", "c", "1")
+	r, _, c := newResolver(t, secret)
+	r.refreshInterval = time.Hour
+	shard := activeTLSShard(r, "s", "ns", "c")
+	want, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("first ClientFor() error = %v", err)
+	}
+	state := r.states[types.NamespacedName{Namespace: "ns", Name: "c"}]
+	state.mu.Lock()
+	state.fetchedAt = time.Now().Add(-2 * r.refreshInterval)
+	state.mu.Unlock()
+	cancelReader := &cancelFirstReader{Reader: c, started: make(chan struct{})}
+	r.reader = cancelReader
+	refreshCtx, cancelRefresh := context.WithCancel(t.Context())
+	refreshResult := make(chan struct {
+		client rpcclient.MultipoolerClient
+		err    error
+	}, 1)
+	go func() {
+		client, err := r.ClientFor(refreshCtx, shard)
+		refreshResult <- struct {
+			client rpcclient.MultipoolerClient
+			err    error
+		}{client: client, err: err}
+	}()
+	<-cancelReader.started
+	cancelRefresh()
+	result := <-refreshResult
+	if result.err != nil || result.client != want {
+		t.Fatalf(
+			"canceled refresh ClientFor() = (%v, %v), want existing client",
+			result.client,
+			result.err,
+		)
+	}
+	state.mu.Lock()
+	lastErr := state.lastErr
+	state.mu.Unlock()
+	if lastErr != nil {
+		t.Fatalf("canceled refresh cached error %v", lastErr)
+	}
+	if got, err := r.ClientFor(t.Context(), shard); err != nil || got != want {
+		t.Fatalf("healthy retry ClientFor() = (%v, %v), want existing client", got, err)
+	}
+	if got := cancelReader.getCount(); got != 2 {
+		t.Fatalf("Secret reads = %d, want immediate retry after cancellation", got)
+	}
+}
+
+type blockingReader struct {
+	client.Reader
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (r *blockingReader) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	r.started <- struct{}{}
+	select {
+	case <-r.release:
+		return r.Reader.Get(ctx, key, obj, opts...)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestClientForDoesNotBlockOnConcurrentRefresh(t *testing.T) {
+	ca := newTestCA(t)
+	secret := operatorSecret(t, ca, "ns", "c", "1")
+	r, _, c := newResolver(t, secret)
+	r.refreshInterval = 0
+	shard := activeTLSShard(r, "s", "ns", "c")
+
+	want, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("first ClientFor() error = %v", err)
+	}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	r.reader = &blockingReader{Reader: c, started: started, release: release}
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, refreshErr := r.ClientFor(t.Context(), shard)
+		refreshDone <- refreshErr
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("background refresh did not start")
+	}
+
+	reuseDone := make(chan rpcclient.MultipoolerClient, 1)
+	go func() {
+		got, reuseErr := r.ClientFor(t.Context(), shard)
+		if reuseErr != nil {
+			reuseDone <- nil
+			return
+		}
+		reuseDone <- got
+	}()
+	select {
+	case got := <-reuseDone:
+		if got != want {
+			close(release)
+			t.Fatal("concurrent reconcile did not reuse the current client")
+		}
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("concurrent reconcile blocked behind Secret refresh")
+	}
+	close(release)
+	if err := <-refreshDone; err != nil {
+		t.Fatalf("background refresh error = %v", err)
+	}
+}
+
+func TestClientForKeepsClientOnMalformedRotation(t *testing.T) {
+	ca := newTestCA(t)
+	secret := operatorSecret(t, ca, "ns", "c", "1")
+	r, _, c := newResolver(t, secret)
+	r.refreshInterval = 0
+	shard := activeTLSShard(r, "s", "ns", "c")
+
+	want, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("first ClientFor() error = %v", err)
+	}
+	current := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}
+	if err := c.Get(t.Context(), key, current); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	current.Data[corev1.TLSCertKey] = []byte("not a cert")
+	if err := c.Update(t.Context(), current); err != nil {
+		t.Fatalf("update secret: %v", err)
+	}
+	got, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("refresh ClientFor() error = %v", err)
+	}
+	if got != want {
+		t.Error("malformed rotation replaced the working client")
+	}
+}
+
+func TestClientForRebuildsOnSecretRotation(t *testing.T) {
+	ca := newTestCA(t)
+	secret := operatorSecret(t, ca, "ns", "c", "1")
+	r, _, c := newResolver(t, secret)
+	r.refreshInterval = 0
+	r.retirementGrace = time.Hour
+	closeCount := 0
+	r.newClient = func(*tls.Config) rpcclient.MultipoolerClient {
+		return &closeTrackingClient{
+			MultipoolerClient: rpcclient.NewFakeClient(),
+			closeCount:        &closeCount,
+		}
+	}
+	shard := activeTLSShard(r, "s", "ns", "c")
+	first, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("first ClientFor() error = %v", err)
+	}
+
+	current := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}
+	if err := c.Get(t.Context(), key, current); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	certPEM, keyPEM, _ := ca.issue(t, nil, x509.ExtKeyUsageClientAuth)
+	current.Data[corev1.TLSCertKey] = certPEM
+	current.Data[corev1.TLSPrivateKeyKey] = keyPEM
+	if err := c.Update(t.Context(), current); err != nil {
+		t.Fatalf("rotate secret: %v", err)
+	}
+
+	after, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("post-rotation ClientFor() error = %v", err)
+	}
+	if after == first {
+		t.Error("rotated secret did not produce a new client")
+	}
+	state := r.states[types.NamespacedName{Namespace: "ns", Name: "c"}]
+	if len(state.retiredClients) != 1 || state.retiredClients[0].client != first {
+		t.Error("old client was not retained for in-flight RPCs")
+	}
+	r.Close()
+	if closeCount != 2 {
+		t.Errorf("client close count after resolver shutdown = %d, want 2", closeCount)
+	}
+}
+
+type closeTrackingClient struct {
+	rpcclient.MultipoolerClient
+	closeCount *int
+}
+
+func (c *closeTrackingClient) Close() {
+	*c.closeCount++
+}
+
+type closeSignalClient struct {
+	rpcclient.MultipoolerClient
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (c *closeSignalClient) Close() {
+	c.once.Do(func() { close(c.closed) })
+}
+
+func TestForgetClusterBlocksStaleShardUntilReactivated(t *testing.T) {
+	ca := newTestCA(t)
+	r, _, _ := newResolver(t, operatorSecret(t, ca, "ns", "c", "1"))
+	r.retirementGrace = 10 * time.Millisecond
+	clients := make([]*closeSignalClient, 0, 2)
+	r.newClient = func(*tls.Config) rpcclient.MultipoolerClient {
+		client := &closeSignalClient{
+			MultipoolerClient: rpcclient.NewFakeClient(),
+			closed:            make(chan struct{}),
+		}
+		clients = append(clients, client)
+		return client
+	}
+	key := types.NamespacedName{Namespace: "ns", Name: "c"}
+	shard := activeTLSShard(r, "s", key.Namespace, key.Name)
+	first, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("first ClientFor() error = %v", err)
+	}
+
+	r.ForgetCluster(key)
+	if _, err := r.ClientFor(t.Context(), shard); err == nil ||
+		!strings.Contains(err.Error(), "not active") {
+		t.Fatalf("stale shard ClientFor() error = %v, want inactive cluster", err)
+	}
+	r.mu.Lock()
+	_, stateRecreated := r.states[key]
+	_, stillActive := r.active[key]
+	r.mu.Unlock()
+	if stateRecreated || stillActive {
+		t.Fatalf(
+			"forgotten cluster state/active = %v/%v, want false/false",
+			stateRecreated,
+			stillActive,
+		)
+	}
+	select {
+	case <-clients[0].closed:
+	case <-time.After(time.Second):
+		t.Fatal("forgotten cluster client was not closed after the grace period")
+	}
+
+	r.ActivateCluster(key)
+	after, err := r.ClientFor(t.Context(), shard)
+	if err != nil {
+		t.Fatalf("reactivated ClientFor() error = %v", err)
+	}
+	if after == first {
+		t.Fatal("reactivated cluster reused the forgotten client")
+	}
+}
+
+func TestClientForMalformedInitialSecret(t *testing.T) {
+	secret := operatorSecret(t, newTestCA(t), "ns", "c", "1")
+	delete(secret.Data, corev1.TLSPrivateKeyKey)
+	r, _, _ := newResolver(t, secret)
+	if _, err := r.ClientFor(t.Context(), activeTLSShard(r, "s", "ns", "c")); err == nil {
+		t.Fatal("ClientFor() expected malformed Secret error")
+	}
+}
+
+func TestBuildTLSConfigVerifiesExactClusterIdentity(t *testing.T) {
+	ca := newTestCA(t)
+	secret := operatorSecret(t, ca, "ns-a", "cluster-a", "1")
+	serverName := "multipooler.cluster-a.ns-a.multigres.internal"
+	config, err := buildTLSConfig(secret, serverName)
+	if err != nil {
+		t.Fatalf("buildTLSConfig() error = %v", err)
+	}
+	if config.ServerName != serverName || config.InsecureSkipVerify {
+		t.Fatalf(
+			"TLS config ServerName/InsecureSkipVerify = %q/%v",
+			config.ServerName,
+			config.InsecureSkipVerify,
+		)
+	}
+
+	foreignCA := newTestCA(t)
+	tests := []struct {
+		name     string
+		issuer   *testCA
+		dnsNames []string
+		usage    x509.ExtKeyUsage
+		wantOK   bool
+	}{
+		{
+			name:     "target multipooler",
+			issuer:   ca,
+			dnsNames: []string{serverName},
+			usage:    x509.ExtKeyUsageServerAuth,
+			wantOK:   true,
+		},
+		{
+			name:     "other cluster",
+			issuer:   ca,
+			dnsNames: []string{"multipooler.cluster-b.ns-a.multigres.internal"},
+			usage:    x509.ExtKeyUsageServerAuth,
+		},
+		{
+			// Multigateway deliberately carries the same-cluster multipooler
+			// alias, so standard hostname verification accepts that shared
+			// serving certificate while still rejecting another cluster.
+			name:   "same cluster multigateway certificate with pooler alias",
+			issuer: ca,
+			dnsNames: []string{
+				"multigateway.cluster-a.ns-a.multigres.internal",
+				serverName,
+			},
+			usage:  x509.ExtKeyUsageServerAuth,
+			wantOK: true,
+		},
+		{
+			name:     "foreign issuer",
+			issuer:   foreignCA,
+			dnsNames: []string{serverName},
+			usage:    x509.ExtKeyUsageServerAuth,
+		},
+		{
+			name:     "client auth only",
+			issuer:   ca,
+			dnsNames: []string{serverName},
+			usage:    x509.ExtKeyUsageClientAuth,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, leaf := tt.issuer.issue(t, tt.dnsNames, tt.usage)
+			_, err := leaf.Verify(x509.VerifyOptions{
+				Roots:   config.RootCAs,
+				DNSName: config.ServerName,
+			})
+			if (err == nil) != tt.wantOK {
+				t.Errorf("Verify() error = %v, want success %v", err, tt.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient"
 	corev1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,6 +63,14 @@ func (r *ShardReconciler) reconcileDataPlane(
 		var err error
 		rpcClient, err = r.PoolerClients.ClientFor(ctx, shard)
 		if err != nil {
+			previous := meta.FindStatusCondition(
+				shard.Status.Conditions,
+				posture.ConditionConsistent,
+			)
+			enteringUnavailable := previous == nil ||
+				previous.Status != metav1.ConditionUnknown ||
+				previous.Reason != reasonPoolerClientUnavailable
+
 			// A resolver error breaks the sequence of posture observations. It must
 			// not let a strike from before the transport outage combine with the
 			// first unsettled observation after recovery.
@@ -74,20 +83,28 @@ func (r *ShardReconciler) reconcileDataPlane(
 			poolerClientUnavailable = true
 			setPostureUnknownUnlessFalse(
 				shard,
-				"PoolerClientUnavailable",
+				reasonPoolerClientUnavailable,
 				fmt.Sprintf("Failed to build multipooler RPC client: %v", err),
 			)
-			logger.Error(err, "Failed to resolve multipooler RPC client")
-			r.Recorder.Eventf(shard, "Warning", "PoolerClientUnavailable",
-				"Failed to build multipooler RPC client: %v", err)
+			setBackupUnknownUnlessFalse(
+				shard,
+				fmt.Sprintf("Failed to build multipooler RPC client: %v", err),
+			)
+			if enteringUnavailable {
+				logger.Error(err, "Failed to resolve multipooler RPC client")
+				r.Recorder.Eventf(shard, "Warning", reasonPoolerClientUnavailable,
+					"Failed to build multipooler RPC client: %v", err)
+			} else {
+				logger.V(1).Info("Multipooler RPC client is still unavailable", "error", err)
+			}
 		}
 	}
 
-	postureRequeue := false
+	postureRetryAfter := time.Duration(0)
 	if rpcClient != nil {
 		_, childSpan := monitoring.StartChildSpan(ctx, "Shard.ReconcilePosture")
 		var err error
-		postureRequeue, err = r.reconcilePosture(ctx, store, shard, rpcClient)
+		postureRetryAfter, err = r.reconcilePosture(ctx, store, shard, rpcClient)
 		if err != nil {
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
@@ -112,7 +129,7 @@ func (r *ShardReconciler) reconcileDataPlane(
 		logger.Info("No primary in podRoles, requeueing to re-read topology")
 		return withDataPlaneRequeue(
 			ctrl.Result{RequeueAfter: 10 * time.Second},
-			postureRequeue,
+			postureRetryAfter,
 			poolerClientUnavailable,
 		), nil
 	}
@@ -140,7 +157,7 @@ func (r *ShardReconciler) reconcileDataPlane(
 		if acted {
 			return withDataPlaneRequeue(
 				ctrl.Result{RequeueAfter: quarantineRemediationRequeue},
-				postureRequeue,
+				postureRetryAfter,
 				poolerClientUnavailable,
 			), nil
 		}
@@ -159,7 +176,7 @@ func (r *ShardReconciler) reconcileDataPlane(
 		if requeue {
 			return withDataPlaneRequeue(
 				ctrl.Result{RequeueAfter: 2 * time.Second},
-				postureRequeue,
+				postureRetryAfter,
 				poolerClientUnavailable,
 			), nil
 		}
@@ -168,6 +185,7 @@ func (r *ShardReconciler) reconcileDataPlane(
 	// Phase: Evaluate backup health
 	if rpcClient != nil {
 		_, childSpan := monitoring.StartChildSpan(ctx, "Shard.ReconcileBackupHealth")
+		backupBase := shard.DeepCopy()
 		result, err := backuphealth.Evaluate(ctx, store, rpcClient, shard)
 		if err != nil {
 			monitoring.RecordSpanError(childSpan, err)
@@ -180,8 +198,15 @@ func (r *ShardReconciler) reconcileDataPlane(
 				"Failed to check backup health: %v",
 				err,
 			)
+			setBackupUnknownUnlessFalse(
+				shard,
+				fmt.Sprintf("Failed to check backup health: %v", err),
+			)
+			if patchErr := r.Status().
+				Patch(ctx, shard, client.MergeFrom(backupBase)); patchErr != nil {
+				return ctrl.Result{}, fmt.Errorf("update unavailable backup status: %w", patchErr)
+			}
 		} else if result != nil {
-			backupBase := shard.DeepCopy()
 			prevHealthy := status.IsConditionTrue(
 				shard.Status.Conditions,
 				backuphealth.ConditionHealthy,
@@ -219,7 +244,7 @@ func (r *ShardReconciler) reconcileDataPlane(
 		if wait > 0 {
 			return withDataPlaneRequeue(
 				ctrl.Result{RequeueAfter: wait},
-				postureRequeue,
+				postureRetryAfter,
 				poolerClientUnavailable,
 			), nil
 		}
@@ -227,7 +252,7 @@ func (r *ShardReconciler) reconcileDataPlane(
 
 	return withDataPlaneRequeue(
 		ctrl.Result{},
-		postureRequeue,
+		postureRetryAfter,
 		poolerClientUnavailable,
 	), nil
 }
@@ -296,11 +321,17 @@ func (r *ShardReconciler) reconcilePodRoles(
 }
 
 const (
-	postureStrikeThreshold      = 2
-	postureDebounceRequeueDelay = 5 * time.Second
+	postureStrikeThreshold       = 2
+	postureDebounceRequeueDelay  = 5 * time.Second
+	poolerRegistrationRetryDelay = time.Minute
 	// poolerClientRetryDelay is the requeue delay when the multipooler RPC
 	// client cannot be built yet (e.g. operator client cert not issued).
 	poolerClientRetryDelay = 10 * time.Second
+
+	reasonPoolerClientUnavailable    = "PoolerClientUnavailable"
+	reasonAwaitingPoolerRegistration = "AwaitingPoolerRegistration"
+	reasonObservationPending         = "ObservationPending"
+	reasonBackupCheckUnavailable     = "BackupCheckUnavailable"
 )
 
 func (r *ShardReconciler) reconcilePosture(
@@ -308,7 +339,7 @@ func (r *ShardReconciler) reconcilePosture(
 	store topoclient.Store,
 	shard *multigresv1alpha1.Shard,
 	rpcClient rpcclient.MultipoolerClient,
-) (bool, error) {
+) (time.Duration, error) {
 	lbls := map[string]string{
 		metadata.LabelMultigresCluster:    shard.Labels[metadata.LabelMultigresCluster],
 		metadata.LabelMultigresDatabase:   string(shard.Spec.DatabaseName),
@@ -320,7 +351,7 @@ func (r *ShardReconciler) reconcilePosture(
 		client.InNamespace(shard.Namespace),
 		client.MatchingLabels(lbls),
 	); err != nil {
-		return false, fmt.Errorf("list pods for posture reconciliation: %w", err)
+		return 0, fmt.Errorf("list pods for posture reconciliation: %w", err)
 	}
 	podNames := make([]string, len(podList.Items))
 	for i := range podList.Items {
@@ -331,7 +362,7 @@ func (r *ShardReconciler) reconcilePosture(
 	if err != nil {
 		r.Recorder.Eventf(shard, "Warning", "PostureCheckFailed",
 			"Failed to check postgres posture consistency: %v", err)
-		return false, fmt.Errorf("evaluate posture consistency: %w", err)
+		return 0, fmt.Errorf("evaluate posture consistency: %w", err)
 	}
 	if result == nil {
 		// An empty topology is expected during bootstrap, but it is not a settled
@@ -340,10 +371,10 @@ func (r *ShardReconciler) reconcilePosture(
 		r.recordPostureObservation(shard, false)
 		setPostureUnknownUnlessFalse(
 			shard,
-			"AwaitingPoolerRegistration",
+			reasonAwaitingPoolerRegistration,
 			"Waiting for multipoolers to register in topology",
 		)
-		return true, nil
+		return poolerRegistrationRetryDelay, nil
 	}
 
 	clusterName := shard.Labels[metadata.LabelMultigresCluster]
@@ -373,16 +404,16 @@ func (r *ShardReconciler) reconcilePosture(
 		// Once RPCs recover, do not retain a transport-specific condition reason
 		// during the debounce cycle. The observation is available but still needs
 		// confirmation before it may change the shard's health.
-		if condition := postureCondition(
+		if condition := meta.FindStatusCondition(
 			shard.Status.Conditions,
-		); condition != nil &&
-			condition.Reason == "PoolerClientUnavailable" {
+			posture.ConditionConsistent,
+		); condition != nil && condition.Status == metav1.ConditionUnknown {
 			status.SetCondition(&shard.Status.Conditions, metav1.Condition{
 				Type:               posture.ConditionConsistent,
 				Status:             metav1.ConditionUnknown,
 				ObservedGeneration: shard.Generation,
 				LastTransitionTime: metav1.Now(),
-				Reason:             "ObservationPending",
+				Reason:             reasonObservationPending,
 				Message:            result.Message,
 			})
 		}
@@ -396,16 +427,10 @@ func (r *ShardReconciler) reconcilePosture(
 		r.Recorder.Eventf(shard, "Warning", reason, result.Message)
 	}
 
-	return unsettled && strikes < postureStrikeThreshold, nil
-}
-
-func postureCondition(conditions []metav1.Condition) *metav1.Condition {
-	for i := range conditions {
-		if conditions[i].Type == posture.ConditionConsistent {
-			return &conditions[i]
-		}
+	if unsettled && strikes < postureStrikeThreshold {
+		return postureDebounceRequeueDelay, nil
 	}
-	return nil
+	return 0, nil
 }
 
 func setPostureUnknownUnlessFalse(
@@ -426,14 +451,28 @@ func setPostureUnknownUnlessFalse(
 	})
 }
 
+func setBackupUnknownUnlessFalse(shard *multigresv1alpha1.Shard, message string) {
+	if status.IsConditionFalse(shard.Status.Conditions, backuphealth.ConditionHealthy) {
+		return
+	}
+	status.SetCondition(&shard.Status.Conditions, metav1.Condition{
+		Type:               backuphealth.ConditionHealthy,
+		Status:             metav1.ConditionUnknown,
+		ObservedGeneration: shard.Generation,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reasonBackupCheckUnavailable,
+		Message:            message,
+	})
+}
+
 func withDataPlaneRequeue(
 	result ctrl.Result,
-	posturePending bool,
+	postureRetryAfter time.Duration,
 	poolerClientUnavailable bool,
 ) ctrl.Result {
-	if posturePending &&
-		(result.RequeueAfter == 0 || result.RequeueAfter > postureDebounceRequeueDelay) {
-		result.RequeueAfter = postureDebounceRequeueDelay
+	if postureRetryAfter > 0 &&
+		(result.RequeueAfter == 0 || result.RequeueAfter > postureRetryAfter) {
+		result.RequeueAfter = postureRetryAfter
 	}
 	if poolerClientUnavailable &&
 		(result.RequeueAfter == 0 || result.RequeueAfter > poolerClientRetryDelay) {

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -50,11 +52,42 @@ func (r *ShardReconciler) reconcileDataPlane(
 		childSpan.End()
 	}
 
+	// Resolve the pooler RPC client once for every RPC phase. A
+	// resolution failure (e.g. operator client cert not issued yet) is not a
+	// reconcile error: skip RPC phases, continue topology maintenance, and retry
+	// shortly.
+	var rpcClient rpcclient.MultipoolerClient
+	poolerClientUnavailable := false
+	if r.PoolerClients != nil {
+		var err error
+		rpcClient, err = r.PoolerClients.ClientFor(ctx, shard)
+		if err != nil {
+			// A resolver error breaks the sequence of posture observations. It must
+			// not let a strike from before the transport outage combine with the
+			// first unsettled observation after recovery.
+			r.recordPostureObservation(shard, false)
+
+			// A partial observation cannot clear a confirmed posture failure. Keep a
+			// split-brain shard Degraded while the RPC client is unavailable; for all
+			// other prior states, report that posture cannot currently be observed.
+			rpcClient = nil
+			poolerClientUnavailable = true
+			setPostureUnknownUnlessFalse(
+				shard,
+				"PoolerClientUnavailable",
+				fmt.Sprintf("Failed to build multipooler RPC client: %v", err),
+			)
+			logger.Error(err, "Failed to resolve multipooler RPC client")
+			r.Recorder.Eventf(shard, "Warning", "PoolerClientUnavailable",
+				"Failed to build multipooler RPC client: %v", err)
+		}
+	}
+
 	postureRequeue := false
-	if r.RPCClient != nil {
+	if rpcClient != nil {
 		_, childSpan := monitoring.StartChildSpan(ctx, "Shard.ReconcilePosture")
 		var err error
-		postureRequeue, err = r.reconcilePosture(ctx, store, shard)
+		postureRequeue, err = r.reconcilePosture(ctx, store, shard, rpcClient)
 		if err != nil {
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
@@ -62,18 +95,26 @@ func (r *ShardReconciler) reconcileDataPlane(
 		}
 		childSpan.End()
 
-		// Publish posture, condition, and phase in one status update.
-		if err := r.updateStatus(ctx, shard, rendered); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update status after posture observation: %w", err)
-		}
+	}
+
+	// Publish the topology-derived pod roles even when the RPC client is not
+	// available yet. When posture ran, this also publishes its observation,
+	// condition, and resulting phase in the same status update.
+	if err := r.updateStatus(ctx, shard, rendered); err != nil {
+		return ctrl.Result{}, fmt.Errorf("update status after data-plane observation: %w", err)
 	}
 
 	// Requeue when the shard is Healthy but topology hasn't elected a primary
 	// yet. This closes a race where the reconciliation burst settles before
 	// multiorch writes the primary type to etcd.
-	if shard.Status.Phase == multigresv1alpha1.PhaseHealthy && !hasPrimary(shard.Status.PodRoles) {
+	if shard.Status.Phase == multigresv1alpha1.PhaseHealthy &&
+		!hasPrimary(shard.Status.PodRoles) {
 		logger.Info("No primary in podRoles, requeueing to re-read topology")
-		return withPostureRequeue(ctrl.Result{RequeueAfter: 10 * time.Second}, postureRequeue), nil
+		return withDataPlaneRequeue(
+			ctrl.Result{RequeueAfter: 10 * time.Second},
+			postureRequeue,
+			poolerClientUnavailable,
+		), nil
 	}
 
 	// Phase: Prune stale pooler entries from topology
@@ -97,9 +138,10 @@ func (r *ShardReconciler) reconcileDataPlane(
 		}
 		childSpan.End()
 		if acted {
-			return withPostureRequeue(
+			return withDataPlaneRequeue(
 				ctrl.Result{RequeueAfter: quarantineRemediationRequeue},
 				postureRequeue,
+				poolerClientUnavailable,
 			), nil
 		}
 	}
@@ -115,17 +157,18 @@ func (r *ShardReconciler) reconcileDataPlane(
 		}
 		childSpan.End()
 		if requeue {
-			return withPostureRequeue(
+			return withDataPlaneRequeue(
 				ctrl.Result{RequeueAfter: 2 * time.Second},
 				postureRequeue,
+				poolerClientUnavailable,
 			), nil
 		}
 	}
 
 	// Phase: Evaluate backup health
-	if r.RPCClient != nil {
+	if rpcClient != nil {
 		_, childSpan := monitoring.StartChildSpan(ctx, "Shard.ReconcileBackupHealth")
-		result, err := backuphealth.Evaluate(ctx, store, r.RPCClient, shard)
+		result, err := backuphealth.Evaluate(ctx, store, rpcClient, shard)
 		if err != nil {
 			monitoring.RecordSpanError(childSpan, err)
 			childSpan.End()
@@ -167,18 +210,26 @@ func (r *ShardReconciler) reconcileDataPlane(
 	// so a reload-only postgresql.conf change converges without recreating pods.
 	{
 		_, childSpan := monitoring.StartChildSpan(ctx, "Shard.ReconcileReloadState")
-		wait, err := r.reconcileReloadState(ctx, store, shard, rendered)
+		wait, err := r.reconcileReloadState(ctx, store, shard, rendered, rpcClient)
 		childSpan.End()
 		if err != nil {
 			logger.Error(err, "Failed to reconcile config reload state")
 			return ctrl.Result{}, err
 		}
 		if wait > 0 {
-			return withPostureRequeue(ctrl.Result{RequeueAfter: wait}, postureRequeue), nil
+			return withDataPlaneRequeue(
+				ctrl.Result{RequeueAfter: wait},
+				postureRequeue,
+				poolerClientUnavailable,
+			), nil
 		}
 	}
 
-	return withPostureRequeue(ctrl.Result{}, postureRequeue), nil
+	return withDataPlaneRequeue(
+		ctrl.Result{},
+		postureRequeue,
+		poolerClientUnavailable,
+	), nil
 }
 
 // reconcilePodRoles queries the topology for pooler status and updates
@@ -247,12 +298,16 @@ func (r *ShardReconciler) reconcilePodRoles(
 const (
 	postureStrikeThreshold      = 2
 	postureDebounceRequeueDelay = 5 * time.Second
+	// poolerClientRetryDelay is the requeue delay when the multipooler RPC
+	// client cannot be built yet (e.g. operator client cert not issued).
+	poolerClientRetryDelay = 10 * time.Second
 )
 
 func (r *ShardReconciler) reconcilePosture(
 	ctx context.Context,
 	store topoclient.Store,
 	shard *multigresv1alpha1.Shard,
+	rpcClient rpcclient.MultipoolerClient,
 ) (bool, error) {
 	lbls := map[string]string{
 		metadata.LabelMultigresCluster:    shard.Labels[metadata.LabelMultigresCluster],
@@ -272,14 +327,23 @@ func (r *ShardReconciler) reconcilePosture(
 		podNames[i] = podList.Items[i].Name
 	}
 
-	result, err := posture.Evaluate(ctx, store, r.RPCClient, shard, podNames)
+	result, err := posture.Evaluate(ctx, store, rpcClient, shard, podNames)
 	if err != nil {
 		r.Recorder.Eventf(shard, "Warning", "PostureCheckFailed",
 			"Failed to check postgres posture consistency: %v", err)
 		return false, fmt.Errorf("evaluate posture consistency: %w", err)
 	}
 	if result == nil {
-		return false, nil
+		// An empty topology is expected during bootstrap, but it is not a settled
+		// posture observation. Keep polling until poolers register rather than
+		// leaving a previous transport condition stuck until the periodic resync.
+		r.recordPostureObservation(shard, false)
+		setPostureUnknownUnlessFalse(
+			shard,
+			"AwaitingPoolerRegistration",
+			"Waiting for multipoolers to register in topology",
+		)
+		return true, nil
 	}
 
 	clusterName := shard.Labels[metadata.LabelMultigresCluster]
@@ -306,6 +370,22 @@ func (r *ShardReconciler) reconcilePosture(
 		posture.Apply(shard, result)
 	} else {
 		shard.Status.PodPostures = result.Postures
+		// Once RPCs recover, do not retain a transport-specific condition reason
+		// during the debounce cycle. The observation is available but still needs
+		// confirmation before it may change the shard's health.
+		if condition := postureCondition(
+			shard.Status.Conditions,
+		); condition != nil &&
+			condition.Reason == "PoolerClientUnavailable" {
+			status.SetCondition(&shard.Status.Conditions, metav1.Condition{
+				Type:               posture.ConditionConsistent,
+				Status:             metav1.ConditionUnknown,
+				ObservedGeneration: shard.Generation,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "ObservationPending",
+				Message:            result.Message,
+			})
+		}
 	}
 
 	if !prevFalse && status.IsConditionFalse(shard.Status.Conditions, posture.ConditionConsistent) {
@@ -319,9 +399,45 @@ func (r *ShardReconciler) reconcilePosture(
 	return unsettled && strikes < postureStrikeThreshold, nil
 }
 
-func withPostureRequeue(result ctrl.Result, pending bool) ctrl.Result {
-	if pending && (result.RequeueAfter == 0 || result.RequeueAfter > postureDebounceRequeueDelay) {
+func postureCondition(conditions []metav1.Condition) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == posture.ConditionConsistent {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func setPostureUnknownUnlessFalse(
+	shard *multigresv1alpha1.Shard,
+	reason string,
+	message string,
+) {
+	if status.IsConditionFalse(shard.Status.Conditions, posture.ConditionConsistent) {
+		return
+	}
+	status.SetCondition(&shard.Status.Conditions, metav1.Condition{
+		Type:               posture.ConditionConsistent,
+		Status:             metav1.ConditionUnknown,
+		ObservedGeneration: shard.Generation,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+func withDataPlaneRequeue(
+	result ctrl.Result,
+	posturePending bool,
+	poolerClientUnavailable bool,
+) ctrl.Result {
+	if posturePending &&
+		(result.RequeueAfter == 0 || result.RequeueAfter > postureDebounceRequeueDelay) {
 		result.RequeueAfter = postureDebounceRequeueDelay
+	}
+	if poolerClientUnavailable &&
+		(result.RequeueAfter == 0 || result.RequeueAfter > poolerClientRetryDelay) {
+		result.RequeueAfter = poolerClientRetryDelay
 	}
 	return result
 }

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane_posture_internal_test.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane_posture_internal_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/data-handler/backuphealth"
 	"github.com/multigres/multigres-operator/pkg/data-handler/poolerclient"
 	"github.com/multigres/multigres-operator/pkg/data-handler/posture"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
@@ -32,6 +33,19 @@ type countingPoolerResolver struct {
 	client rpcclient.MultipoolerClient
 	err    error
 	calls  int
+}
+
+type backupErrorClient struct {
+	rpcclient.MultipoolerClient
+	err error
+}
+
+func (c backupErrorClient) GetBackups(
+	context.Context,
+	*clustermetadata.Multipooler,
+	*multipoolermanagerdatapb.GetBackupsRequest,
+) (*multipoolermanagerdatapb.GetBackupsResponse, error) {
+	return nil, c.err
 }
 
 func (r *countingPoolerResolver) ClientFor(
@@ -208,16 +222,16 @@ func TestReconcilePostureDebouncesFirstInconsistency(t *testing.T) {
 	})
 	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
 
-	pending, err := r.reconcilePosture(t.Context(), store, shard, rpc)
+	retryAfter, err := r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("first reconcilePosture() error = %v", err)
 	}
-	if !pending {
+	if retryAfter != postureDebounceRequeueDelay {
 		t.Error("first inconsistent posture observation did not request a requeue")
 	}
 	if got := withDataPlaneRequeue(
 		ctrl.Result{},
-		pending,
+		retryAfter,
 		false,
 	).RequeueAfter; got != postureDebounceRequeueDelay {
 		t.Errorf("first requeue delay = %v, want %v", got, postureDebounceRequeueDelay)
@@ -226,11 +240,11 @@ func TestReconcilePostureDebouncesFirstInconsistency(t *testing.T) {
 		t.Errorf("conditions = %#v, want no failure on first observation", shard.Status.Conditions)
 	}
 
-	pending, err = r.reconcilePosture(t.Context(), store, shard, rpc)
+	retryAfter, err = r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("second reconcilePosture() error = %v", err)
 	}
-	if pending {
+	if retryAfter != 0 {
 		t.Error("second inconsistent posture observation requested another debounce requeue")
 	}
 	if !conditionIsFalse(shard.Status.Conditions, posture.ConditionConsistent) {
@@ -257,16 +271,16 @@ func TestReconcilePostureDebouncesFirstIncompleteObservation(t *testing.T) {
 	rpc.Errors[poolerID] = errors.New("connection error: EOF")
 	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
 
-	pending, err := r.reconcilePosture(t.Context(), store, shard, rpc)
+	retryAfter, err := r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("first reconcilePosture() error = %v", err)
 	}
-	if !pending {
+	if retryAfter != postureDebounceRequeueDelay {
 		t.Error("first incomplete posture observation did not request a requeue")
 	}
 	if got := withDataPlaneRequeue(
 		ctrl.Result{},
-		pending,
+		retryAfter,
 		false,
 	).RequeueAfter; got != postureDebounceRequeueDelay {
 		t.Errorf("first requeue delay = %v, want %v", got, postureDebounceRequeueDelay)
@@ -278,11 +292,11 @@ func TestReconcilePostureDebouncesFirstIncompleteObservation(t *testing.T) {
 		)
 	}
 
-	pending, err = r.reconcilePosture(t.Context(), store, shard, rpc)
+	retryAfter, err = r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("second reconcilePosture() error = %v", err)
 	}
-	if pending {
+	if retryAfter != 0 {
 		t.Error("second incomplete posture observation requested another debounce requeue")
 	}
 	for _, condition := range shard.Status.Conditions {
@@ -344,11 +358,20 @@ func TestReconcileDataPlaneRequeuesFirstPostureStrike(t *testing.T) {
 
 func TestReconcileDataPlaneContinuesWithoutPoolerClient(t *testing.T) {
 	shard := postureTestShard()
+	lastBackup := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+	shard.Status.LastBackupTime = &lastBackup
+	shard.Status.LastBackupType = "full"
 	shard.Status.Conditions = []metav1.Condition{{
 		Type:               posture.ConditionConsistent,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Consistent",
 		Message:            "postures consistent with topology roles",
+		LastTransitionTime: metav1.Now(),
+	}, {
+		Type:               backuphealth.ConditionHealthy,
+		Status:             metav1.ConditionTrue,
+		Reason:             "BackupRecent",
+		Message:            "backup is recent",
 		LastTransitionTime: metav1.Now(),
 	}}
 	store, _ := postureTestStore(t)
@@ -411,15 +434,57 @@ func TestReconcileDataPlaneContinuesWithoutPoolerClient(t *testing.T) {
 	if calls := rpc.GetCallLog(); len(calls) != 0 {
 		t.Errorf("RPC phases ran with resolver error, call log = %v", calls)
 	}
+	backupCondition := findPostureCondition(got.Status.Conditions, backuphealth.ConditionHealthy)
+	if backupCondition == nil || backupCondition.Status != metav1.ConditionUnknown ||
+		backupCondition.Reason != reasonBackupCheckUnavailable {
+		t.Errorf(
+			"backup condition = %#v, want Unknown/%s",
+			backupCondition,
+			reasonBackupCheckUnavailable,
+		)
+	}
+	if got.Status.LastBackupTime == nil || !got.Status.LastBackupTime.Equal(&lastBackup) ||
+		got.Status.LastBackupType != "full" {
+		t.Errorf(
+			"last backup fields changed during outage: time=%v type=%q",
+			got.Status.LastBackupTime,
+			got.Status.LastBackupType,
+		)
+	}
 
 	recorder := r.Recorder.(*record.FakeRecorder)
-	select {
-	case event := <-recorder.Events:
-		if !strings.Contains(event, "PoolerClientUnavailable") {
-			t.Errorf("event = %q, want PoolerClientUnavailable", event)
-		}
-	default:
+	if !containsEventWithReason(drainEvents(recorder), "PoolerClientUnavailable") {
 		t.Error("expected PoolerClientUnavailable event")
+	}
+
+	secondStore, _ := postureTestStore(t)
+	r.CreateTopoStore = func(*multigresv1alpha1.Shard) (topoclient.Store, error) {
+		return secondStore, nil
+	}
+	if _, err := r.reconcileDataPlane(t.Context(), got, renderedConfig{}); err != nil {
+		t.Fatalf("second reconcileDataPlane() error = %v", err)
+	}
+	if events := drainEvents(recorder); containsEventWithReason(events, "PoolerClientUnavailable") {
+		t.Errorf(
+			"repeated resolver failure re-emitted PoolerClientUnavailable, events = %v",
+			events,
+		)
+	}
+}
+
+func TestSetBackupUnknownPreservesConfirmedFailure(t *testing.T) {
+	shard := postureTestShard()
+	shard.Status.Conditions = []metav1.Condition{{
+		Type:               backuphealth.ConditionHealthy,
+		Status:             metav1.ConditionFalse,
+		Reason:             "BackupStale",
+		LastTransitionTime: metav1.Now(),
+	}}
+	setBackupUnknownUnlessFalse(shard, "RPC unavailable")
+	condition := findPostureCondition(shard.Status.Conditions, backuphealth.ConditionHealthy)
+	if condition == nil || condition.Status != metav1.ConditionFalse ||
+		condition.Reason != "BackupStale" {
+		t.Errorf("backup condition = %#v, want preserved False/BackupStale", condition)
 	}
 }
 
@@ -475,15 +540,71 @@ func TestReconcileDataPlaneResolverFailurePreservesConfirmedPostureFailure(t *te
 	}
 }
 
-func TestReconcilePostureClearsUnavailableReasonDuringDebounce(t *testing.T) {
+func TestReconcileDataPlaneMarksBackupUnknownOnRPCFailure(t *testing.T) {
 	shard := postureTestShard()
+	lastBackup := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+	shard.Status.LastBackupTime = &lastBackup
+	shard.Status.LastBackupType = "full"
 	shard.Status.Conditions = []metav1.Condition{{
-		Type:               posture.ConditionConsistent,
-		Status:             metav1.ConditionUnknown,
-		Reason:             "PoolerClientUnavailable",
-		Message:            "certificate not issued",
+		Type:               backuphealth.ConditionHealthy,
+		Status:             metav1.ConditionTrue,
+		Reason:             "BackupRecent",
 		LastTransitionTime: metav1.Now(),
 	}}
+	store, poolerID := postureTestStore(t)
+	if _, err := store.UpdateMultipoolerFields(
+		t.Context(),
+		&clustermetadata.ID{Cell: "cell1", Name: "pooler-0"},
+		func(pooler *clustermetadata.Multipooler) error {
+			pooler.RoutingState.Role = clustermetadata.RoutingRole_ROUTING_ROLE_PRIMARY
+			return nil
+		},
+	); err != nil {
+		t.Fatalf("make pooler primary: %v", err)
+	}
+
+	baseRPC := rpcclient.NewFakeClient()
+	baseRPC.SetStatusResponse(poolerID, &multipoolermanagerdatapb.StatusResponse{
+		Status: &multipoolermanagerdatapb.Status{
+			PostgresStatus: multipoolermanagerdatapb.PostgresStatus_POSTGRES_STATUS_PRIMARY,
+		},
+	})
+	rpc := backupErrorClient{
+		MultipoolerClient: baseRPC,
+		err:               errors.New("backup RPC unavailable"),
+	}
+	pod := postureTestPod()
+	pod.Labels[metadata.LabelAppComponent] = PoolComponentName
+	pod.Labels[metadata.LabelMultigresCell] = "cell1"
+	pod.Labels[metadata.LabelMultigresPool] = "default"
+	r, c := postureTestReconciler(t, shard, rpc, pod)
+	r.CreateTopoStore = func(*multigresv1alpha1.Shard) (topoclient.Store, error) {
+		return store, nil
+	}
+
+	if _, err := r.reconcileDataPlane(t.Context(), shard, renderedConfig{}); err != nil {
+		t.Fatalf("reconcileDataPlane() error = %v", err)
+	}
+	got := &multigresv1alpha1.Shard{}
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get updated shard: %v", err)
+	}
+	condition := findPostureCondition(got.Status.Conditions, backuphealth.ConditionHealthy)
+	if condition == nil || condition.Status != metav1.ConditionUnknown ||
+		condition.Reason != reasonBackupCheckUnavailable {
+		t.Errorf("backup condition = %#v, want Unknown/%s", condition, reasonBackupCheckUnavailable)
+	}
+	if got.Status.LastBackupTime == nil || !got.Status.LastBackupTime.Equal(&lastBackup) ||
+		got.Status.LastBackupType != "full" {
+		t.Errorf(
+			"last backup fields changed: time=%v type=%q",
+			got.Status.LastBackupTime,
+			got.Status.LastBackupType,
+		)
+	}
+}
+
+func TestReconcilePostureClearsStaleUnknownReasonDuringDebounce(t *testing.T) {
 	store, poolerID := postureTestStore(t)
 	defer func() { _ = store.Close() }()
 
@@ -493,19 +614,34 @@ func TestReconcilePostureClearsUnavailableReasonDuringDebounce(t *testing.T) {
 			PostgresStatus: multipoolermanagerdatapb.PostgresStatus_POSTGRES_STATUS_PRIMARY,
 		},
 	})
-	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
+	for _, previousReason := range []string{
+		reasonPoolerClientUnavailable,
+		reasonAwaitingPoolerRegistration,
+	} {
+		t.Run(previousReason, func(t *testing.T) {
+			shard := postureTestShard()
+			shard.Status.Conditions = []metav1.Condition{{
+				Type:               posture.ConditionConsistent,
+				Status:             metav1.ConditionUnknown,
+				Reason:             previousReason,
+				Message:            "observation unavailable",
+				LastTransitionTime: metav1.Now(),
+			}}
+			r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
 
-	pending, err := r.reconcilePosture(t.Context(), store, shard, rpc)
-	if err != nil {
-		t.Fatalf("reconcilePosture() error = %v", err)
-	}
-	if !pending {
-		t.Fatal("first recovered unsettled observation did not request debounce requeue")
-	}
-	condition := findPostureCondition(shard.Status.Conditions, posture.ConditionConsistent)
-	if condition == nil || condition.Status != metav1.ConditionUnknown ||
-		condition.Reason != "ObservationPending" {
-		t.Errorf("condition = %#v, want Unknown/ObservationPending", condition)
+			retryAfter, err := r.reconcilePosture(t.Context(), store, shard, rpc)
+			if err != nil {
+				t.Fatalf("reconcilePosture() error = %v", err)
+			}
+			if retryAfter != postureDebounceRequeueDelay {
+				t.Fatal("first recovered unsettled observation did not request debounce requeue")
+			}
+			condition := findPostureCondition(shard.Status.Conditions, posture.ConditionConsistent)
+			if condition == nil || condition.Status != metav1.ConditionUnknown ||
+				condition.Reason != reasonObservationPending {
+				t.Errorf("condition = %#v, want Unknown/ObservationPending", condition)
+			}
+		})
 	}
 }
 
@@ -529,11 +665,11 @@ func TestReconcilePostureRequeuesWhileTopologyHasNoPoolers(t *testing.T) {
 
 	rpc := rpcclient.NewFakeClient()
 	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
-	pending, err := r.reconcilePosture(t.Context(), store, shard, rpc)
+	retryAfter, err := r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("reconcilePosture() error = %v", err)
 	}
-	if !pending {
+	if retryAfter != poolerRegistrationRetryDelay {
 		t.Fatal("empty topology did not request a bootstrap requeue")
 	}
 	condition := findPostureCondition(shard.Status.Conditions, posture.ConditionConsistent)
@@ -547,20 +683,20 @@ func TestWithDataPlaneRequeueUsesEarliestDelay(t *testing.T) {
 	tests := []struct {
 		name                    string
 		result                  ctrl.Result
-		posturePending          bool
+		postureRetryAfter       time.Duration
 		poolerClientUnavailable bool
 		want                    time.Duration
 	}{
 		{
 			name:                    "keeps earlier phase retry",
 			result:                  ctrl.Result{RequeueAfter: 2 * time.Second},
-			posturePending:          true,
+			postureRetryAfter:       postureDebounceRequeueDelay,
 			poolerClientUnavailable: true,
 			want:                    2 * time.Second,
 		},
 		{
 			name:                    "posture debounce wins",
-			posturePending:          true,
+			postureRetryAfter:       postureDebounceRequeueDelay,
 			poolerClientUnavailable: true,
 			want:                    postureDebounceRequeueDelay,
 		},
@@ -574,7 +710,7 @@ func TestWithDataPlaneRequeueUsesEarliestDelay(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := withDataPlaneRequeue(
 				tt.result,
-				tt.posturePending,
+				tt.postureRetryAfter,
 				tt.poolerClientUnavailable,
 			)
 			if result.RequeueAfter != tt.want {
@@ -605,6 +741,29 @@ func conditionIsFalse(conditions []metav1.Condition, conditionType string) bool 
 func conditionIsTrue(conditions []metav1.Condition, conditionType string) bool {
 	for _, condition := range conditions {
 		if condition.Type == conditionType && condition.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// drainEvents returns every event currently buffered in the fake recorder.
+func drainEvents(recorder *record.FakeRecorder) []string {
+	var events []string
+	for {
+		select {
+		case event := <-recorder.Events:
+			events = append(events, event)
+		default:
+			return events
+		}
+	}
+}
+
+// containsEventWithReason reports whether any event message mentions reason.
+func containsEventWithReason(events []string, reason string) bool {
+	for _, event := range events {
+		if strings.Contains(event, reason) {
 			return true
 		}
 	}

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane_posture_internal_test.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane_posture_internal_test.go
@@ -3,6 +3,7 @@ package shard
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,9 +23,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/data-handler/poolerclient"
 	"github.com/multigres/multigres-operator/pkg/data-handler/posture"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
+
+type countingPoolerResolver struct {
+	client rpcclient.MultipoolerClient
+	err    error
+	calls  int
+}
+
+func (r *countingPoolerResolver) ClientFor(
+	context.Context,
+	*multigresv1alpha1.Shard,
+) (rpcclient.MultipoolerClient, error) {
+	r.calls++
+	return r.client, r.err
+}
 
 func postureTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -79,7 +95,7 @@ func postureTestReconciler(
 		Client:          c,
 		Scheme:          scheme,
 		Recorder:        record.NewFakeRecorder(20),
-		RPCClient:       rpc,
+		PoolerClients:   poolerclient.Static(rpc),
 		CreateTopoStore: newMemoryTopoFactory(),
 	}, c
 }
@@ -192,16 +208,17 @@ func TestReconcilePostureDebouncesFirstInconsistency(t *testing.T) {
 	})
 	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
 
-	pending, err := r.reconcilePosture(t.Context(), store, shard)
+	pending, err := r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("first reconcilePosture() error = %v", err)
 	}
 	if !pending {
 		t.Error("first inconsistent posture observation did not request a requeue")
 	}
-	if got := withPostureRequeue(
+	if got := withDataPlaneRequeue(
 		ctrl.Result{},
 		pending,
+		false,
 	).RequeueAfter; got != postureDebounceRequeueDelay {
 		t.Errorf("first requeue delay = %v, want %v", got, postureDebounceRequeueDelay)
 	}
@@ -209,7 +226,7 @@ func TestReconcilePostureDebouncesFirstInconsistency(t *testing.T) {
 		t.Errorf("conditions = %#v, want no failure on first observation", shard.Status.Conditions)
 	}
 
-	pending, err = r.reconcilePosture(t.Context(), store, shard)
+	pending, err = r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("second reconcilePosture() error = %v", err)
 	}
@@ -240,16 +257,17 @@ func TestReconcilePostureDebouncesFirstIncompleteObservation(t *testing.T) {
 	rpc.Errors[poolerID] = errors.New("connection error: EOF")
 	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
 
-	pending, err := r.reconcilePosture(t.Context(), store, shard)
+	pending, err := r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("first reconcilePosture() error = %v", err)
 	}
 	if !pending {
 		t.Error("first incomplete posture observation did not request a requeue")
 	}
-	if got := withPostureRequeue(
+	if got := withDataPlaneRequeue(
 		ctrl.Result{},
 		pending,
+		false,
 	).RequeueAfter; got != postureDebounceRequeueDelay {
 		t.Errorf("first requeue delay = %v, want %v", got, postureDebounceRequeueDelay)
 	}
@@ -260,7 +278,7 @@ func TestReconcilePostureDebouncesFirstIncompleteObservation(t *testing.T) {
 		)
 	}
 
-	pending, err = r.reconcilePosture(t.Context(), store, shard)
+	pending, err = r.reconcilePosture(t.Context(), store, shard, rpc)
 	if err != nil {
 		t.Fatalf("second reconcilePosture() error = %v", err)
 	}
@@ -300,6 +318,8 @@ func TestReconcileDataPlaneRequeuesFirstPostureStrike(t *testing.T) {
 		ConfigLoadTime: timestamppb.Now(),
 	}
 	r, _ := postureTestReconciler(t, shard, rpc, pod)
+	resolver := &countingPoolerResolver{client: rpc}
+	r.PoolerClients = resolver
 	r.CreateTopoStore = func(*multigresv1alpha1.Shard) (topoclient.Store, error) {
 		return store, nil
 	}
@@ -317,16 +337,260 @@ func TestReconcileDataPlaneRequeuesFirstPostureStrike(t *testing.T) {
 	if !callLogHas(rpc.GetCallLog(), "ReloadConfig") {
 		t.Errorf("reload phase did not run, call log = %v", rpc.GetCallLog())
 	}
+	if resolver.calls != 1 {
+		t.Errorf("ClientFor calls = %d, want exactly 1 per reconcile", resolver.calls)
+	}
 }
 
-func TestWithPostureRequeueKeepsEarlierRequeue(t *testing.T) {
-	result := withPostureRequeue(
-		ctrl.Result{RequeueAfter: 2 * time.Second},
-		true,
-	)
-	if result.RequeueAfter != 2*time.Second {
-		t.Errorf("requeue delay = %v, want 2s", result.RequeueAfter)
+func TestReconcileDataPlaneContinuesWithoutPoolerClient(t *testing.T) {
+	shard := postureTestShard()
+	shard.Status.Conditions = []metav1.Condition{{
+		Type:               posture.ConditionConsistent,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Consistent",
+		Message:            "postures consistent with topology roles",
+		LastTransitionTime: metav1.Now(),
+	}}
+	store, _ := postureTestStore(t)
+	pod := postureTestPod()
+	pod.Labels[metadata.LabelAppComponent] = PoolComponentName
+	pod.Labels[metadata.LabelMultigresCell] = "cell1"
+	pod.Labels[metadata.LabelMultigresPool] = "default"
+
+	rpc := rpcclient.NewFakeClient()
+	r, c := postureTestReconciler(t, shard, nil, pod)
+	resolver := &countingPoolerResolver{
+		client: rpc,
+		err:    errors.New("certificate not issued"),
 	}
+	r.PoolerClients = resolver
+	r.CreateTopoStore = func(*multigresv1alpha1.Shard) (topoclient.Store, error) {
+		return store, nil
+	}
+
+	result, err := r.reconcileDataPlane(t.Context(), shard, renderedConfig{})
+	if err != nil {
+		t.Fatalf("reconcileDataPlane() error = %v", err)
+	}
+	if result.RequeueAfter != poolerClientRetryDelay {
+		t.Errorf("requeue delay = %v, want %v", result.RequeueAfter, poolerClientRetryDelay)
+	}
+	if resolver.calls != 1 {
+		t.Errorf("ClientFor calls = %d, want 1", resolver.calls)
+	}
+
+	got := &multigresv1alpha1.Shard{}
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get updated shard: %v", err)
+	}
+	if got.Status.PodRoles["pooler-0"] != "REPLICA" {
+		t.Errorf("podRoles = %v, want topology-derived pooler-0 REPLICA", got.Status.PodRoles)
+	}
+	if got.Status.Phase != multigresv1alpha1.PhaseProgressing {
+		t.Errorf("phase = %q, want %q", got.Status.Phase, multigresv1alpha1.PhaseProgressing)
+	}
+	postureCondition := findPostureCondition(
+		got.Status.Conditions,
+		posture.ConditionConsistent,
+	)
+	if postureCondition == nil {
+		t.Fatalf(
+			"conditions = %#v, want %s condition",
+			got.Status.Conditions,
+			posture.ConditionConsistent,
+		)
+	}
+	if postureCondition.Status != metav1.ConditionUnknown ||
+		postureCondition.Reason != "PoolerClientUnavailable" ||
+		!strings.Contains(postureCondition.Message, "certificate not issued") {
+		t.Errorf(
+			"condition = %#v, want Unknown/PoolerClientUnavailable with resolver error",
+			postureCondition,
+		)
+	}
+	if calls := rpc.GetCallLog(); len(calls) != 0 {
+		t.Errorf("RPC phases ran with resolver error, call log = %v", calls)
+	}
+
+	recorder := r.Recorder.(*record.FakeRecorder)
+	select {
+	case event := <-recorder.Events:
+		if !strings.Contains(event, "PoolerClientUnavailable") {
+			t.Errorf("event = %q, want PoolerClientUnavailable", event)
+		}
+	default:
+		t.Error("expected PoolerClientUnavailable event")
+	}
+}
+
+func TestReconcileDataPlaneResolverFailurePreservesConfirmedPostureFailure(t *testing.T) {
+	shard := postureTestShard()
+	shard.Status.Conditions = []metav1.Condition{{
+		Type:               posture.ConditionConsistent,
+		Status:             metav1.ConditionFalse,
+		Reason:             "MultiplePrimaries",
+		Message:            "observed two primaries",
+		LastTransitionTime: metav1.Now(),
+	}}
+	store, _ := postureTestStore(t)
+	pod := postureTestPod()
+	pod.Labels[metadata.LabelAppComponent] = PoolComponentName
+	pod.Labels[metadata.LabelMultigresCell] = "cell1"
+	pod.Labels[metadata.LabelMultigresPool] = "default"
+
+	r, c := postureTestReconciler(t, shard, nil, pod)
+	r.PoolerClients = &countingPoolerResolver{err: errors.New("certificate not issued")}
+	r.CreateTopoStore = func(*multigresv1alpha1.Shard) (topoclient.Store, error) {
+		return store, nil
+	}
+
+	// Simulate one unsettled observation immediately before the transport
+	// outage. Resolver failure must break that sequence.
+	if strikes := r.recordPostureObservation(shard, true); strikes != 1 {
+		t.Fatalf("initial strikes = %d, want 1", strikes)
+	}
+
+	result, err := r.reconcileDataPlane(t.Context(), shard, renderedConfig{})
+	if err != nil {
+		t.Fatalf("reconcileDataPlane() error = %v", err)
+	}
+	if result.RequeueAfter != poolerClientRetryDelay {
+		t.Errorf("requeue delay = %v, want %v", result.RequeueAfter, poolerClientRetryDelay)
+	}
+
+	got := &multigresv1alpha1.Shard{}
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(shard), got); err != nil {
+		t.Fatalf("get updated shard: %v", err)
+	}
+	condition := findPostureCondition(got.Status.Conditions, posture.ConditionConsistent)
+	if condition == nil || condition.Status != metav1.ConditionFalse ||
+		condition.Reason != "MultiplePrimaries" {
+		t.Errorf("condition = %#v, want preserved False/MultiplePrimaries", condition)
+	}
+	if got.Status.Phase != multigresv1alpha1.PhaseDegraded {
+		t.Errorf("phase = %q, want %q", got.Status.Phase, multigresv1alpha1.PhaseDegraded)
+	}
+	if strikes := r.recordPostureObservation(shard, true); strikes != 1 {
+		t.Errorf("first post-outage strikes = %d, want 1", strikes)
+	}
+}
+
+func TestReconcilePostureClearsUnavailableReasonDuringDebounce(t *testing.T) {
+	shard := postureTestShard()
+	shard.Status.Conditions = []metav1.Condition{{
+		Type:               posture.ConditionConsistent,
+		Status:             metav1.ConditionUnknown,
+		Reason:             "PoolerClientUnavailable",
+		Message:            "certificate not issued",
+		LastTransitionTime: metav1.Now(),
+	}}
+	store, poolerID := postureTestStore(t)
+	defer func() { _ = store.Close() }()
+
+	rpc := rpcclient.NewFakeClient()
+	rpc.SetStatusResponse(poolerID, &multipoolermanagerdatapb.StatusResponse{
+		Status: &multipoolermanagerdatapb.Status{
+			PostgresStatus: multipoolermanagerdatapb.PostgresStatus_POSTGRES_STATUS_PRIMARY,
+		},
+	})
+	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
+
+	pending, err := r.reconcilePosture(t.Context(), store, shard, rpc)
+	if err != nil {
+		t.Fatalf("reconcilePosture() error = %v", err)
+	}
+	if !pending {
+		t.Fatal("first recovered unsettled observation did not request debounce requeue")
+	}
+	condition := findPostureCondition(shard.Status.Conditions, posture.ConditionConsistent)
+	if condition == nil || condition.Status != metav1.ConditionUnknown ||
+		condition.Reason != "ObservationPending" {
+		t.Errorf("condition = %#v, want Unknown/ObservationPending", condition)
+	}
+}
+
+func TestReconcilePostureRequeuesWhileTopologyHasNoPoolers(t *testing.T) {
+	shard := postureTestShard()
+	shard.Status.Conditions = []metav1.Condition{{
+		Type:               posture.ConditionConsistent,
+		Status:             metav1.ConditionUnknown,
+		Reason:             "PoolerClientUnavailable",
+		Message:            "certificate not issued",
+		LastTransitionTime: metav1.Now(),
+	}}
+	_, factory := memorytopo.NewServerAndFactory(t.Context(), "cell1")
+	store := topoclient.NewWithFactory(
+		factory,
+		"",
+		[]string{""},
+		topoclient.NewDefaultTopoConfig(),
+	)
+	defer func() { _ = store.Close() }()
+
+	rpc := rpcclient.NewFakeClient()
+	r, _ := postureTestReconciler(t, shard, rpc, postureTestPod())
+	pending, err := r.reconcilePosture(t.Context(), store, shard, rpc)
+	if err != nil {
+		t.Fatalf("reconcilePosture() error = %v", err)
+	}
+	if !pending {
+		t.Fatal("empty topology did not request a bootstrap requeue")
+	}
+	condition := findPostureCondition(shard.Status.Conditions, posture.ConditionConsistent)
+	if condition == nil || condition.Status != metav1.ConditionUnknown ||
+		condition.Reason != "AwaitingPoolerRegistration" {
+		t.Errorf("condition = %#v, want Unknown/AwaitingPoolerRegistration", condition)
+	}
+}
+
+func TestWithDataPlaneRequeueUsesEarliestDelay(t *testing.T) {
+	tests := []struct {
+		name                    string
+		result                  ctrl.Result
+		posturePending          bool
+		poolerClientUnavailable bool
+		want                    time.Duration
+	}{
+		{
+			name:                    "keeps earlier phase retry",
+			result:                  ctrl.Result{RequeueAfter: 2 * time.Second},
+			posturePending:          true,
+			poolerClientUnavailable: true,
+			want:                    2 * time.Second,
+		},
+		{
+			name:                    "posture debounce wins",
+			posturePending:          true,
+			poolerClientUnavailable: true,
+			want:                    postureDebounceRequeueDelay,
+		},
+		{
+			name:                    "pooler client retry",
+			poolerClientUnavailable: true,
+			want:                    poolerClientRetryDelay,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := withDataPlaneRequeue(
+				tt.result,
+				tt.posturePending,
+				tt.poolerClientUnavailable,
+			)
+			if result.RequeueAfter != tt.want {
+				t.Errorf("requeue delay = %v, want %v", result.RequeueAfter, tt.want)
+			}
+		})
+	}
+}
+
+func findPostureCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
 }
 
 func conditionIsFalse(conditions []metav1.Condition, conditionType string) bool {

--- a/pkg/resource-handler/controller/shard/reload.go
+++ b/pkg/resource-handler/controller/shard/reload.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/multigres/multigres/go/common/rpcclient"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,11 +49,12 @@ func (r *ShardReconciler) reconcileReloadState(
 	store topoclient.Store,
 	shard *multigresv1alpha1.Shard,
 	rendered renderedConfig,
+	rpcClient rpcclient.MultipoolerClient,
 ) (time.Duration, error) {
 	logger := log.FromContext(ctx)
 
 	desired := rendered.reloadHash
-	if desired == "" || rendered.err != nil || r.RPCClient == nil {
+	if desired == "" || rendered.err != nil || rpcClient == nil {
 		return 0, nil
 	}
 
@@ -91,7 +93,6 @@ func (r *ShardReconciler) reconcileReloadState(
 	requeue := time.Duration(0)
 	var stale, reloaded, skippedRestart, notSynced, needsRestart int
 
-	var err error
 	for i := range podList.Items {
 		pod := &podList.Items[i]
 		podReload := pod.Annotations[metadata.AnnotationPostgresReloadHash]
@@ -116,6 +117,7 @@ func (r *ShardReconciler) reconcileReloadState(
 		cellName := pod.Labels[metadata.LabelMultigresCell]
 		poolers, ok := poolersByCell[cellName]
 		if !ok {
+			var err error
 			poolers, err = store.GetMultipoolersByCell(ctx, cellName, topo.ShardFilter(shard))
 			if err != nil {
 				if topo.IsTopoUnavailable(err) {
@@ -139,7 +141,7 @@ func (r *ShardReconciler) reconcileReloadState(
 			continue
 		}
 
-		resp, rerr := r.RPCClient.ReloadConfig(ctx, pooler.Multipooler, req)
+		resp, rerr := rpcClient.ReloadConfig(ctx, pooler.Multipooler, req)
 		if rerr != nil {
 			logger.Error(rerr, "ReloadConfig RPC failed", "pod", pod.Name)
 			requeue = reloadRetryDelay

--- a/pkg/resource-handler/controller/shard/reload_internal_test.go
+++ b/pkg/resource-handler/controller/shard/reload_internal_test.go
@@ -124,10 +124,9 @@ func newReloadReconciler(
 ) *ShardReconciler {
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 	return &ShardReconciler{
-		Client:    c,
-		Scheme:    scheme,
-		Recorder:  record.NewFakeRecorder(20),
-		RPCClient: rpc,
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(20),
 	}
 }
 
@@ -169,7 +168,13 @@ func TestReconcileReloadStateStampsWhenVerified(t *testing.T) {
 	pod := reloadTestPodObj("R1", reloadTestRestart, nil) // stale reload-hash, current restart-hash
 	r := newReloadReconciler(scheme, rpc, shard, pod)
 
-	wait, err := r.reconcileReloadState(context.Background(), store, shard, reloadTestRendered())
+	wait, err := r.reconcileReloadState(
+		context.Background(),
+		store,
+		shard,
+		reloadTestRendered(),
+		rpc,
+	)
 	if err != nil {
 		t.Fatalf("reconcileReloadState: %v", err)
 	}
@@ -206,7 +211,13 @@ func TestReconcileReloadStateNotSyncedRetries(t *testing.T) {
 	pod := reloadTestPodObj("R1", reloadTestRestart, nil)
 	r := newReloadReconciler(scheme, rpc, shard, pod)
 
-	wait, err := r.reconcileReloadState(context.Background(), store, shard, reloadTestRendered())
+	wait, err := r.reconcileReloadState(
+		context.Background(),
+		store,
+		shard,
+		reloadTestRendered(),
+		rpc,
+	)
 	if err != nil {
 		t.Fatalf("reconcileReloadState: %v", err)
 	}
@@ -237,7 +248,13 @@ func TestReconcileReloadStateNeedsRestart(t *testing.T) {
 	pod := reloadTestPodObj("R1", reloadTestRestart, nil)
 	r := newReloadReconciler(scheme, rpc, shard, pod)
 
-	wait, err := r.reconcileReloadState(context.Background(), store, shard, reloadTestRendered())
+	wait, err := r.reconcileReloadState(
+		context.Background(),
+		store,
+		shard,
+		reloadTestRendered(),
+		rpc,
+	)
 	if err != nil {
 		t.Fatalf("reconcileReloadState: %v", err)
 	}
@@ -287,6 +304,7 @@ func TestReconcileReloadStateSkips(t *testing.T) {
 				store,
 				shard,
 				reloadTestRendered(),
+				rpc,
 			); err != nil {
 				t.Fatalf("reconcileReloadState: %v", err)
 			}

--- a/pkg/resource-handler/controller/shard/shard_controller.go
+++ b/pkg/resource-handler/controller/shard/shard_controller.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/multigres/multigres/go/common/rpcclient"
 	"github.com/multigres/multigres/go/common/topoclient"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/data-handler/poolerclient"
 	"github.com/multigres/multigres-operator/pkg/monitoring"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	pvcutil "github.com/multigres/multigres-operator/pkg/util/pvc"
@@ -71,7 +71,7 @@ type ShardReconciler struct {
 	// label, so we need APIReader to validate user-provided pgBackRest TLS Secrets
 	// and external postgres password Secrets.
 	APIReader       client.Reader
-	RPCClient       rpcclient.MultipoolerClient
+	PoolerClients   poolerclient.Resolver
 	CreateTopoStore func(*multigresv1alpha1.Shard) (topoclient.Store, error)
 
 	postureStrikesMu sync.Mutex

--- a/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
+++ b/pkg/resource-handler/controller/shard/shard_controller_internal_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/data-handler/posture"
 	"github.com/multigres/multigres-operator/pkg/testutil"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 	"github.com/multigres/multigres-operator/pkg/util/name"
@@ -4796,7 +4797,6 @@ func TestUpdateStatus_HealthyPhase(t *testing.T) {
 			Phase: multigresv1alpha1.PhaseProgressing,
 		},
 	}
-
 	labels := buildPoolLabelsWithCell(shard, "primary", "zone1")
 	podName := BuildPoolPodName(shard, "primary", "zone1", 0)
 	pod := &corev1.Pod{
@@ -5145,6 +5145,11 @@ func TestUpdatePoolsStatus_DegradedOnCrashLoop(t *testing.T) {
 			},
 		},
 	}
+	shard.Status.Conditions = []metav1.Condition{{
+		Type:   posture.ConditionConsistent,
+		Status: metav1.ConditionUnknown,
+		Reason: "PoolerClientUnavailable",
+	}}
 
 	labels := buildPoolLabelsWithCell(shard, "primary", "zone1")
 	podName := BuildPoolPodName(shard, "primary", "zone1", 0)

--- a/pkg/resource-handler/controller/shard/status.go
+++ b/pkg/resource-handler/controller/shard/status.go
@@ -73,9 +73,6 @@ func (r *ShardReconciler) updateStatus(
 	case status.IsConditionFalse(shard.Status.Conditions, posture.ConditionConsistent):
 		shard.Status.Phase = multigresv1alpha1.PhaseDegraded
 		shard.Status.Message = "Postgres posture inconsistent with topology roles (possible split brain)"
-	case postureCondition != nil && postureCondition.Status == metav1.ConditionUnknown:
-		shard.Status.Phase = multigresv1alpha1.PhaseProgressing
-		shard.Status.Message = "Postgres posture check incomplete"
 	case pools.poolDegraded || orchDegraded:
 		shard.Status.Phase = multigresv1alpha1.PhaseDegraded
 		if pools.poolDegraded {
@@ -83,6 +80,9 @@ func (r *ShardReconciler) updateStatus(
 		} else {
 			shard.Status.Message = "One or more Multiorch pods are crash-looping"
 		}
+	case postureCondition != nil && postureCondition.Status == metav1.ConditionUnknown:
+		shard.Status.Phase = multigresv1alpha1.PhaseProgressing
+		shard.Status.Message = "Postgres posture check incomplete"
 	case shard.Status.PoolsReady && shard.Status.OrchReady:
 		shard.Status.Phase = multigresv1alpha1.PhaseHealthy
 		shard.Status.Message = "Ready"


### PR DESCRIPTION
## Summary

Fix operator-to-multipooler RPCs for clusters with `spec.internalTLS.enabled: true`.

The operator now uses a cluster-specific mTLS client when calling `Status`, `GetBackups`, and `ReloadConfig`. Clusters without internal TLS continue using the existing insecure client.

## Root cause

`InternalTLS` clusters configure multipooler as an mTLS gRPC server. However, the shard controller continued using a client configured with `insecure.NewCredentials()`.

Multipooler therefore rejected every operator RPC with a connection reset. This prevented the operator from observing pooler posture and backup state or applying reload-safe configuration changes. Posture remained unknown, `PostureConsistent` became `Unknown`, and affected shards remained `Progressing`.

The posture debounce remains useful for transient observation failures, but it cannot recover from a permanently incompatible transport.

## Solution

The `MultigresCluster` certificate controller now creates a dedicated operator client certificate for every internal-TLS cluster.

The certificate:

- Is owned by the `MultigresCluster` and follows its lifecycle.
- Uses the same resolved issuer as the cluster's server certificates.
- Is issued for client authentication only.
- Is stored in the cluster namespace.

The new `poolerclient.Resolver`:

- Returns the existing insecure client when internal TLS is disabled.
- Derives the owning cluster from the shard labels.
- Reads the cluster-owned operator certificate Secret directly.
- Caches one TLS `MultipoolerClient` per cluster.
- Verifies the exact server identity: `multipooler.<cluster>.<namespace>.multigres.internal`.
- Uses standard certificate-chain, hostname, and server-auth verification.
- Re-reads the Secret periodically and rebuilds the client only when its `ResourceVersion` changes.
- Keeps the last working client if a refresh encounters a transient API failure or temporarily malformed rotated Secret.
- Retains replaced clients briefly so in-flight reconciliations can complete.
- Allows concurrent reconciliations to continue using the current client while a refresh is in progress.

This removes the need for runtime Certificate creation, issuer-specific certificate names, a separate issuer flag, and a `MultigresCluster` API lookup during every resolution.

## Failure behavior

If the client certificate has not been issued yet, the shard controller:

- Skips multipooler RPC phases.
- Publishes topology-derived pod roles.
- Sets `PostureConsistent=Unknown` with reason `PoolerClientUnavailable`.
- Keeps the shard in `Progressing`.
- Emits a `PoolerClientUnavailable` warning event.
- Requeues after 10 seconds without controller error backoff.

The existing Healthy/no-primary safety guard remains unchanged.

## Security

TLS verification is bound to the shard's exact cluster and namespace. A certificate for another cluster, even when signed by the same issuer, is rejected.

The operator client certificate is cluster-owned, so deletion or certificate reconciliation cleans it up together with the other cluster certificates.

