### PR TITLE
feat(toposerver): require a client certificate on the topology server

### DIFF
--- a/api/v1alpha1/multigrescluster_types.go
+++ b/api/v1alpha1/multigrescluster_types.go
@@ -50,6 +50,15 @@ import (
 // ============================================================================
 
 // MultigresClusterSpec defines the desired state of MultigresCluster.
+//
+// topoTLS is immutable after creation. Enabling it switches the etcd client and
+// peer listeners to TLS, and changing the issuer rotates the CA every certificate
+// chains to. etcd cannot serve plaintext and TLS on one port, its persisted peer
+// membership is not rewritten by a restart, and the topology clients load their
+// certificate at process start, so neither the enablement nor the issuer can be
+// changed on a running cluster without a coordinated migration. Both are fixed at
+// creation.
+// +kubebuilder:validation:XValidation:rule="has(self.topoTLS) == has(oldSelf.topoTLS) && (!has(self.topoTLS) || self.topoTLS == oldSelf.topoTLS)",message="topoTLS is immutable and can only be set when the cluster is created"
 type MultigresClusterSpec struct {
 	// Images defines the container images for all components in the cluster.
 	// +optional

--- a/api/v1alpha1/topo_client_tls_helpers.go
+++ b/api/v1alpha1/topo_client_tls_helpers.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import corev1 "k8s.io/api/core/v1"
+
+const (
+	// TopoClientTLSVolumeName is the volume that carries the certificate a
+	// component presents to the topology server, along with the CA bundle
+	// that verifies the server.
+	TopoClientTLSVolumeName = "topo-client-tls"
+
+	// TopoClientTLSMountPath is where that volume is mounted. It is separate
+	// from the internal component mTLS mount so a component that speaks both
+	// never has one credential shadow the other.
+	TopoClientTLSMountPath = "/etc/multigres/topo-client-tls"
+
+	// TopoClientTLSCertFile is the client certificate presented to the
+	// topology server.
+	TopoClientTLSCertFile = TopoClientTLSMountPath + "/tls.crt"
+
+	// TopoClientTLSKeyFile is the private key for the client certificate.
+	TopoClientTLSKeyFile = TopoClientTLSMountPath + "/tls.key"
+
+	// TopoClientTLSCAFile is the CA bundle that verifies the topology
+	// server's certificate.
+	TopoClientTLSCAFile = TopoClientTLSMountPath + "/ca.crt"
+)
+
+// TopoClientTLSConfigured reports whether the reference carries both the client
+// credential and the CA bundle needed to open a TLS connection to the topology
+// server. The two are populated together, so either one alone is treated as no
+// TLS material.
+func TopoClientTLSConfigured(ref GlobalTopoServerRef) bool {
+	return ref.ClientCertSecret != "" && ref.CASecret != ""
+}
+
+// BuildTopoClientTLSVolume projects the client keypair and the CA bundle into a
+// single volume. The keypair comes from ClientCertSecret and the CA from
+// CASecret; for a managed topology server both name the same cert-manager
+// Secret, while an external topology server may split them across two. Both
+// Secrets follow the cert-manager key layout of tls.crt, tls.key and ca.crt.
+func BuildTopoClientTLSVolume(ref GlobalTopoServerRef) corev1.Volume {
+	defaultMode := int32(0o444)
+	return corev1.Volume{
+		Name: TopoClientTLSVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				DefaultMode: &defaultMode,
+				Sources: []corev1.VolumeProjection{
+					{
+						Secret: &corev1.SecretProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: ref.ClientCertSecret,
+							},
+							Items: []corev1.KeyToPath{
+								{Key: "tls.crt", Path: "tls.crt"},
+								{Key: "tls.key", Path: "tls.key"},
+							},
+						},
+					},
+					{
+						Secret: &corev1.SecretProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: ref.CASecret,
+							},
+							Items: []corev1.KeyToPath{
+								{Key: "ca.crt", Path: "ca.crt"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TopoClientTLSVolumeMount mounts the topo client credential read-only. It is
+// mounted only into the containers that open a topology connection, never into
+// a container that shares the postgres data volume or socket directory.
+func TopoClientTLSVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      TopoClientTLSVolumeName,
+		MountPath: TopoClientTLSMountPath,
+		ReadOnly:  true,
+	}
+}
+
+// TopoClientTLSArgs returns the flags that point a component's etcd topology
+// client at the mounted credential. Presenting the certificate is harmless
+// against a server that does not require it and mandatory against one that
+// does.
+func TopoClientTLSArgs() []string {
+	return []string{
+		"--topo-etcd-tls-cert", TopoClientTLSCertFile,
+		"--topo-etcd-tls-key", TopoClientTLSKeyFile,
+		"--topo-etcd-tls-ca", TopoClientTLSCAFile,
+	}
+}

--- a/api/v1alpha1/topo_client_tls_helpers_test.go
+++ b/api/v1alpha1/topo_client_tls_helpers_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "testing"
+
+func TestTopoClientTLSConfigured(t *testing.T) {
+	tests := map[string]struct {
+		ref  GlobalTopoServerRef
+		want bool
+	}{
+		"both secrets set": {
+			ref:  GlobalTopoServerRef{CASecret: "ca", ClientCertSecret: "client"},
+			want: true,
+		},
+		"neither set":     {ref: GlobalTopoServerRef{}, want: false},
+		"only ca set":     {ref: GlobalTopoServerRef{CASecret: "ca"}, want: false},
+		"only client set": {ref: GlobalTopoServerRef{ClientCertSecret: "client"}, want: false},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := TopoClientTLSConfigured(tc.ref); got != tc.want {
+				t.Errorf("TopoClientTLSConfigured() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A managed topology names one Secret for both the keypair and the CA; an
+// external topology may split them. The projection has to read the keypair from
+// ClientCertSecret and the CA from CASecret in either case.
+func TestBuildTopoClientTLSVolume_ProjectsFromBothSecrets(t *testing.T) {
+	ref := GlobalTopoServerRef{CASecret: "the-ca", ClientCertSecret: "the-client"}
+	vol := BuildTopoClientTLSVolume(ref)
+
+	if vol.Name != TopoClientTLSVolumeName {
+		t.Errorf("volume name = %q, want %q", vol.Name, TopoClientTLSVolumeName)
+	}
+	if vol.Projected == nil {
+		t.Fatal("expected a projected volume source")
+	}
+	sources := vol.Projected.Sources
+	if len(sources) != 2 {
+		t.Fatalf("got %d projection sources, want 2", len(sources))
+	}
+
+	keypair := sources[0].Secret
+	if keypair == nil || keypair.Name != "the-client" {
+		t.Fatalf("keypair source = %+v, want secret the-client", keypair)
+	}
+	wantKeypairKeys := map[string]string{"tls.crt": "tls.crt", "tls.key": "tls.key"}
+	gotKeypairKeys := map[string]string{}
+	for _, item := range keypair.Items {
+		gotKeypairKeys[item.Key] = item.Path
+	}
+	for k, v := range wantKeypairKeys {
+		if gotKeypairKeys[k] != v {
+			t.Errorf("keypair projects %q to %q, want %q", k, gotKeypairKeys[k], v)
+		}
+	}
+
+	ca := sources[1].Secret
+	if ca == nil || ca.Name != "the-ca" {
+		t.Fatalf("ca source = %+v, want secret the-ca", ca)
+	}
+	if len(ca.Items) != 1 || ca.Items[0].Key != "ca.crt" || ca.Items[0].Path != "ca.crt" {
+		t.Errorf("ca projection = %+v, want ca.crt to ca.crt", ca.Items)
+	}
+}
+
+func TestTopoClientTLSArgs(t *testing.T) {
+	args := TopoClientTLSArgs()
+	want := []string{
+		"--topo-etcd-tls-cert", TopoClientTLSCertFile,
+		"--topo-etcd-tls-key", TopoClientTLSKeyFile,
+		"--topo-etcd-tls-ca", TopoClientTLSCAFile,
+	}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}

--- a/cmd/multigres-operator/main.go
+++ b/cmd/multigres-operator/main.go
@@ -450,10 +450,11 @@ func main() {
 	)
 
 	if err = (&multigresclustercontroller.MultigresClusterReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("multigrescluster-controller"),
-		Images:   imagesConfig,
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("multigrescluster-controller"),
+		Images:    imagesConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MultigresCluster")
 		os.Exit(1)

--- a/config/crd/bases/multigres.com_multigresclusters.yaml
+++ b/config/crd/bases/multigres.com_multigresclusters.yaml
@@ -54,7 +54,16 @@ spec:
           metadata:
             type: object
           spec:
-            description: MultigresClusterSpec defines the desired state of MultigresCluster.
+            description: |-
+              MultigresClusterSpec defines the desired state of MultigresCluster.
+
+              topoTLS is immutable after creation. Enabling it switches the etcd client and
+              peer listeners to TLS, and changing the issuer rotates the CA every certificate
+              chains to. etcd cannot serve plaintext and TLS on one port, its persisted peer
+              membership is not rewritten by a restart, and the topology clients load their
+              certificate at process start, so neither the enablement nor the issuer can be
+              changed on a running cluster without a coordinated migration. Both are fixed at
+              creation.
             properties:
               backup:
                 description: Backup configures the default backup settings for the
@@ -12214,6 +12223,11 @@ spec:
             required:
             - postgresPasswordSecretRef
             type: object
+            x-kubernetes-validations:
+            - message: topoTLS is immutable and can only be set when the cluster is
+                created
+              rule: has(self.topoTLS) == has(oldSelf.topoTLS) && (!has(self.topoTLS)
+                || self.topoTLS == oldSelf.topoTLS)
           status:
             description: MultigresClusterStatus defines the observed state.
             properties:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.6
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
-	github.com/multigres/multigres v0.0.0-20260903184453-a5aeb4ba5752
+	github.com/multigres/multigres v0.0.0-20260904153201-6f6a784616ea
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/multigres/multigres v0.0.0-20260903184453-a5aeb4ba5752 h1:KP7Elq6DWhvxDoxUCWmS9lpsa8mX78GCS9PSwvbksy0=
-github.com/multigres/multigres v0.0.0-20260903184453-a5aeb4ba5752/go.mod h1:B8zkdsvFfa+ytjvoecXIUlD+1bFpcYtKC5QgN3nVpJk=
+github.com/multigres/multigres v0.0.0-20260904153201-6f6a784616ea h1:qAmABEvAkikYNl24et9KH/2ci48NcB5fOZtzkPth8dc=
+github.com/multigres/multigres v0.0.0-20260904153201-6f6a784616ea/go.mod h1:B8zkdsvFfa+ytjvoecXIUlD+1bFpcYtKC5QgN3nVpJk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=

--- a/pkg/cluster-handler/controller/multigrescluster/builders_global.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global.go
@@ -250,6 +250,22 @@ func BuildMultiadminDeployment(
 		)
 	}
 
+	if multigresv1alpha1.TopoClientTLSConfigured(globalTopo) {
+		podSpec := &deploy.Spec.Template.Spec
+		podSpec.Volumes = append(
+			podSpec.Volumes,
+			multigresv1alpha1.BuildTopoClientTLSVolume(globalTopo),
+		)
+		podSpec.Containers[0].VolumeMounts = append(
+			podSpec.Containers[0].VolumeMounts,
+			multigresv1alpha1.TopoClientTLSVolumeMount(),
+		)
+		podSpec.Containers[0].Args = append(
+			podSpec.Containers[0].Args,
+			multigresv1alpha1.TopoClientTLSArgs()...,
+		)
+	}
+
 	if err := controllerutil.SetControllerReference(cluster, deploy, scheme); err != nil {
 		return nil, err
 	}

--- a/pkg/cluster-handler/controller/multigrescluster/builders_global_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/builders_global_test.go
@@ -1003,3 +1003,92 @@ func TestBuildAdminNetworkPolicies(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestBuildMultiadminDeployment_TopoClientTLS(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-cluster",
+			Namespace: "default",
+			UID:       "cluster-uid",
+		},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			Images: multigresv1alpha1.ClusterImages{Multiadmin: "multiadmin:latest"},
+		},
+	}
+	spec := &multigresv1alpha1.StatelessSpec{Replicas: ptr.To(int32(1))}
+
+	t.Run("presents the client certificate when the reference carries it", func(t *testing.T) {
+		secret := multigresv1alpha1.TopoClientCertSecretName("my-cluster")
+		globalTopo := multigresv1alpha1.GlobalTopoServerRef{
+			Address:          "my-cluster-global-topo.default.svc:2379",
+			RootPath:         "/multigres/global",
+			CASecret:         secret,
+			ClientCertSecret: secret,
+		}
+		got, err := BuildMultiadminDeployment(cluster, spec, nil, globalTopo, scheme)
+		if err != nil {
+			t.Fatalf("BuildMultiadminDeployment() error = %v", err)
+		}
+		c := got.Spec.Template.Spec.Containers[0]
+		if !hasArgValue(c.Args, "--topo-etcd-tls-cert", multigresv1alpha1.TopoClientTLSCertFile) {
+			t.Errorf("missing --topo-etcd-tls-cert flag: %v", c.Args)
+		}
+		if !containerMountsVolume(c, multigresv1alpha1.TopoClientTLSVolumeName) {
+			t.Error("multiadmin does not mount the topo client certificate")
+		}
+		volumes := got.Spec.Template.Spec.Volumes
+		if !podHasVolume(volumes, multigresv1alpha1.TopoClientTLSVolumeName) {
+			t.Error("topo client volume missing from pod spec")
+		}
+	})
+
+	t.Run("renders unchanged when the reference carries no credential", func(t *testing.T) {
+		globalTopo := multigresv1alpha1.GlobalTopoServerRef{
+			Address:  "my-cluster-global-topo.default.svc:2379",
+			RootPath: "/multigres/global",
+		}
+		got, err := BuildMultiadminDeployment(cluster, spec, nil, globalTopo, scheme)
+		if err != nil {
+			t.Fatalf("BuildMultiadminDeployment() error = %v", err)
+		}
+		c := got.Spec.Template.Spec.Containers[0]
+		for _, a := range c.Args {
+			if a == "--topo-etcd-tls-cert" {
+				t.Error("topo TLS flag present with no credential on the reference")
+			}
+		}
+		if podHasVolume(got.Spec.Template.Spec.Volumes, multigresv1alpha1.TopoClientTLSVolumeName) {
+			t.Error("topo client volume present with no credential on the reference")
+		}
+	})
+}
+
+func hasArgValue(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func containerMountsVolume(c corev1.Container, name string) bool {
+	for _, m := range c.VolumeMounts {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func podHasVolume(vols []corev1.Volume, name string) bool {
+	for _, v := range vols {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cluster-handler/controller/multigrescluster/certificate.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/resolver"
 	"github.com/multigres/multigres-operator/pkg/topology"
 	"github.com/multigres/multigres-operator/pkg/util/certs"
 )
@@ -171,6 +172,23 @@ func buildTopoClientCertificate(
 	})
 }
 
+// topologyIsManaged reports whether the cluster's resolved global topology is a
+// managed etcd server the operator runs and issues a serving certificate for,
+// as opposed to an external topology server the user operates.
+func (r *MultigresClusterReconciler) topologyIsManaged(
+	ctx context.Context,
+	cluster *multigresv1alpha1.MultigresCluster,
+) (bool, error) {
+	res := resolver.NewResolver(r.Client, cluster.Namespace)
+	spec, err := res.ResolveGlobalTopo(ctx, cluster)
+	if err != nil {
+		return false, fmt.Errorf(
+			"failed to resolve global topology for client certificate: %w", err,
+		)
+	}
+	return spec.Etcd != nil, nil
+}
+
 // issuerName returns the cluster's configured cert-manager ClusterIssuer
 // name, defaulting to CertIssuerName when unset.
 func issuerName(cluster *multigresv1alpha1.MultigresCluster) string {
@@ -226,13 +244,24 @@ func (r *MultigresClusterReconciler) reconcileCertificate(
 		desiredCerts = append(desiredCerts, internalCerts...)
 	}
 	if cluster.Spec.TopoTLS.IsEnabled() {
-		topoClientCert, err := buildTopoClientCertificate(cluster, r.Scheme)
+		managed, err := r.topologyIsManaged(ctx, cluster)
 		if err != nil {
-			return fmt.Errorf(
-				"failed to build topology client cert-manager Certificate: %w", err,
-			)
+			return err
 		}
-		desiredCerts = append(desiredCerts, topoClientCert)
+		// An external topology server brings its own CA and client Secrets, so a
+		// credential issued from the cluster's own issuer would never be trusted
+		// and would sit unused. Only a managed etcd topology, whose serving
+		// certificate the operator issues from the same CA, gets a client
+		// credential.
+		if managed {
+			topoClientCert, err := buildTopoClientCertificate(cluster, r.Scheme)
+			if err != nil {
+				return fmt.Errorf(
+					"failed to build topology client cert-manager Certificate: %w", err,
+				)
+			}
+			desiredCerts = append(desiredCerts, topoClientCert)
+		}
 	}
 	if cluster.Spec.CertCommonName != "" {
 		publicCert, err := buildCertificate(cluster, r.Scheme)

--- a/pkg/cluster-handler/controller/multigrescluster/certificate_topo_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate_topo_test.go
@@ -224,6 +224,35 @@ func TestReconcileCertificateTopoTLS(t *testing.T) {
 		}
 	})
 
+	t.Run("issues nothing when the topology server is external", func(t *testing.T) {
+		scheme := setupScheme()
+		cluster := topoTLSCluster("test-cluster", "supabase", nil)
+		// An external topology server brings its own CA and client Secrets, so
+		// the operator does not issue a credential from the cluster's issuer.
+		cluster.Spec.GlobalTopoServer = &multigresv1alpha1.GlobalTopoServerSpec{
+			External: &multigresv1alpha1.ExternalTopoServerSpec{
+				Endpoints: []multigresv1alpha1.EndpointUrl{"https://etcd.example.com:2379"},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+		r := &MultigresClusterReconciler{
+			Client:   c,
+			Scheme:   scheme,
+			Recorder: record.NewFakeRecorder(10),
+		}
+
+		if err := r.reconcileCertificate(context.Background(), cluster); err != nil {
+			t.Fatalf("reconcileCertificate() error = %v", err)
+		}
+
+		got := &unstructured.Unstructured{}
+		got.SetGroupVersionKind(certGVK)
+		key := client.ObjectKey{Namespace: "supabase", Name: certName}
+		if err := c.Get(context.Background(), key, got); err == nil {
+			t.Fatal("expected no topology client Certificate for an external topology server")
+		}
+	})
+
 	t.Run("issues nothing when topology TLS is unset", func(t *testing.T) {
 		scheme := setupScheme()
 		cluster := topoTLSCluster("test-cluster", "supabase", nil)

--- a/pkg/cluster-handler/controller/multigrescluster/integration_validation_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/integration_validation_test.go
@@ -135,4 +135,55 @@ func TestMultigresCluster_Validation(t *testing.T) {
 			t.Fatalf("Expected cluster with topology TLS disabled to be accepted, got: %v", err)
 		}
 	})
+
+	// Enablement is fixed at creation: flipping it on a running cluster cannot be
+	// rolled out safely, so the API rejects the transition.
+	t.Run("Enabling Topology TLS After Creation (Should Fail)", func(t *testing.T) {
+		t.Parallel()
+		k8sClient, _ := setupIntegration(t)
+		cluster := &multigresv1alpha1.MultigresCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "mutate-topo-tls", Namespace: testNamespace},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				TopoTLS: &multigresv1alpha1.TopoTLSConfig{Enabled: ptr.To(false)},
+			},
+		}
+		setTestPostgresPasswordSecretRef(cluster)
+		if err := k8sClient.Create(t.Context(), cluster); err != nil {
+			t.Fatalf("Expected initial cluster to be accepted, got: %v", err)
+		}
+
+		cluster.Spec.TopoTLS = &multigresv1alpha1.TopoTLSConfig{
+			Enabled:    ptr.To(true),
+			IssuerName: "multigres-infra-issuer",
+		}
+		if err := k8sClient.Update(t.Context(), cluster); err == nil {
+			t.Fatal("Expected enabling topology TLS after creation to be rejected")
+		}
+	})
+
+	// Rotating the issuer rotates the CA every certificate chains to, which the
+	// running clients cannot follow, so changing it after creation is rejected
+	// too.
+	t.Run("Changing Topology TLS Issuer After Creation (Should Fail)", func(t *testing.T) {
+		t.Parallel()
+		k8sClient, _ := setupIntegration(t)
+		cluster := &multigresv1alpha1.MultigresCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "rotate-topo-issuer", Namespace: testNamespace},
+			Spec: multigresv1alpha1.MultigresClusterSpec{
+				TopoTLS: &multigresv1alpha1.TopoTLSConfig{
+					Enabled:    ptr.To(true),
+					IssuerName: "issuer-a",
+				},
+			},
+		}
+		setTestPostgresPasswordSecretRef(cluster)
+		if err := k8sClient.Create(t.Context(), cluster); err != nil {
+			t.Fatalf("Expected initial cluster to be accepted, got: %v", err)
+		}
+
+		cluster.Spec.TopoTLS.IssuerName = "issuer-b"
+		if err := k8sClient.Update(t.Context(), cluster); err == nil {
+			t.Fatal("Expected changing the topology TLS issuer after creation to be rejected")
+		}
+	})
 }

--- a/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
+++ b/pkg/cluster-handler/controller/multigrescluster/multigrescluster_controller.go
@@ -38,6 +38,12 @@ type MultigresClusterReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 
+	// APIReader is an uncached client that reads directly from the API server.
+	// The cached client only sees tenant-namespace Secrets carrying the
+	// operator's managed-by label, so cert-manager and user-provided topology
+	// Secrets have to be read through this.
+	APIReader client.Reader
+
 	// Images is the operator's default component image set and update
 	// strategy. The zero value falls back to the compiled-in defaults with
 	// the immediate strategy.

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/multigres/multigres/go/common/topoclient"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,13 +86,18 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 		}
 	}
 
-	store, err := r.openTopoStore(globalTopoRef)
+	store, err := r.openTopoStore(ctx, cluster.Namespace, globalTopoRef)
 	if err != nil {
 		if topo.IsTopoUnavailable(err) {
 			return r.handleTopoUnavailable(cluster, logger)
 		}
+		// A missing or unusable client credential is a configuration error, not a
+		// transient outage, so record it in the cluster's status as well as an
+		// event. The store-open error names the Secret, so the reason a cluster
+		// stays not ready is visible without reading the operator logs.
 		r.Recorder.Eventf(cluster, "Warning", "TopoConnectFailed",
 			"Failed to connect to topology server: %v", err)
+		r.markTopologyConnectFailed(ctx, cluster, err, logger)
 		return ctrl.Result{}, fmt.Errorf("failed to open topology store: %w", err)
 	}
 	defer func() { _ = store.Close() }()
@@ -175,7 +181,48 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 		}
 	}
 
