### PR TITLE
fix(postgresconfig): classify backend/superuser-backend GUCs as restart

### DIFF
--- a/pkg/postgresconfig/classify.go
+++ b/pkg/postgresconfig/classify.go
@@ -2,19 +2,33 @@ package postgresconfig
 
 import "strings"
 
-// restartContexts are the pg_settings "context" values whose parameters only
-// take effect after a full PostgreSQL restart. A configuration reload (SIGHUP)
-// does not apply them:
+// restartContexts are the pg_settings "context" values whose parameters do not
+// take effect for the running data plane on a configuration reload (SIGHUP), so
+// the operator must recreate the pods to apply them:
 //
 //   - postmaster: settable only at server start (e.g. shared_buffers,
 //     max_connections, wal_level).
 //   - internal: compiled-in / read-only (e.g. block_size); never reloadable.
+//   - backend / superuser-backend: fixed at backend start. A SIGHUP updates the
+//     value the postmaster hands to SUBSEQUENTLY-started backends, but existing
+//     backends keep their start-time value (PostgreSQL does not re-read the
+//     config file mid-session; see set_config_option's PGC_BACKEND handling).
+//     Because the multipooler fronts PostgreSQL with long-lived pooled backends,
+//     no new backend is started on a reload, so params like log_connections /
+//     log_disconnections would silently never take effect until the pods are
+//     recreated. Classifying them as restart recycles those backends so the
+//     change actually applies. (The pooler's ReloadConfig would even report the
+//     reload as succeeded — pg_file_settings.applied is true for these — so
+//     without this the operator would mark the change done while it had no
+//     effect.)
 //
-// Every other context (sighup, superuser, user, backend, superuser-backend) is
-// applied by a reload without a restart.
+// Every other context (sighup, superuser, user) is applied by a reload without a
+// restart.
 var restartContexts = map[string]bool{
-	"postmaster": true,
-	"internal":   true,
+	"postmaster":        true,
+	"internal":          true,
+	"backend":           true,
+	"superuser-backend": true,
 }
 
 // RequiresRestart reports whether changing the given parameter requires a

