### PR TITLE
fix: remove duplicate declaration introduced during rebase

### DIFF
--- a/pkg/resource-handler/controller/shard/integration_test.go
+++ b/pkg/resource-handler/controller/shard/integration_test.go
@@ -1935,7 +1935,6 @@ func setInlineConfig(
 		if s.Spec.PostgresConfig == nil {
 			s.Spec.PostgresConfig = map[string]string{}
 		}
-		base := s.DeepCopy()
 		s.Spec.PostgresConfig[key] = val
 		return c.Patch(ctx, s, client.MergeFrom(base))
 	}); err != nil {


### PR DESCRIPTION
Removing a duplicated  `base := s.DeepCopy()` introduced during a rebase.