+	// Registration reached the topology server, so clear any earlier connection
+	// failure. The change is persisted by the later status update on this
+	// reconcile; steady state leaves the condition untouched.
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:               conditionTopologyReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             "TopoConnected",
+		Message:            "Topology server reachable",
+		ObservedGeneration: cluster.Generation,
+		LastTransitionTime: metav1.Now(),
+	})
+
 	return ctrl.Result{}, nil
+}
+
+// conditionTopologyReady reports whether the operator can reach the topology
+// server with the configured credentials.
+const conditionTopologyReady = "TopologyReady"
+
+// markTopologyConnectFailed records a topology connection failure in the
+// cluster status: a Degraded phase, a message carrying the error, and a
+// TopologyReady=False condition. The status write is best effort, since the
+// reconcile already returns the error and will retry.
+func (r *MultigresClusterReconciler) markTopologyConnectFailed(
+	ctx context.Context,
+	cluster *multigresv1alpha1.MultigresCluster,
+	cause error,
+	logger interface{ Error(error, string, ...any) },
+) {
+	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+		Type:               conditionTopologyReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             "TopoConnectFailed",
+		Message:            cause.Error(),
+		ObservedGeneration: cluster.Generation,
+		LastTransitionTime: metav1.Now(),
+	})
+	cluster.Status.Phase = multigresv1alpha1.PhaseDegraded
+	cluster.Status.Message = cause.Error()
+	if err := r.Status().Update(ctx, cluster); err != nil {
+		logger.Error(err, "Failed to persist topology connection failure to status")
+	}
 }
 
 func specCellNames(cluster *multigresv1alpha1.MultigresCluster) []string {
@@ -258,14 +305,20 @@ func (r *MultigresClusterReconciler) managedLocalTopoServerReady(
 }
 
 // openTopoStore opens a topology store, using the injected factory for tests
-// or the real NewStoreFromRef for production.
+// or the real NewStoreFromRef for production. The namespace is where the
+// reference's client TLS Secrets live.
 func (r *MultigresClusterReconciler) openTopoStore(
+	ctx context.Context,
+	namespace string,
 	ref multigresv1alpha1.GlobalTopoServerRef,
 ) (topoclient.Store, error) {
 	if r.CreateTopoStore != nil {
 		return r.CreateTopoStore(ref)
 	}
-	return topo.NewStoreFromRef(ref)
+	// Read the client credential with the uncached reader: the manager's cache
+	// only stores tenant-namespace Secrets carrying the operator's managed-by
+	// label, and a cert-manager or user-provided topology Secret does not.
+	return topo.NewStoreFromRef(ctx, r.APIReader, namespace, ref)
 }
 
 // isPruningEnabled returns true if topology pruning is enabled for the cluster.

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_tls_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_tls_test.go
@@ -1,0 +1,79 @@
+package multigrescluster
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+// A topology connection failure has to be visible in the cluster status, not
+// only in the logs, so an operator can see why the cluster is not becoming
+// ready and which Secret is missing.
+func TestMarkTopologyConnectFailed_SurfacesInStatus(t *testing.T) {
+	scheme := setupScheme()
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-cluster",
+			Namespace:  "supabase",
+			Generation: 3,
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster).
+		WithStatusSubresource(cluster).
+		Build()
+	r := &MultigresClusterReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	cause := errors.New(
+		`reading topology client TLS Secret "test-cluster-topo-client-tls" in namespace "supabase": not found`,
+	)
+	r.markTopologyConnectFailed(context.Background(), cluster, cause, testLogger{})
+
+	got := &multigresv1alpha1.MultigresCluster{}
+	if err := c.Get(
+		context.Background(),
+		client.ObjectKey{Namespace: "supabase", Name: "test-cluster"},
+		got,
+	); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	if got.Status.Phase != multigresv1alpha1.PhaseDegraded {
+		t.Errorf("phase = %q, want %q", got.Status.Phase, multigresv1alpha1.PhaseDegraded)
+	}
+	if !strings.Contains(got.Status.Message, "test-cluster-topo-client-tls") {
+		t.Errorf("status message does not name the Secret: %q", got.Status.Message)
+	}
+	var found bool
+	for _, cond := range got.Status.Conditions {
+		if cond.Type == conditionTopologyReady {
+			found = true
+			if cond.Status != metav1.ConditionFalse {
+				t.Errorf("%s status = %q, want False", conditionTopologyReady, cond.Status)
+			}
+			if !strings.Contains(cond.Message, "test-cluster-topo-client-tls") {
+				t.Errorf("condition message does not name the Secret: %q", cond.Message)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no %s condition set", conditionTopologyReady)
+	}
+}
+
+type testLogger struct{}
+
+func (testLogger) Error(error, string, ...any) {}

--- a/pkg/data-handler/topo/store.go
+++ b/pkg/data-handler/topo/store.go
@@ -5,70 +5,167 @@
 package topo
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/multigres/multigres/go/common/topoclient"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 )
 
+// tls Secret keys follow the cert-manager layout: the client keypair in
+// tls.crt and tls.key, and the CA bundle in ca.crt.
+const (
+	tlsCertKey = "tls.crt"
+	tlsKeyKey  = "tls.key"
+	tlsCAKey   = "ca.crt"
+)
+
 // NewStoreFromShard creates a topoclient.Store using the GlobalTopoServer
-// configuration from a Shard resource.
-func NewStoreFromShard(shard *multigresv1alpha1.Shard) (topoclient.Store, error) {
-	implementation := shard.Spec.GlobalTopoServer.Implementation
-	if implementation == "" {
-		implementation = "etcd"
-	}
-
-	rootPath := shard.Spec.GlobalTopoServer.RootPath
-	serverAddrs := []string{shard.Spec.GlobalTopoServer.Address}
-	config := topoclient.NewDefaultTopoConfig()
-
-	store, err := topoclient.OpenServer(implementation, rootPath, serverAddrs, config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open topology store: %w", err)
-	}
-	return store, nil
+// configuration from a Shard resource. When the reference names a client
+// credential Secret, the connection presents that certificate; otherwise it
+// connects in plaintext.
+func NewStoreFromShard(
+	ctx context.Context,
+	c client.Reader,
+	shard *multigresv1alpha1.Shard,
+) (topoclient.Store, error) {
+	return newStore(ctx, c, shard.Namespace, shard.Spec.GlobalTopoServer)
 }
 
 // NewStoreFromCell creates a topoclient.Store using the GlobalTopoServer
 // configuration from a Cell resource.
-func NewStoreFromCell(cell *multigresv1alpha1.Cell) (topoclient.Store, error) {
-	implementation := cell.Spec.GlobalTopoServer.Implementation
-	if implementation == "" {
-		implementation = "etcd"
-	}
-
-	rootPath := cell.Spec.GlobalTopoServer.RootPath
-	serverAddrs := []string{cell.Spec.GlobalTopoServer.Address}
-	config := topoclient.NewDefaultTopoConfig()
-
-	store, err := topoclient.OpenServer(implementation, rootPath, serverAddrs, config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open topology store: %w", err)
-	}
-	return store, nil
+func NewStoreFromCell(
+	ctx context.Context,
+	c client.Reader,
+	cell *multigresv1alpha1.Cell,
+) (topoclient.Store, error) {
+	return newStore(ctx, c, cell.Namespace, cell.Spec.GlobalTopoServer)
 }
 
-// NewStoreFromRef creates a topoclient.Store using a GlobalTopoServerRef.
-// This is used by the MultigresCluster controller which already computes
-// the reference via getGlobalTopoRef().
-func NewStoreFromRef(ref multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+// NewStoreFromRef creates a topoclient.Store using a GlobalTopoServerRef and the
+// namespace the referenced Secrets live in. This is used by the MultigresCluster
+// controller, which already computes the reference.
+func NewStoreFromRef(
+	ctx context.Context,
+	c client.Reader,
+	namespace string,
+	ref multigresv1alpha1.GlobalTopoServerRef,
+) (topoclient.Store, error) {
+	return newStore(ctx, c, namespace, ref)
+}
+
+// newStore opens a topology store for the given reference, loading client TLS
+// material from the referenced Secrets when the reference carries it.
+func newStore(
+	ctx context.Context,
+	c client.Reader,
+	namespace string,
+	ref multigresv1alpha1.GlobalTopoServerRef,
+) (topoclient.Store, error) {
 	implementation := ref.Implementation
 	if implementation == "" {
 		implementation = "etcd"
 	}
 
-	rootPath := ref.RootPath
-	serverAddrs := []string{ref.Address}
 	config := topoclient.NewDefaultTopoConfig()
+	tlsOptions, err := loadClientTLS(ctx, c, namespace, ref)
+	if err != nil {
+		return nil, err
+	}
+	config.TLS = tlsOptions
 
-	store, err := topoclient.OpenServer(implementation, rootPath, serverAddrs, config)
+	store, err := topoclient.OpenServer(
+		implementation, ref.RootPath, []string{ref.Address}, config,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open topology store: %w", err)
 	}
 	return store, nil
+}
+
+// loadClientTLS reads the client keypair and CA bundle the reference names and
+// returns them as topoclient.TLSOptions. It returns nil when the reference
+// carries no TLS material, so an unconfigured connection stays plaintext. A
+// named Secret that is missing or lacks a required key is a hard error that
+// names the Secret, so a misconfigured cluster fails visibly rather than
+// silently connecting without a certificate.
+func loadClientTLS(
+	ctx context.Context,
+	c client.Reader,
+	namespace string,
+	ref multigresv1alpha1.GlobalTopoServerRef,
+) (*topoclient.TLSOptions, error) {
+	if ref.ClientCertSecret == "" && ref.CASecret == "" {
+		return nil, nil
+	}
+
+	opts := &topoclient.TLSOptions{}
+	secrets := map[string]*corev1.Secret{}
+
+	get := func(name string) (*corev1.Secret, error) {
+		if s, ok := secrets[name]; ok {
+			return s, nil
+		}
+		s := &corev1.Secret{}
+		key := types.NamespacedName{Namespace: namespace, Name: name}
+		if err := c.Get(ctx, key, s); err != nil {
+			return nil, fmt.Errorf(
+				"reading topology client TLS Secret %q in namespace %q: %w",
+				name, namespace, err,
+			)
+		}
+		secrets[name] = s
+		return s, nil
+	}
+
+	if ref.ClientCertSecret != "" {
+		s, err := get(ref.ClientCertSecret)
+		if err != nil {
+			return nil, err
+		}
+		cert, err := requireKey(s, tlsCertKey)
+		if err != nil {
+			return nil, err
+		}
+		keyPEM, err := requireKey(s, tlsKeyKey)
+		if err != nil {
+			return nil, err
+		}
+		opts.CertPEM = cert
+		opts.KeyPEM = keyPEM
+	}
+
+	if ref.CASecret != "" {
+		s, err := get(ref.CASecret)
+		if err != nil {
+			return nil, err
+		}
+		ca, err := requireKey(s, tlsCAKey)
+		if err != nil {
+			return nil, err
+		}
+		opts.CAPEM = ca
+	}
+
+	return opts, nil
+}
+
+// requireKey returns the named key's bytes, or an error naming the Secret and
+// the missing key.
+func requireKey(secret *corev1.Secret, key string) ([]byte, error) {
+	v, ok := secret.Data[key]
+	if !ok || len(v) == 0 {
+		return nil, fmt.Errorf(
+			"topology client TLS Secret %q in namespace %q is missing key %q",
+			secret.Name, secret.Namespace, key,
+		)
+	}
+	return v, nil
 }
 
 // IsTopoUnavailable returns true if the error indicates the topology server

--- a/pkg/data-handler/topo/store_internal_test.go
+++ b/pkg/data-handler/topo/store_internal_test.go
@@ -1,0 +1,89 @@
+package topo
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+func tlsTestClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func TestLoadClientTLS_PlaintextWhenNoSecrets(t *testing.T) {
+	ref := multigresv1alpha1.GlobalTopoServerRef{Address: "localhost:2379"}
+	opts, err := loadClientTLS(context.Background(), tlsTestClient(), "team-a", ref)
+	if err != nil {
+		t.Fatalf("loadClientTLS() error = %v", err)
+	}
+	if opts != nil {
+		t.Errorf("expected nil TLS options for a plaintext reference, got %+v", opts)
+	}
+}
+
+// The managed path names one Secret for both the keypair and the CA. The loaded
+// options have to carry the tls.crt, tls.key, and ca.crt bytes verbatim.
+func TestLoadClientTLS_ManagedSecret(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "topo-tls", Namespace: "team-a"},
+		Data: map[string][]byte{
+			"tls.crt": []byte("CERT"),
+			"tls.key": []byte("KEY"),
+			"ca.crt":  []byte("CA"),
+		},
+	}
+	ref := multigresv1alpha1.GlobalTopoServerRef{
+		Address:          "localhost:2379",
+		CASecret:         "topo-tls",
+		ClientCertSecret: "topo-tls",
+	}
+
+	opts, err := loadClientTLS(context.Background(), tlsTestClient(secret), "team-a", ref)
+	if err != nil {
+		t.Fatalf("loadClientTLS() error = %v", err)
+	}
+	if opts == nil {
+		t.Fatal("expected TLS options, got nil")
+	}
+	if !bytes.Equal(opts.CertPEM, []byte("CERT")) ||
+		!bytes.Equal(opts.KeyPEM, []byte("KEY")) ||
+		!bytes.Equal(opts.CAPEM, []byte("CA")) {
+		t.Errorf("TLS options do not carry the Secret material verbatim: %+v", opts)
+	}
+}
+
+// An external topology can split the CA and the client keypair across two
+// Secrets; both are read.
+func TestLoadClientTLS_SeparateCAAndClientSecrets(t *testing.T) {
+	client := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "client", Namespace: "team-a"},
+		Data:       map[string][]byte{"tls.crt": []byte("CERT"), "tls.key": []byte("KEY")},
+	}
+	ca := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "ca", Namespace: "team-a"},
+		Data:       map[string][]byte{"ca.crt": []byte("CA")},
+	}
+	ref := multigresv1alpha1.GlobalTopoServerRef{
+		Address:          "localhost:2379",
+		CASecret:         "ca",
+		ClientCertSecret: "client",
+	}
+
+	opts, err := loadClientTLS(context.Background(), tlsTestClient(client, ca), "team-a", ref)
+	if err != nil {
+		t.Fatalf("loadClientTLS() error = %v", err)
+	}
+	if !bytes.Equal(opts.CertPEM, []byte("CERT")) || !bytes.Equal(opts.CAPEM, []byte("CA")) {
+		t.Errorf("expected material from both Secrets: %+v", opts)
+	}
+}