--- a/pkg/postgresconfig/classify_test.go
+++ b/pkg/postgresconfig/classify_test.go
@@ -26,6 +26,11 @@ func TestRequiresRestart(t *testing.T) {
 		{"random_page_cost", false},
 		// superuser context → reload
 		{"session_preload_libraries", false},
+		// backend / superuser-backend context → restart: fixed at backend start, so
+		// a reload never reaches the multipooler's long-lived pooled backends.
+		{"log_connections", true},
+		{"log_disconnections", true},
+		{"post_auth_delay", true},
 		// case-insensitive
 		{"Work_Mem", false},
 		{"SHARED_BUFFERS", true},

--- a/test/e2e/shared/postgresconfig/helpers_test.go
+++ b/test/e2e/shared/postgresconfig/helpers_test.go
@@ -1,0 +1,29 @@
+//go:build e2e
+
+package postgresconfig_test
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// poolPodUIDs returns the current pool pods (component shard-pool) in ns keyed by
+// name -> UID. Tests snapshot it before and after a config change to tell a reload
+// (stable UIDs) apart from a restart (recreated pods, new UIDs).
+func poolPodUIDs(t *testing.T, ctx context.Context, c client.Client, ns string) map[string]types.UID {
+	t.Helper()
+	pods := &corev1.PodList{}
+	if err := c.List(ctx, pods, client.InNamespace(ns),
+		client.MatchingLabels{"app.kubernetes.io/component": "shard-pool"}); err != nil {
+		t.Fatalf("list pool pods: %v", err)
+	}
+	uids := map[string]types.UID{}
+	for i := range pods.Items {
+		uids[pods.Items[i].Name] = pods.Items[i].UID
+	}
+	return uids
+}

--- a/test/e2e/shared/postgresconfig/logconnections_test.go
+++ b/test/e2e/shared/postgresconfig/logconnections_test.go
@@ -6,10 +6,6 @@ import (
 	"context"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/multigres/multigres-operator/test/e2e/framework"
 )
 
@@ -52,23 +48,10 @@ func TestLogConnectionsTakesEffect(t *testing.T) {
 	// does not set it, so this proves the "on" below is our change taking effect.
 	framework.WaitForPsqlValue(t, cluster, ns, gw, "SHOW log_connections", "off")
 
-	poolPodUIDs := func() map[string]types.UID {
-		pods := &corev1.PodList{}
-		if err := c.List(ctx, pods, client.InNamespace(ns),
-			client.MatchingLabels{"app.kubernetes.io/component": "shard-pool"}); err != nil {
-			t.Fatalf("list pool pods: %v", err)
-		}
-		uids := map[string]types.UID{}
-		for i := range pods.Items {
-			uids[pods.Items[i].Name] = pods.Items[i].UID
-		}
-		return uids
-	}
-
 	// Change log_connections on a settled cluster so the rollout is not raced by
 	// the initial config still converging.
 	framework.WaitForShardConfigSettled(t, c, ns)
-	before := poolPodUIDs()
+	before := poolPodUIDs(t, ctx, c, ns)
 	if len(before) == 0 {
 		t.Fatal("no pool pods found before enabling log_connections")
 	}
@@ -95,7 +78,7 @@ func TestLogConnectionsTakesEffect(t *testing.T) {
 	// It takes effect because the pods were recreated: a backend-context GUC that a
 	// reload cannot apply to existing pooled backends goes through the restart
 	// path. Changed pool-pod UIDs prove Postgres was actually restarted.
-	after := poolPodUIDs()
+	after := poolPodUIDs(t, ctx, c, ns)
 	recreated := false
 	for name, uid := range before {
 		if after[name] != uid {

--- a/test/e2e/shared/postgresconfig/logconnections_test.go
+++ b/test/e2e/shared/postgresconfig/logconnections_test.go
@@ -1,0 +1,109 @@
+//go:build e2e
+
+package postgresconfig_test
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/multigres/multigres-operator/test/e2e/framework"
+)
+
+// TestLogConnectionsTakesEffect is a regression test for a postgresql.conf change
+// that silently failed to apply on a running cluster: log_connections.
+//
+// log_connections is a superuser-backend context GUC: its value is fixed when a
+// backend starts, and a SIGHUP reload only changes it for backends started
+// afterwards — PostgreSQL never re-reads the config file mid-session. Here
+// PostgreSQL sits behind the multipooler, which keeps long-lived pooled backends,
+// so a reload reaches no running backend and the change has no observable effect
+// (worse, the pooler's ReloadConfig reports the reload as applied, because
+// pg_file_settings.applied is true for it, so the operator marks the change done).
+//
+// The operator must therefore treat log_connections as a restart-context change
+// and recreate the pods — the only way the new value reaches the pooled backends.
+// This test flips log_connections on against a running cluster and asserts the
+// effective value read back through the gateway actually becomes "on".
+func TestLogConnectionsTakesEffect(t *testing.T) {
+	ns := cluster.CreateNamespace(t)
+	c, err := cluster.CRClient()
+	if err != nil {
+		t.Fatalf("create CR client: %v", err)
+	}
+	ctx := context.Background()
+
+	cr := framework.MustLoadCluster("config/samples/no-templates.yaml", ns)
+	framework.WithCIResources(&cr.Spec)
+	if err := c.Create(ctx, cr); err != nil {
+		t.Fatalf("create MultigresCluster: %v", err)
+	}
+
+	// Wait for Postgres to come up and serve queries through the gateway.
+	framework.WaitForPod(t, c, ns, "postgres")
+	cluster.WaitForAllPodsReady(t, ns)
+	gw := framework.FindGatewayService(t, cluster, ns)
+	framework.WaitForQueryServing(t, cluster, ns, gw)
+
+	// Baseline: log_connections defaults to off — the operator's baseline template
+	// does not set it, so this proves the "on" below is our change taking effect.
+	framework.WaitForPsqlValue(t, cluster, ns, gw, "SHOW log_connections", "off")
+
+	poolPodUIDs := func() map[string]types.UID {
+		pods := &corev1.PodList{}
+		if err := c.List(ctx, pods, client.InNamespace(ns),
+			client.MatchingLabels{"app.kubernetes.io/component": "shard-pool"}); err != nil {
+			t.Fatalf("list pool pods: %v", err)
+		}
+		uids := map[string]types.UID{}
+		for i := range pods.Items {
+			uids[pods.Items[i].Name] = pods.Items[i].UID
+		}
+		return uids
+	}
+
+	// Change log_connections on a settled cluster so the rollout is not raced by
+	// the initial config still converging.
+	framework.WaitForShardConfigSettled(t, c, ns)
+	before := poolPodUIDs()
+	if len(before) == 0 {
+		t.Fatal("no pool pods found before enabling log_connections")
+	}
+
+	// Turn log_connections on via the inline spec.postgresConfig map. Send the full
+	// databases array with the one changed value: JSON merge-patch replaces arrays
+	// wholesale, so mutate the live object to preserve every server-defaulted field.
+	live := framework.GetCluster(t, c, ns, cr.Name)
+	shard := &live.Spec.Databases[0].TableGroups[0].Shards[0]
+	if shard.Spec.PostgresConfig == nil {
+		shard.Spec.PostgresConfig = map[string]string{}
+	}
+	shard.Spec.PostgresConfig["log_connections"] = "on"
+	framework.PatchCluster(t, c, live, framework.MustMarshal(map[string]any{
+		"spec": map[string]any{"databases": live.Spec.Databases},
+	}))
+
+	// The change must take effect in the running server. Reading it back through
+	// the gateway (a pooled backend) is exactly what a user does — and is the
+	// assertion that fails when the change is applied by SIGHUP reload only,
+	// because the pooled backend keeps its start-time value.
+	framework.WaitForPsqlValue(t, cluster, ns, gw, "SHOW log_connections", "on")
+
+	// It takes effect because the pods were recreated: a backend-context GUC that a
+	// reload cannot apply to existing pooled backends goes through the restart
+	// path. Changed pool-pod UIDs prove Postgres was actually restarted.
+	after := poolPodUIDs()
+	recreated := false
+	for name, uid := range before {
+		if after[name] != uid {
+			recreated = true
+			break
+		}
+	}
+	if !recreated {
+		t.Errorf("expected pool pods to be recreated to apply log_connections, but UIDs were unchanged: before=%v after=%v", before, after)
+	}
+}

--- a/test/e2e/shared/postgresconfig/postgresconfig_test.go
+++ b/test/e2e/shared/postgresconfig/postgresconfig_test.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
@@ -113,20 +112,7 @@ func TestPostgresConfigManagement(t *testing.T) {
 		// racing the primary-last restart still converging the initial config.
 		framework.WaitForShardConfigSettled(t, c, ns)
 
-		poolPodUIDs := func() map[string]types.UID {
-			pods := &corev1.PodList{}
-			if err := c.List(ctx, pods, client.InNamespace(ns),
-				client.MatchingLabels{"app.kubernetes.io/component": "shard-pool"}); err != nil {
-				t.Fatalf("list pool pods: %v", err)
-			}
-			uids := map[string]types.UID{}
-			for i := range pods.Items {
-				uids[pods.Items[i].Name] = pods.Items[i].UID
-			}
-			return uids
-		}
-
-		before := poolPodUIDs()
+		before := poolPodUIDs(t, ctx, c, ns)
 		if len(before) == 0 {
 			t.Fatal("no pool pods found before reload-safe change")
 		}
@@ -144,7 +130,7 @@ func TestPostgresConfigManagement(t *testing.T) {
 
 		// The pods must be the very same objects — a reload-safe change must not
 		// recreate them. Stable UIDs prove Postgres was never restarted.
-		after := poolPodUIDs()
+		after := poolPodUIDs(t, ctx, c, ns)
 		if len(after) != len(before) {
 			t.Errorf("pool pod set changed across a reload-safe change: before=%v after=%v", before, after)
 		}
@@ -173,19 +159,6 @@ func TestPostgresConfigManagement(t *testing.T) {
 	t.Run("removing a reload-safe setting reverts it in place", func(t *testing.T) {
 		framework.WaitForShardConfigSettled(t, c, ns)
 
-		poolPodUIDs := func() map[string]types.UID {
-			pods := &corev1.PodList{}
-			if err := c.List(ctx, pods, client.InNamespace(ns),
-				client.MatchingLabels{"app.kubernetes.io/component": "shard-pool"}); err != nil {
-				t.Fatalf("list pool pods: %v", err)
-			}
-			uids := map[string]types.UID{}
-			for i := range pods.Items {
-				uids[pods.Items[i].Name] = pods.Items[i].UID
-			}
-			return uids
-		}
-
 		// Add cpu_tuple_cost via the inline map and confirm it reloads in.
 		live := framework.GetCluster(t, c, ns, cr.Name)
 		live.Spec.Databases[0].TableGroups[0].Shards[0].Spec.PostgresConfig["cpu_tuple_cost"] = "0.05"
@@ -194,7 +167,7 @@ func TestPostgresConfigManagement(t *testing.T) {
 		}))
 		framework.WaitForPsqlValue(t, cluster, ns, gw, "SHOW cpu_tuple_cost", "0.05")
 
-		before := poolPodUIDs()
+		before := poolPodUIDs(t, ctx, c, ns)
 		if len(before) == 0 {
 			t.Fatal("no pool pods found before the removal")
 		}
@@ -211,7 +184,7 @@ func TestPostgresConfigManagement(t *testing.T) {
 		framework.WaitForPsqlValue(t, cluster, ns, gw, "SHOW cpu_tuple_cost", "0.01")
 
 		// The removal was applied by an in-place reload — no pod recreation.
-		after := poolPodUIDs()
+		after := poolPodUIDs(t, ctx, c, ns)
 		if len(after) != len(before) {
 			t.Errorf("pool pod set changed across a reload-safe removal: before=%v after=%v", before, after)
 		}


### PR DESCRIPTION
## Summary

- Backend and superuser-backend context GUCs (`log_connections`, `log_disconnections`, and four others) were classified reload-safe, but a SIGHUP reload never applies them to the multipooler's long-lived pooled backends — so the change silently never took effect, while the pooler's `ReloadConfig` still reported success.
- Classify `backend`/`superuser-backend` as restart so these GUCs go through pod recreation, which recycles the pooled backends and actually applies the change.
- Add an e2e regression test that enables `log_connections` on a running cluster and asserts it takes effect through the gateway.

## Problem

`log_connections` set via `spec.postgresConfig` had no effect on a running cluster. It is a `superuser-backend` context GUC: its value is fixed when a backend starts, and a SIGHUP reload only changes the value the postmaster hands to subsequently-started backends, never existing ones (see `set_config_option`'s `PGC_BACKEND` handling in PostgreSQL). Because the multipooler fronts PostgreSQL with long-lived pooled backends, no new backend is started on a reload, so the change never reaches a running backend.

The failure was silent: the pooler's `ReloadConfig` gate checks `pg_file_settings.applied`, which is `true` for these GUCs, and only escalates `needs_restart` for `postmaster` context — so the operator marked the config change done while it had no effect.

## Solution

Add `backend` and `superuser-backend` to the classifier's `restartContexts`, so these GUCs drive pod recreation (the restart path) instead of an in-place reload. Recreating the pods restarts PostgreSQL with the new config, which is the only way the value reaches the pooled backends. Six GUCs are affected: `log_connections`, `log_disconnections`, `jit_debugging_support`, `jit_profiling_support`, `ignore_system_indexes`, `post_auth_delay`.

Verified end-to-end on Kind (reproduce-then-fix): with the unfixed operator the new `TestLogConnectionsTakesEffect` fails (`SHOW log_connections` stuck at `off`); with the fix it passes (pods recreated, value becomes `on`). `sighup`/`user`/`superuser` GUCs (e.g. `work_mem`, `max_wal_size`) remain reload-safe and unaffected.