--- a/pkg/data-handler/topo/store_test.go
+++ b/pkg/data-handler/topo/store_test.go
@@ -1,18 +1,29 @@
 package topo_test
 
 import (
+	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	_ "github.com/multigres/multigres/go/common/topoclient/etcdtopo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/data-handler/topo"
 )
 
-func TestNewStoreFromShard(t *testing.T) {
-	t.Parallel()
+func topoTestClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
 
+func TestNewStoreFromShard(t *testing.T) {
 	tests := map[string]struct {
 		shard   *multigresv1alpha1.Shard
 		wantErr bool
@@ -32,9 +43,7 @@ func TestNewStoreFromShard(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			store, err := topo.NewStoreFromShard(tc.shard)
+			store, err := topo.NewStoreFromShard(context.Background(), topoTestClient(), tc.shard)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("NewStoreFromShard() error = %v, wantErr %v", err, tc.wantErr)
 				return
@@ -57,7 +66,7 @@ func TestNewStoreFromShard_InvalidImplementation(t *testing.T) {
 		},
 	}
 
-	store, err := topo.NewStoreFromShard(shard)
+	store, err := topo.NewStoreFromShard(context.Background(), topoTestClient(), shard)
 	if err == nil {
 		if store != nil {
 			_ = store.Close()
@@ -66,9 +75,85 @@ func TestNewStoreFromShard_InvalidImplementation(t *testing.T) {
 	}
 }
 
-func TestIsTopoUnavailable(t *testing.T) {
-	t.Parallel()
+// A reference that names a client credential Secret which does not exist has to
+// fail with the Secret name, so a misconfigured cluster reports the missing
+// material instead of silently connecting without a certificate.
+func TestNewStoreFromShard_MissingSecretIsLoud(t *testing.T) {
+	tlsName := "cluster-topo-client-tls"
+	shard := &multigresv1alpha1.Shard{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a"},
+		Spec: multigresv1alpha1.ShardSpec{
+			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+				Address:          "localhost:2379",
+				RootPath:         "/test",
+				CASecret:         tlsName,
+				ClientCertSecret: tlsName,
+			},
+		},
+	}
 
+	_, err := topo.NewStoreFromShard(context.Background(), topoTestClient(), shard)
+	if err == nil {
+		t.Fatal("expected an error for a missing client credential Secret")
+	}
+	if !strings.Contains(err.Error(), tlsName) {
+		t.Errorf("error does not name the missing Secret: %v", err)
+	}
+}
+
+// A Secret that exists but is missing a required key also fails loudly, naming
+// the key.
+func TestNewStoreFromRef_MissingKeyIsLoud(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "topo-tls", Namespace: "team-a"},
+		Data: map[string][]byte{
+			"tls.crt": []byte("cert"),
+			// tls.key intentionally absent.
+			"ca.crt": []byte("ca"),
+		},
+	}
+	ref := multigresv1alpha1.GlobalTopoServerRef{
+		Address:          "localhost:2379",
+		RootPath:         "/test",
+		CASecret:         "topo-tls",
+		ClientCertSecret: "topo-tls",
+	}
+
+	_, err := topo.NewStoreFromRef(context.Background(), topoTestClient(secret), "team-a", ref)
+	if err == nil {
+		t.Fatal("expected an error for a Secret missing tls.key")
+	}
+	if !strings.Contains(err.Error(), "tls.key") || !strings.Contains(err.Error(), "topo-tls") {
+		t.Errorf("error does not name the Secret and missing key: %v", err)
+	}
+}
+
+func TestNewStoreFromRef_WithClientCert(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "topo-tls", Namespace: "team-a"},
+		Data: map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+			"ca.crt":  []byte("ca"),
+		},
+	}
+	ref := multigresv1alpha1.GlobalTopoServerRef{
+		Address:          "localhost:2379",
+		RootPath:         "/test",
+		CASecret:         "topo-tls",
+		ClientCertSecret: "topo-tls",
+	}
+
+	store, err := topo.NewStoreFromRef(context.Background(), topoTestClient(secret), "team-a", ref)
+	if err != nil {
+		t.Fatalf("NewStoreFromRef() unexpected error: %v", err)
+	}
+	if store != nil {
+		_ = store.Close()
+	}
+}
+
+func TestIsTopoUnavailable(t *testing.T) {
 	tests := map[string]struct {
 		err  error
 		want bool
@@ -81,7 +166,6 @@ func TestIsTopoUnavailable(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			if got := topo.IsTopoUnavailable(tc.err); got != tc.want {
 				t.Errorf("IsTopoUnavailable(%v) = %v, want %v", tc.err, got, tc.want)
 			}
@@ -90,8 +174,6 @@ func TestIsTopoUnavailable(t *testing.T) {
 }
 
 func TestNewStoreFromCell(t *testing.T) {
-	t.Parallel()
-
 	cell := &multigresv1alpha1.Cell{
 		Spec: multigresv1alpha1.CellSpec{
 			GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
@@ -101,7 +183,7 @@ func TestNewStoreFromCell(t *testing.T) {
 		},
 	}
 
-	store, err := topo.NewStoreFromCell(cell)
+	store, err := topo.NewStoreFromCell(context.Background(), topoTestClient(), cell)
 	if err != nil {
 		t.Fatalf("NewStoreFromCell() unexpected error: %v", err)
 	}
@@ -121,7 +203,7 @@ func TestNewStoreFromCell_InvalidImplementation(t *testing.T) {
 		},
 	}
 
-	store, err := topo.NewStoreFromCell(cell)
+	store, err := topo.NewStoreFromCell(context.Background(), topoTestClient(), cell)
 	if err == nil {
 		if store != nil {
 			_ = store.Close()
@@ -131,14 +213,12 @@ func TestNewStoreFromCell_InvalidImplementation(t *testing.T) {
 }
 
 func TestNewStoreFromRef(t *testing.T) {
-	t.Parallel()
-
 	ref := multigresv1alpha1.GlobalTopoServerRef{
 		Address:  "localhost:2379",
 		RootPath: "/test",
 	}
 
-	store, err := topo.NewStoreFromRef(ref)
+	store, err := topo.NewStoreFromRef(context.Background(), topoTestClient(), "team-a", ref)
 	if err != nil {
 		t.Fatalf("NewStoreFromRef() unexpected error: %v", err)
 	}
@@ -154,7 +234,7 @@ func TestNewStoreFromRef_InvalidImplementation(t *testing.T) {
 		Implementation: "invalid-implementation-that-does-not-exist",
 	}
 
-	store, err := topo.NewStoreFromRef(ref)
+	store, err := topo.NewStoreFromRef(context.Background(), topoTestClient(), "team-a", ref)
 	if err == nil {
 		if store != nil {
 			_ = store.Close()

--- a/pkg/resource-handler/controller/cell/multigateway.go
+++ b/pkg/resource-handler/controller/cell/multigateway.go
@@ -334,6 +334,21 @@ func BuildMultigatewayDeployment(
 		)
 	}
 
+	if multigresv1alpha1.TopoClientTLSConfigured(cell.Spec.GlobalTopoServer) {
+		podSpec.Volumes = append(
+			podSpec.Volumes,
+			multigresv1alpha1.BuildTopoClientTLSVolume(cell.Spec.GlobalTopoServer),
+		)
+		podSpec.Containers[0].VolumeMounts = append(
+			podSpec.Containers[0].VolumeMounts,
+			multigresv1alpha1.TopoClientTLSVolumeMount(),
+		)
+		podSpec.Containers[0].Args = append(
+			podSpec.Containers[0].Args,
+			multigresv1alpha1.TopoClientTLSArgs()...,
+		)
+	}
+
 	if err := ctrl.SetControllerReference(cell, deployment, scheme); err != nil {
 		return nil, fmt.Errorf("failed to set controller reference: %w", err)
 	}

--- a/pkg/resource-handler/controller/cell/multigateway_test.go
+++ b/pkg/resource-handler/controller/cell/multigateway_test.go
@@ -2516,3 +2516,72 @@ func TestBuildMultigatewayDeployment_Buffer(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildMultigatewayDeployment_TopoClientTLS(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = multigresv1alpha1.AddToScheme(scheme)
+
+	baseCell := func() *multigresv1alpha1.Cell {
+		return &multigresv1alpha1.Cell{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cell",
+				Namespace: "default",
+				UID:       "test-uid",
+				Labels:    map[string]string{"multigres.com/cluster": "test-cluster"},
+			},
+			Spec: multigresv1alpha1.CellSpec{
+				Name: "zone1",
+				GlobalTopoServer: multigresv1alpha1.GlobalTopoServerRef{
+					Address:        "global-topo:2379",
+					RootPath:       "/multigres/global",
+					Implementation: "etcd",
+				},
+				LogLevels: multigresv1alpha1.ComponentLogLevels{
+					Pgctld: "info", Multipooler: "info", Multiorch: "info",
+					Multiadmin: "info", Multigateway: "info",
+				},
+			},
+		}
+	}
+
+	t.Run("presents the client certificate when the reference carries it", func(t *testing.T) {
+		cell := baseCell()
+		secret := multigresv1alpha1.TopoClientCertSecretName("test-cluster")
+		cell.Spec.GlobalTopoServer.CASecret = secret
+		cell.Spec.GlobalTopoServer.ClientCertSecret = secret
+
+		got, err := BuildMultigatewayDeployment(cell, scheme)
+		if err != nil {
+			t.Fatalf("BuildMultigatewayDeployment() error = %v", err)
+		}
+		c := got.Spec.Template.Spec.Containers[0]
+		if !slices.Contains(c.Args, "--topo-etcd-tls-cert") {
+			t.Errorf("missing topo client TLS flags: %v", c.Args)
+		}
+		var mounted bool
+		for _, m := range c.VolumeMounts {
+			if m.Name == multigresv1alpha1.TopoClientTLSVolumeName {
+				mounted = true
+			}
+		}
+		if !mounted {
+			t.Error("multigateway does not mount the topo client certificate")
+		}
+	})
+
+	t.Run("renders unchanged when the reference carries no credential", func(t *testing.T) {
+		got, err := BuildMultigatewayDeployment(baseCell(), scheme)
+		if err != nil {
+			t.Fatalf("BuildMultigatewayDeployment() error = %v", err)
+		}
+		c := got.Spec.Template.Spec.Containers[0]
+		if slices.Contains(c.Args, "--topo-etcd-tls-cert") {
+			t.Error("topo TLS flag present with no credential on the reference")
+		}
+		for _, v := range got.Spec.Template.Spec.Volumes {
+			if v.Name == multigresv1alpha1.TopoClientTLSVolumeName {
+				t.Error("topo client volume present with no credential on the reference")
+			}
+		}
+	})
+}

--- a/pkg/resource-handler/controller/shard/containers.go
+++ b/pkg/resource-handler/controller/shard/containers.go
@@ -578,6 +578,9 @@ func buildMultipoolerContainer(
 			"--grpc-server-ca", ShardTLSCAFile,
 		)
 	}
+	if multigresv1alpha1.TopoClientTLSConfigured(shard.Spec.GlobalTopoServer) {
+		args = append(args, multigresv1alpha1.TopoClientTLSArgs()...)
+	}
 
 	if shard.Spec.Backup != nil && shard.Spec.Backup.Encryption != nil {
 		args = append(args,
@@ -669,6 +672,9 @@ func buildMultipoolerContainer(
 	if shardTLSConfigured(shard) {
 		c.VolumeMounts = append(c.VolumeMounts, shardTLSVolumeMount())
 	}
+	if multigresv1alpha1.TopoClientTLSConfigured(shard.Spec.GlobalTopoServer) {
+		c.VolumeMounts = append(c.VolumeMounts, multigresv1alpha1.TopoClientTLSVolumeMount())
+	}
 	if _, otelMount := multigresv1alpha1.BuildOTELSamplingVolume(
 		shard.Spec.Observability,
 	); otelMount != nil {
@@ -714,6 +720,9 @@ func buildMultiorchContainer(shard *multigresv1alpha1.Shard, cellName string) co
 			),
 			"--multipooler-grpc-require-tls",
 		)
+	}
+	if multigresv1alpha1.TopoClientTLSConfigured(shard.Spec.GlobalTopoServer) {
+		args = append(args, multigresv1alpha1.TopoClientTLSArgs()...)
 	}
 
 	c := corev1.Container{
@@ -761,6 +770,9 @@ func buildMultiorchContainer(shard *multigresv1alpha1.Shard, cellName string) co
 	}
 	if shardTLSConfigured(shard) {
 		c.VolumeMounts = append(c.VolumeMounts, shardTLSVolumeMount())
+	}
+	if multigresv1alpha1.TopoClientTLSConfigured(shard.Spec.GlobalTopoServer) {
+		c.VolumeMounts = append(c.VolumeMounts, multigresv1alpha1.TopoClientTLSVolumeMount())
 	}
 	return c
 }
@@ -839,6 +851,12 @@ func buildPoolVolumes(shard *multigresv1alpha1.Shard, cellName string) []corev1.
 			shard,
 			multigresv1alpha1.ComponentMultiPoolerTLS,
 		))
+	}
+	if multigresv1alpha1.TopoClientTLSConfigured(shard.Spec.GlobalTopoServer) {
+		volumes = append(
+			volumes,
+			multigresv1alpha1.BuildTopoClientTLSVolume(shard.Spec.GlobalTopoServer),
+		)
 	}
 	if otelVol, _ := multigresv1alpha1.BuildOTELSamplingVolume(
 		shard.Spec.Observability,

--- a/pkg/resource-handler/controller/shard/multiorch.go
+++ b/pkg/resource-handler/controller/shard/multiorch.go
@@ -91,6 +91,12 @@ func BuildMultiorchDeployment(
 				multigresv1alpha1.ComponentMultiOrchTLS,
 			))
 	}
+	if multigresv1alpha1.TopoClientTLSConfigured(shard.Spec.GlobalTopoServer) {
+		deployment.Spec.Template.Spec.Volumes = append(
+			deployment.Spec.Template.Spec.Volumes,
+			multigresv1alpha1.BuildTopoClientTLSVolume(shard.Spec.GlobalTopoServer),
+		)
+	}
 
 	if err := ctrl.SetControllerReference(shard, deployment, scheme); err != nil {
 		return nil, fmt.Errorf("failed to set controller reference: %w", err)

--- a/pkg/resource-handler/controller/shard/reconcile_data_plane.go
+++ b/pkg/resource-handler/controller/shard/reconcile_data_plane.go
@@ -32,7 +32,7 @@ func (r *ShardReconciler) reconcileDataPlane(
 	logger := log.FromContext(ctx)
 
 	// Open a single topo connection for PodRoles, drain, and backup health.
-	store, err := r.topoStore(shard)
+	store, err := r.topoStore(ctx, shard)
 	if err != nil {
 		if !topo.IsTopoUnavailable(err) {
 			r.Recorder.Eventf(shard, "Warning", "TopologyError",
@@ -456,11 +456,17 @@ func (r *ShardReconciler) isDrainStale(
 }
 
 // topoStore returns a topology store, using the custom factory if set, otherwise the default.
-func (r *ShardReconciler) topoStore(shard *multigresv1alpha1.Shard) (topoclient.Store, error) {
+func (r *ShardReconciler) topoStore(
+	ctx context.Context,
+	shard *multigresv1alpha1.Shard,
+) (topoclient.Store, error) {
 	if r.CreateTopoStore != nil {
 		return r.CreateTopoStore(shard)
 	}
-	return topo.NewStoreFromShard(shard)
+	// Read the client credential with the uncached reader: the manager's cache
+	// only stores tenant-namespace Secrets carrying the operator's managed-by
+	// label, and a cert-manager or user-provided topology Secret does not.
+	return topo.NewStoreFromShard(ctx, r.APIReader, shard)
 }
 
 // reconcilePoolerPrune lists active pods for the shard and marks topology

--- a/pkg/resource-handler/controller/shard/reconcile_deletion.go
+++ b/pkg/resource-handler/controller/shard/reconcile_deletion.go
@@ -263,7 +263,7 @@ func (r *ShardReconciler) handlePendingDeletion(
 	var store topoclient.Store
 	if len(podList.Items) > 0 {
 		var err error
-		store, err = r.topoStore(shard)
+		store, err = r.topoStore(ctx, shard)
 		if err != nil {
 			logger.Error(err, "Failed to get topo store for PendingDeletion")
 			r.Recorder.Eventf(shard, "Warning", "TopologyError",

--- a/pkg/resource-handler/controller/shard/topo_client_tls_test.go
+++ b/pkg/resource-handler/controller/shard/topo_client_tls_test.go
@@ -1,0 +1,175 @@
+package shard
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+)
+
+// topoTLSShard returns a shard whose global topology reference carries the
+// client credential and CA bundle, i.e. the managed etcd case where one
+// cert-manager Secret holds tls.crt, tls.key and ca.crt.
+func topoTLSShard() *multigresv1alpha1.Shard {
+	shard := newTestShard()
+	secret := multigresv1alpha1.TopoClientCertSecretName("test-cluster")
+	shard.Spec.GlobalTopoServer = multigresv1alpha1.GlobalTopoServerRef{
+		Address:          "test-cluster-global-topo.default.svc:2379",
+		RootPath:         "/multigres/global",
+		Implementation:   "etcd",
+		CASecret:         secret,
+		ClientCertSecret: secret,
+	}
+	return shard
+}
+
+func containerByName(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func mountsVolume(c *corev1.Container, volumeName string) bool {
+	if c == nil {
+		return false
+	}
+	for _, m := range c.VolumeMounts {
+		if m.Name == volumeName {
+			return true
+		}
+	}
+	return false
+}
+
+func hasArg(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// The topo client certificate is the only thing separating multipooler from the
+// postgres superuser it shares a pod, an IP, the data PVC and the socket
+// directory with. This asserts the mount boundary that makes that separation
+// real: the credential reaches only the container that speaks to the topology
+// server, never a container that also mounts postgres state, and the pod never
+// shares a process namespace.
+func TestPoolPod_TopoClientTLSMountBoundary(t *testing.T) {
+	pod, err := BuildPoolPod(topoTLSShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	if err != nil {
+		t.Fatalf("BuildPoolPod() error = %v", err)
+	}
+
+	multipooler := containerByName(pod.Spec.Containers, "multipooler")
+	if multipooler == nil {
+		t.Fatal("multipooler container missing")
+	}
+	if !mountsVolume(multipooler, multigresv1alpha1.TopoClientTLSVolumeName) {
+		t.Error("topo client certificate is not mounted into multipooler")
+	}
+
+	// No other container in the pod may mount the credential. pgctld runs as an
+	// init (native sidecar) container named postgres; the exporter sits beside
+	// multipooler. Neither speaks to the topology server.
+	all := append([]corev1.Container{}, pod.Spec.InitContainers...)
+	all = append(all, pod.Spec.Containers...)
+	for i := range all {
+		c := &all[i]
+		if c.Name == "multipooler" {
+			continue
+		}
+		if mountsVolume(c, multigresv1alpha1.TopoClientTLSVolumeName) {
+			t.Errorf("topo client certificate leaked into container %q", c.Name)
+		}
+	}
+
+	// The credential must not ride on a volume the postgres or pgctld containers
+	// also mount: those share the data PVC and the socket directory, so anything
+	// projected onto them is readable by the postgres superuser.
+	postgres := containerByName(pod.Spec.InitContainers, "postgres")
+	if postgres == nil {
+		t.Fatal("postgres (pgctld) container missing")
+	}
+	sharedWithPostgres := map[string]struct{}{}
+	for _, m := range postgres.VolumeMounts {
+		sharedWithPostgres[m.Name] = struct{}{}
+	}
+	if _, shared := sharedWithPostgres[multigresv1alpha1.TopoClientTLSVolumeName]; shared {
+		t.Error("topo client certificate shares a volume with the postgres container")
+	}
+	for _, m := range multipooler.VolumeMounts {
+		if m.Name != multigresv1alpha1.TopoClientTLSVolumeName {
+			continue
+		}
+		// The mount path must be its own, not nested under the shared data or
+		// socket directories.
+		if m.MountPath == DataMountPath || m.MountPath == SocketDirMountPath {
+			t.Errorf("topo client certificate mounted on a shared path %q", m.MountPath)
+		}
+	}
+
+	// Shared PID plus ptrace would expose one container's mounted files through
+	// /proc, defeating the boundary regardless of which volume carries them.
+	if pod.Spec.ShareProcessNamespace != nil {
+		t.Errorf("shareProcessNamespace = %v, want unset", *pod.Spec.ShareProcessNamespace)
+	}
+}
+
+// With no topo client credential on the reference (topology TLS off), the pool
+// pod renders exactly as before: no topo client volume, mount or flags anywhere.
+func TestPoolPod_TopoClientTLSOffRendersUnchanged(t *testing.T) {
+	pod, err := BuildPoolPod(newTestShard(), "main", "z1", newTestPoolSpec(), 0, testScheme())
+	if err != nil {
+		t.Fatalf("BuildPoolPod() error = %v", err)
+	}
+
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == multigresv1alpha1.TopoClientTLSVolumeName {
+			t.Fatal("topo client volume present with topology TLS off")
+		}
+	}
+	all := append([]corev1.Container{}, pod.Spec.InitContainers...)
+	all = append(all, pod.Spec.Containers...)
+	for i := range all {
+		c := &all[i]
+		if mountsVolume(c, multigresv1alpha1.TopoClientTLSVolumeName) {
+			t.Errorf("container %q mounts the topo client volume with topology TLS off", c.Name)
+		}
+		if hasArg(c.Args, "--topo-etcd-tls-cert") {
+			t.Errorf("container %q has topo TLS flags with topology TLS off", c.Name)
+		}
+	}
+}
+
+// multipooler and multiorch both open topology connections, so both present the
+// client certificate through the three etcd TLS flags when it is configured.
+func TestTopoSpeakingContainers_PresentClientCert(t *testing.T) {
+	shard := topoTLSShard()
+	pool := newTestPoolSpec()
+
+	mp := buildMultipoolerContainer(shard, pool, "main", "z1", "p-test-id")
+	orch := buildMultiorchContainer(shard, "z1")
+
+	for name, args := range map[string][]string{
+		"multipooler": mp.Args,
+		"multiorch":   orch.Args,
+	} {
+		if !hasArg(args, "--topo-etcd-tls-cert") ||
+			!hasArg(args, "--topo-etcd-tls-key") ||
+			!hasArg(args, "--topo-etcd-tls-ca") {
+			t.Errorf("%s is missing topo client TLS flags: %v", name, args)
+		}
+	}
+	if !mountsVolume(&mp, multigresv1alpha1.TopoClientTLSVolumeName) {
+		t.Error("multipooler does not mount the topo client certificate")
+	}
+	if !mountsVolume(&orch, multigresv1alpha1.TopoClientTLSVolumeName) {
+		t.Error("multiorch does not mount the topo client certificate")
+	}
+}

--- a/pkg/resource-handler/controller/toposerver/certificate_test.go
+++ b/pkg/resource-handler/controller/toposerver/certificate_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -404,37 +405,108 @@ func TestReconcileCertificate(t *testing.T) {
 	})
 }
 
-// Issuing certificates does not change what etcd runs with. Holding the
-// StatefulSet pod template and the etcd container environment identical is
-// what makes enabling topology TLS safe on a running cluster.
-func TestTopoTLSDoesNotChangeRenderedPodSpec(t *testing.T) {
+// With topology TLS off the etcd StatefulSet renders exactly as it did before
+// enforcement existed: plaintext listeners and no serving certificate mount.
+// This is the invariant that keeps the change safe to merge with the gate off.
+func TestTopoTLSOffRendersPlaintext(t *testing.T) {
 	scheme := certScheme()
 
-	without := certTestTopoServer(nil)
-	with := certTestTopoServer(&multigresv1alpha1.TopoTLSConfig{
+	sts, err := BuildStatefulSet(certTestTopoServer(nil), scheme)
+	if err != nil {
+		t.Fatalf("BuildStatefulSet() error = %v", err)
+	}
+
+	for _, vol := range sts.Spec.Template.Spec.Volumes {
+		if vol.Name == TopoServerTLSVolumeName {
+			t.Fatalf("serving certificate volume present with topology TLS off")
+		}
+	}
+	env := etcdEnvMap(t, sts)
+	if got := env["ETCD_LISTEN_CLIENT_URLS"]; got != "http://[::]:2379" {
+		t.Errorf("ETCD_LISTEN_CLIENT_URLS = %q, want plaintext", got)
+	}
+	if _, ok := env["ETCD_CLIENT_CERT_AUTH"]; ok {
+		t.Errorf("ETCD_CLIENT_CERT_AUTH set with topology TLS off")
+	}
+}
+
+// With topology TLS on, etcd serves its client and peer listeners over TLS,
+// requires a client certificate on each, and mounts the issued serving
+// certificate. The metrics listener stays plaintext so the probes keep working.
+func TestTopoTLSOnRequiresClientCerts(t *testing.T) {
+	scheme := certScheme()
+
+	sts, err := BuildStatefulSet(certTestTopoServer(&multigresv1alpha1.TopoTLSConfig{
 		Enabled:    ptr.To(true),
 		IssuerName: "multigres-infra-issuer",
-	})
-
-	baseline, err := BuildStatefulSet(without, scheme)
-	if err != nil {
-		t.Fatalf("BuildStatefulSet() error = %v", err)
-	}
-	withTLS, err := BuildStatefulSet(with, scheme)
+	}), scheme)
 	if err != nil {
 		t.Fatalf("BuildStatefulSet() error = %v", err)
 	}
 
-	if diff := cmp.Diff(baseline.Spec.Template, withTLS.Spec.Template); diff != "" {
-		t.Errorf(
-			"pod template changed when topology TLS was enabled (-without +with):\n%s",
-			diff,
-		)
+	var servingVol *corev1.Volume
+	for i := range sts.Spec.Template.Spec.Volumes {
+		if sts.Spec.Template.Spec.Volumes[i].Name == TopoServerTLSVolumeName {
+			servingVol = &sts.Spec.Template.Spec.Volumes[i]
+		}
 	}
-	if diff := cmp.Diff(baseline.Spec, withTLS.Spec); diff != "" {
-		t.Errorf(
-			"StatefulSet spec changed when topology TLS was enabled (-without +with):\n%s",
-			diff,
-		)
+	if servingVol == nil {
+		t.Fatal("serving certificate volume missing with topology TLS on")
 	}
+	if servingVol.Secret == nil ||
+		servingVol.Secret.SecretName != multigresv1alpha1.TopoServerCertSecretName(
+			"test-cluster-global-topo",
+		) {
+		t.Errorf("serving certificate volume references the wrong Secret: %+v", servingVol.Secret)
+	}
+
+	var mounted bool
+	for _, m := range sts.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if m.Name == TopoServerTLSVolumeName {
+			mounted = true
+			if !m.ReadOnly || m.MountPath != TopoServerTLSMountPath {
+				t.Errorf(
+					"serving certificate mount = %+v, want read-only at %s",
+					m,
+					TopoServerTLSMountPath,
+				)
+			}
+		}
+	}
+	if !mounted {
+		t.Error("serving certificate is not mounted into the etcd container")
+	}
+
+	env := etcdEnvMap(t, sts)
+	wantEnv := map[string]string{
+		"ETCD_LISTEN_CLIENT_URLS":    "https://[::]:2379",
+		"ETCD_LISTEN_PEER_URLS":      "https://[::]:2380",
+		"ETCD_LISTEN_METRICS_URLS":   "http://[::]:2381",
+		"ETCD_CLIENT_CERT_AUTH":      "true",
+		"ETCD_PEER_CLIENT_CERT_AUTH": "true",
+		"ETCD_CERT_FILE":             TopoServerTLSCertFile,
+		"ETCD_KEY_FILE":              TopoServerTLSKeyFile,
+		"ETCD_TRUSTED_CA_FILE":       TopoServerTLSCAFile,
+		"ETCD_PEER_CERT_FILE":        TopoServerTLSCertFile,
+		"ETCD_PEER_KEY_FILE":         TopoServerTLSKeyFile,
+		"ETCD_PEER_TRUSTED_CA_FILE":  TopoServerTLSCAFile,
+	}
+	for k, want := range wantEnv {
+		if got := env[k]; got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// etcdEnvMap collects the etcd container's environment variables that carry a
+// literal value into a lookup keyed by name.
+func etcdEnvMap(t *testing.T, sts *appsv1.StatefulSet) map[string]string {
+	t.Helper()
+	env := map[string]string{}
+	for _, e := range sts.Spec.Template.Spec.Containers[0].Env {
+		if e.ValueFrom == nil {
+			env[e.Name] = e.Value
+		}
+	}
+	return env
 }

--- a/pkg/resource-handler/controller/toposerver/container_env.go
+++ b/pkg/resource-handler/controller/toposerver/container_env.go
@@ -9,11 +9,13 @@ import (
 
 // buildContainerEnv constructs all environment variables for etcd clustering in
 // StatefulSets. This combines pod identity, etcd config, and cluster peer
-// discovery details.
+// discovery details. When tlsEnabled is set, etcd serves its client and peer
+// listeners over TLS and requires a client certificate.
 func buildContainerEnv(
 	toposerverName, namespace string,
 	replicas int32,
 	serviceName string,
+	tlsEnabled bool,
 ) []corev1.EnvVar {
 	envVars := make([]corev1.EnvVar, 0)
 
@@ -21,10 +23,15 @@ func buildContainerEnv(
 	envVars = append(envVars, buildPodIdentityEnv()...)
 
 	// Add etcd configuration variables
-	envVars = append(envVars, buildEtcdConfigEnv(toposerverName, serviceName, namespace)...)
+	envVars = append(
+		envVars,
+		buildEtcdConfigEnv(toposerverName, serviceName, namespace, tlsEnabled)...,
+	)
 
 	// Add the initial cluster peer list
-	clusterPeerList := buildEtcdClusterPeerList(toposerverName, serviceName, namespace, replicas)
+	clusterPeerList := buildEtcdClusterPeerList(
+		toposerverName, serviceName, namespace, replicas, peerScheme(tlsEnabled),
+	)
 	envVars = append(envVars, corev1.EnvVar{
 		Name:  "ETCD_INITIAL_CLUSTER",
 		Value: clusterPeerList,
@@ -59,12 +66,41 @@ func buildPodIdentityEnv() []corev1.EnvVar {
 	}
 }
 
+// clientScheme returns the URL scheme etcd uses for client traffic.
+func clientScheme(tlsEnabled bool) string {
+	if tlsEnabled {
+		return "https"
+	}
+	return "http"
+}
+
+// peerScheme returns the URL scheme etcd uses for peer traffic. Peer TLS is
+// switched on together with client TLS: the serving certificate is issued for
+// both the client Service and the headless peer Service, so member-to-member
+// traffic uses the same credential rather than staying in plaintext.
+func peerScheme(tlsEnabled bool) string {
+	if tlsEnabled {
+		return "https"
+	}
+	return "http"
+}
+
 // buildEtcdConfigEnv creates etcd configuration environment variables.
 // These configure etcd's network endpoints and cluster formation.
 //
+// The metrics listener stays on http regardless of TLS: the StatefulSet's
+// probes target it and carry no client credentials, so moving it to TLS would
+// break them.
+//
 // Ref: https://etcd.io/docs/latest/op-guide/configuration/
-func buildEtcdConfigEnv(toposerverName, serviceName, namespace string) []corev1.EnvVar {
-	return []corev1.EnvVar{
+func buildEtcdConfigEnv(
+	toposerverName, serviceName, namespace string,
+	tlsEnabled bool,
+) []corev1.EnvVar {
+	cScheme := clientScheme(tlsEnabled)
+	pScheme := peerScheme(tlsEnabled)
+
+	env := []corev1.EnvVar{
 		{
 			Name:  "ETCD_NAME",
 			Value: "$(POD_NAME)",
@@ -75,11 +111,11 @@ func buildEtcdConfigEnv(toposerverName, serviceName, namespace string) []corev1.
 		},
 		{
 			Name:  "ETCD_LISTEN_CLIENT_URLS",
-			Value: "http://[::]:2379",
+			Value: cScheme + "://[::]:2379",
 		},
 		{
 			Name:  "ETCD_LISTEN_PEER_URLS",
-			Value: "http://[::]:2380",
+			Value: pScheme + "://[::]:2380",
 		},
 		{
 			Name:  "ETCD_LISTEN_METRICS_URLS",
@@ -88,14 +124,16 @@ func buildEtcdConfigEnv(toposerverName, serviceName, namespace string) []corev1.
 		{
 			Name: "ETCD_ADVERTISE_CLIENT_URLS",
 			Value: fmt.Sprintf(
-				"http://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2379",
+				"%s://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2379",
+				cScheme,
 				serviceName,
 			),
 		},
 		{
 			Name: "ETCD_INITIAL_ADVERTISE_PEER_URLS",
 			Value: fmt.Sprintf(
-				"http://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2380",
+				"%s://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2380",
+				pScheme,
 				serviceName,
 			),
 		},
@@ -108,18 +146,66 @@ func buildEtcdConfigEnv(toposerverName, serviceName, namespace string) []corev1.
 			Value: toposerverName,
 		},
 	}
+
+	if tlsEnabled {
+		env = append(env, buildEtcdTLSEnv()...)
+	}
+
+	return env
+}
+
+// buildEtcdTLSEnv returns the etcd variables that point both listeners at the
+// mounted serving certificate and require a client certificate on each. Client
+// and peer connections are verified against the same CA the certificate chains
+// to, so only a holder of a certificate from that CA can reach the topology.
+func buildEtcdTLSEnv() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "ETCD_CERT_FILE",
+			Value: TopoServerTLSCertFile,
+		},
+		{
+			Name:  "ETCD_KEY_FILE",
+			Value: TopoServerTLSKeyFile,
+		},
+		{
+			Name:  "ETCD_TRUSTED_CA_FILE",
+			Value: TopoServerTLSCAFile,
+		},
+		{
+			Name:  "ETCD_CLIENT_CERT_AUTH",
+			Value: "true",
+		},
+		{
+			Name:  "ETCD_PEER_CERT_FILE",
+			Value: TopoServerTLSCertFile,
+		},
+		{
+			Name:  "ETCD_PEER_KEY_FILE",
+			Value: TopoServerTLSKeyFile,
+		},
+		{
+			Name:  "ETCD_PEER_TRUSTED_CA_FILE",
+			Value: TopoServerTLSCAFile,
+		},
+		{
+			Name:  "ETCD_PEER_CLIENT_CERT_AUTH",
+			Value: "true",
+		},
+	}
 }
 
 // buildEtcdClusterPeerList generates the initial cluster member list for
 // bootstrap. This tells each etcd member about all other members during cluster
 // formation.
 //
-// Format: member-0=http://member-0.service.ns.svc.cluster.local:2380,...
+// Format: member-0=<scheme>://member-0.service.ns.svc.cluster.local:2380,...
 //
 // Ref: https://etcd.io/docs/latest/op-guide/clustering/#static
 func buildEtcdClusterPeerList(
 	toposerverName, serviceName, namespace string,
 	replicas int32,
+	scheme string,
 ) string {
 	if replicas < 0 {
 		return ""
@@ -128,8 +214,8 @@ func buildEtcdClusterPeerList(
 	peers := make([]string, 0, replicas)
 	for i := range replicas {
 		podName := fmt.Sprintf("%s-%d", toposerverName, i)
-		peerURL := fmt.Sprintf("%s=http://%s.%s.%s.svc.cluster.local:2380",
-			podName, podName, serviceName, namespace)
+		peerURL := fmt.Sprintf("%s=%s://%s.%s.%s.svc.cluster.local:2380",
+			podName, scheme, podName, serviceName, namespace)
 		peers = append(peers, peerURL)
 	}
 

--- a/pkg/resource-handler/controller/toposerver/container_env_test.go
+++ b/pkg/resource-handler/controller/toposerver/container_env_test.go
@@ -111,7 +111,7 @@ func TestBuildEtcdConfigEnv(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := buildEtcdConfigEnv(tc.toposerverName, tc.serviceName, tc.namespace)
+			got := buildEtcdConfigEnv(tc.toposerverName, tc.serviceName, tc.namespace, false)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("buildEtcdConfigEnv() mismatch (-want +got):\n%s", diff)
 			}
@@ -178,6 +178,7 @@ func TestBuildEtcdClusterPeerList(t *testing.T) {
 				tc.serviceName,
 				tc.namespace,
 				tc.replicas,
+				"http",
 			)
 			if got != tc.want {
 				t.Errorf("buildEtcdClusterPeerList() = %v, want %v", got, tc.want)
@@ -330,7 +331,13 @@ func TestBuildContainerEnv(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := buildContainerEnv(tc.toposerverName, tc.namespace, tc.replicas, tc.serviceName)
+			got := buildContainerEnv(
+				tc.toposerverName,
+				tc.namespace,
+				tc.replicas,
+				tc.serviceName,
+				false,
+			)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("BuildContainerEnv() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/resource-handler/controller/toposerver/statefulset.go
+++ b/pkg/resource-handler/controller/toposerver/statefulset.go
@@ -31,6 +31,22 @@ const (
 
 	// DataMountPath is the mount path for etcd data
 	DataMountPath = "/var/lib/etcd"
+
+	// TopoServerTLSVolumeName is the volume holding etcd's serving certificate.
+	TopoServerTLSVolumeName = "topo-server-tls"
+
+	// TopoServerTLSMountPath is where the serving certificate is mounted.
+	TopoServerTLSMountPath = "/etc/etcd/tls"
+
+	// TopoServerTLSCertFile is etcd's serving certificate.
+	TopoServerTLSCertFile = TopoServerTLSMountPath + "/tls.crt"
+
+	// TopoServerTLSKeyFile is the private key for the serving certificate.
+	TopoServerTLSKeyFile = TopoServerTLSMountPath + "/tls.key"
+
+	// TopoServerTLSCAFile is the CA bundle etcd verifies client and peer
+	// certificates against.
+	TopoServerTLSCAFile = TopoServerTLSMountPath + "/ca.crt"
 )
 
 // BuildStatefulSet creates a StatefulSet for the TopoServer cluster.
@@ -69,6 +85,22 @@ func BuildStatefulSet(
 	resources := corev1.ResourceRequirements{}
 	if toposerver.Spec.Etcd != nil {
 		resources = toposerver.Spec.Etcd.Resources
+	}
+
+	tlsEnabled := toposerver.Spec.TLS.IsEnabled()
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      DataVolumeName,
+			MountPath: DataMountPath,
+		},
+	}
+	if tlsEnabled {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      TopoServerTLSVolumeName,
+			MountPath: TopoServerTLSMountPath,
+			ReadOnly:  true,
+		})
 	}
 
 	// Defensive copy so the built StatefulSet does not alias the TopoServer spec.
@@ -110,14 +142,10 @@ func BuildStatefulSet(
 								toposerver.Namespace,
 								replicas,
 								headlessServiceName,
+								tlsEnabled,
 							),
-							Ports: buildContainerPorts(toposerver),
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      DataVolumeName,
-									MountPath: DataMountPath,
-								},
-							},
+							Ports:        buildContainerPorts(toposerver),
+							VolumeMounts: volumeMounts,
 							StartupProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -157,6 +185,19 @@ func BuildStatefulSet(
 			VolumeClaimTemplates:                 buildVolumeClaimTemplates(toposerver),
 			PersistentVolumeClaimRetentionPolicy: pvc.BuildRetentionPolicy(stsRetentionPolicy),
 		},
+	}
+
+	if tlsEnabled {
+		defaultMode := int32(0o444)
+		sts.Spec.Template.Spec.Volumes = append(sts.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: TopoServerTLSVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  multigresv1alpha1.TopoServerCertSecretName(toposerver.Name),
+					DefaultMode: &defaultMode,
+				},
+			},
+		})
 	}
 
 	if err := ctrl.SetControllerReference(toposerver, sts, scheme); err != nil {

--- a/pkg/resource-handler/controller/toposerver/statefulset_test.go
+++ b/pkg/resource-handler/controller/toposerver/statefulset_test.go
@@ -99,6 +99,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										"default",
 										3,
 										"test-toposerver-headless",
+										false,
 									),
 									Ports: buildContainerPorts(nil), // Default
 									VolumeMounts: []corev1.VolumeMount{
@@ -246,6 +247,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										"default",
 										3,
 										"test-toposerver-headless",
+										false,
 									),
 									Ports: buildContainerPorts(nil), // Default
 									VolumeMounts: []corev1.VolumeMount{
@@ -395,6 +397,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										"test",
 										5,
 										"toposerver-custom-headless",
+										false,
 									),
 									Ports: buildContainerPorts(nil),
 									VolumeMounts: []corev1.VolumeMount{
@@ -538,6 +541,7 @@ func TestBuildStatefulSet(t *testing.T) {
 										"default",
 										3,
 										"test-toposerver-headless",
+										false,
 									),
 									Ports: buildContainerPorts(nil),
 									VolumeMounts: []corev1.VolumeMount{

--- a/test/e2e/fixtures/topo-tls.yaml
+++ b/test/e2e/fixtures/topo-tls.yaml
@@ -37,8 +37,13 @@ spec:
                   replicas: 1
                 pools:
                   default:
+                    # The cluster defaults to AT_LEAST_2 durability. Multiorch only
+                    # bootstraps a primary when the initial pooler cohort can satisfy
+                    # that policy under the failure-safe check, which needs three
+                    # poolers; fewer leaves the shard a replica and no primary is ever
+                    # elected.
                     type: readWrite
                     cells: ["zone-a"]
-                    replicasPerCell: 1
+                    replicasPerCell: 3
                     storage:
                       size: "1Gi"

--- a/test/e2e/fixtures/topo-tls.yaml
+++ b/test/e2e/fixtures/topo-tls.yaml
@@ -1,0 +1,44 @@
+apiVersion: multigres.com/v1alpha1
+kind: MultigresCluster
+metadata:
+  name: topo-tls
+  namespace: default
+spec:
+  postgresPasswordSecretRef:
+    name: multigres-admin-password
+    key: password
+  pvcDeletionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  # Require TLS on the topology server. The operator issues the etcd serving
+  # certificate and the per-cluster client credential from this issuer, so etcd
+  # and every client chain to the same CA. The scenario creates this issuer.
+  topoTLS:
+    enabled: true
+    issuerName: topo-e2e-ca
+  # A single etcd member keeps this scenario light on the shared cluster while
+  # still exercising the client certificate path etcd now requires.
+  globalTopoServer:
+    etcd:
+      replicas: 1
+  cells:
+    - name: "zone-a"
+      zoneId: us-central1-a
+  databases:
+    - name: "postgres"
+      default: true
+      tablegroups:
+        - name: "default"
+          default: true
+          shards:
+            - name: "0-inf"
+              spec:
+                multiorch:
+                  replicas: 1
+                pools:
+                  default:
+                    type: readWrite
+                    cells: ["zone-a"]
+                    replicasPerCell: 1
+                    storage:
+                      size: "1Gi"

--- a/test/e2e/framework/certmanager.go
+++ b/test/e2e/framework/certmanager.go
@@ -1,0 +1,126 @@
+//go:build e2e
+
+package framework
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// certManagerVersion is the cert-manager release the topology TLS scenario
+// installs. Bump it in one place.
+const certManagerVersion = "v1.16.2"
+
+// topoTLSIssuerName is the CA ClusterIssuer the topology TLS scenario points
+// topoTLS.issuerName at. The etcd serving certificate and the per-cluster
+// client credential both chain to this one CA, so the server trusts the client.
+const topoTLSIssuerName = "topo-e2e-ca"
+
+// caIssuerManifest is a self-signed root, a CA certificate issued from it, and a
+// CA ClusterIssuer backed by that certificate. A self-signed issuer alone would
+// sign each certificate under a different key, so the topology server would not
+// trust the client; the shared CA is what makes mutual verification work. The
+// CA Secret lives in the cert-manager namespace because that is where a
+// ClusterIssuer of kind CA reads it from by default.
+const caIssuerManifest = `apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: topo-e2e-selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: topo-e2e-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: topo-e2e-ca
+  secretName: topo-e2e-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: topo-e2e-selfsigned
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: topo-e2e-ca
+spec:
+  ca:
+    secretName: topo-e2e-ca
+`
+
+// EnsureTopoTLSIssuer installs cert-manager and creates the CA ClusterIssuer the
+// topology TLS scenario signs with. It is idempotent, so a retained cluster can
+// be reused. It returns the issuer name to put in topoTLS.issuerName.
+func (c *Cluster) EnsureTopoTLSIssuer(t testing.TB) string {
+	t.Helper()
+
+	url := fmt.Sprintf(
+		"https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml",
+		certManagerVersion,
+	)
+	if err := c.kubectl("apply", "-f", url); err != nil {
+		t.Fatalf("install cert-manager: %v", err)
+	}
+	for _, deploy := range []string{"cert-manager", "cert-manager-webhook", "cert-manager-cainjector"} {
+		if err := c.kubectl(
+			"-n", "cert-manager", "rollout", "status", "deployment/"+deploy, "--timeout=300s",
+		); err != nil {
+			t.Fatalf("wait for %s: %v", deploy, err)
+		}
+	}
+
+	// The webhook can still reject requests briefly after its Deployment reports
+	// available, so apply the issuer chain with a short retry.
+	if err := c.retry(10, 3*time.Second, func() error {
+		return c.kubectlStdin(caIssuerManifest, "apply", "-f", "-")
+	}); err != nil {
+		t.Fatalf("apply CA issuer: %v", err)
+	}
+
+	if err := c.kubectl(
+		"wait", "--for=condition=Ready", "clusterissuer/"+topoTLSIssuerName, "--timeout=120s",
+	); err != nil {
+		t.Fatalf("wait for CA issuer ready: %v", err)
+	}
+	return topoTLSIssuerName
+}
+
+func (c *Cluster) kubectl(args ...string) error {
+	full := append([]string{"--kubeconfig", c.Kubeconfig}, args...)
+	cmd := exec.Command("kubectl", full...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl %v: %w\n%s", args, err, out)
+	}
+	return nil
+}
+
+func (c *Cluster) kubectlStdin(stdin string, args ...string) error {
+	full := append([]string{"--kubeconfig", c.Kubeconfig}, args...)
+	cmd := exec.Command("kubectl", full...)
+	cmd.Stdin = bytes.NewBufferString(stdin)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("kubectl %v: %w\n%s", args, err, out)
+	}
+	return nil
+}
+
+func (c *Cluster) retry(attempts int, wait time.Duration, fn func() error) error {
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		time.Sleep(wait)
+	}
+	return err
+}

--- a/test/e2e/shared/topotls/main_test.go
+++ b/test/e2e/shared/topotls/main_test.go
@@ -1,0 +1,23 @@
+//go:build e2e
+
+package topotls_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/multigres/multigres-operator/test/e2e/framework"
+)
+
+var cluster *framework.Cluster
+
+func TestMain(m *testing.M) {
+	var err error
+	cluster, err = framework.EnsureSharedCluster()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e setup: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/test/e2e/shared/topotls/topotls_test.go
+++ b/test/e2e/shared/topotls/topotls_test.go
@@ -1,0 +1,89 @@
+//go:build e2e
+
+package topotls_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/test/e2e/framework"
+)
+
+// TestTopoTLSCluster brings up a cluster with topoTLS enabled and verifies it
+// serves queries. Reaching that state proves the full mutual TLS path: etcd
+// requires a client certificate on its client and peer listeners, the four pod
+// components present the issued certificate, and the operator presents it on its
+// own connections when it registers the cell and database. A plaintext client
+// anywhere in that path would leave the cluster unable to become ready.
+func TestTopoTLSCluster(t *testing.T) {
+	t.Parallel()
+
+	// cert-manager and the shared CA the operator signs the etcd serving
+	// certificate and the client credential with.
+	cluster.EnsureTopoTLSIssuer(t)
+
+	ns := cluster.CreateNamespace(t)
+	c, err := cluster.CRClient()
+	if err != nil {
+		t.Fatalf("create CR client: %v", err)
+	}
+
+	cr := framework.MustLoadCluster("test/e2e/fixtures/topo-tls.yaml", ns)
+	if err := c.Create(context.Background(), cr); err != nil {
+		t.Fatalf("create MultigresCluster: %v", err)
+	}
+
+	// The child resource tree still forms with topology TLS on.
+	framework.WaitForCRDCount(t, c, ns,
+		&multigresv1alpha1.TopoServerList{},
+		func(l *multigresv1alpha1.TopoServerList) int { return len(l.Items) },
+		1, "TopoServer",
+	)
+
+	// etcd, the components, and the pool pod all come up. etcd requires a client
+	// certificate on its listeners, so every component reaching a ready state
+	// means it presented the mounted certificate.
+	framework.WaitForStatefulSet(t, c, ns, "etcd")
+	framework.WaitForDeployment(t, c, ns, "multiadmin")
+	framework.WaitForDeployment(t, c, ns, "multigateway")
+	framework.WaitForDeployment(t, c, ns, "multiorch")
+	framework.WaitForPod(t, c, ns, "postgres")
+	cluster.WaitForAllPodsReady(t, ns)
+
+	// The operator also connects to etcd, over the same mutual TLS, to register
+	// the cell and database. TopologyReady goes true only once that connection
+	// succeeds, so it is the direct signal that the operator presented its own
+	// certificate.
+	waitForTopologyReady(t, c, ns, "topo-tls")
+
+	// Pod readiness and the operator's own connection do not prove the data
+	// plane works: multigateway, multiorch and multipooler each open their own
+	// topology connection with the mounted certificate to resolve a pooler and
+	// route queries, and a broken client path there leaves the pods ready but
+	// unable to serve. A served query is the end-to-end check that they too
+	// present the certificate.
+	gwSvc := framework.FindGatewayService(t, cluster, ns)
+	framework.WaitForQueryServing(t, cluster, ns, gwSvc)
+}
+
+func waitForTopologyReady(t *testing.T, c client.Client, ns, name string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	err := wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		cluster := &multigresv1alpha1.MultigresCluster{}
+		if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: name}, cluster); err != nil {
+			return false, nil
+		}
+		return meta.IsStatusConditionTrue(cluster.Status.Conditions, "TopologyReady"), nil
+	})
+	if err != nil {
+		t.Fatalf("timed out waiting for TopologyReady on cluster %s/%s: %v", ns, name, err)
+	}
+}


### PR DESCRIPTION
## Description

this PR turns on TLS for the etcd topology server and moves every client onto it, so the `topoTLS` gate can be flipped on. etcd requires a client cert, the four pod components (multiadmin, multigateway, multipooler, multiorch) mount the issued one, and the operator loads it from the referenced Secret for its own connections. Off by default, and the whole `topoTLS` block (enablement and issuer) is immutable so it is fixed at creation: etcd can't serve plaintext and TLS on one port, its persisted peer membership isn't rewritten by a restart, and clients load their cert at process start, so neither the switch nor a CA rotation can roll out safely on a running cluster.

For multipooler the cert is the only isolation from the postgres superuser it shares a pod, IP, data PVC, and socket dir with, so a network policy won't do. It's mounted only into the topo-speaking containers, off any volume postgres or pgctld mount, with `shareProcessNamespace` unset, and a pod-spec test checks all three.

## Main changes

- etcd client and peer listeners move to https with `ETCD_CLIENT_CERT_AUTH` and `ETCD_PEER_CLIENT_CERT_AUTH`; metrics stays http for the probes. Peer TLS is included.
- Client cert mounted into the four pod components and nowhere else, with `--topo-etcd-tls-cert/-key/-ca`.
- The operator reads the credential with the uncached API reader (its cache only stores tenant Secrets carrying the managed-by label, which cert-manager and user-provided Secrets lack) and passes it as per-connection `TLSOptions`; an empty reference stays plaintext.
- `topoTLS` is immutable via a CEL rule, so enablement and issuer can only be set at creation.
- No credential issued for external topologies. Missing client material fails loudly, naming the Secret, as a Degraded phase with a `TopologyReady=False` condition that clears once the operator reconnects.

## Testing

Ran `make verify`, `make pre-commit`, and the TopoServer, cluster, shard, and topo integration suites locally, all green, including CEL integration tests that reject enabling topoTLS or changing its issuer after creation. Added the mount-boundary test, topoTLS-off render tests, and the operator secret-loading and loud-failure tests. Added a shared e2e scenario (`test/e2e/shared/topotls`) that installs cert-manager, issues from a CA so the server and clients share one root, and brings up a topoTLS cluster; a served `SELECT 1` proves the full mTLS path including the operator's own registration. Kick it with `/e2e`.
