### PR TITLE
fix(topology): bound fallback roots for TLS certificates

### DIFF
--- a/docs/development/shared-topology.md
+++ b/docs/development/shared-topology.md
@@ -20,6 +20,25 @@ The `multigres.com/project-ref` annotation is the preferred stable
 different namespaces cannot collide. Values that are not safe path segments
 are percent-encoded.
 
+With managed topology and `topoTLS` enabled, the cluster root is also the
+client certificate's common name and must fit within 64 bytes. If the
+namespace/name fallback exceeds that limit, it becomes
+`/multigres-fallback/<hash>`, where `<hash>` is the unpadded base64url SHA-256
+digest of the original escaped cluster root. Shorter roots, plaintext roots,
+and external topology roots keep their existing paths. The `topoTLS` setting
+is immutable, so this does not move running plaintext clusters to another
+keyspace.
+
+If an explicit global or cell root points outside the shortened identity, the
+operator reports a certificate failure instead of changing it. Align the
+configured root and migrate any existing topology data before retrying.
+
+Explicit project refs are never shortened. With managed topology TLS, they
+must fit within 53 bytes after percent-encoding. An oversized ref prevents
+certificate creation and sets `TopologyReady=False` with reason
+`TopoCertificateFailed`, including the root length and limit. The condition
+clears after a successful topology connection.
+
 For example, a cluster annotated with project ref `proj_123` and containing
 cells `zone-a` and `zone-b` uses:
 

--- a/pkg/cluster-handler/controller/multigrescluster/certificate.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate.go
@@ -7,11 +7,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/resolver"
 	"github.com/multigres/multigres-operator/pkg/topology"
 	"github.com/multigres/multigres-operator/pkg/util/certs"
+	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
 
 const (
@@ -173,7 +175,7 @@ func buildTopoClientCertificate(
 	cluster *multigresv1alpha1.MultigresCluster,
 	scheme *runtime.Scheme,
 ) (*unstructured.Unstructured, error) {
-	roots, err := topology.NewRoots(cluster.Annotations, cluster.Namespace, cluster.Name)
+	roots, err := topology.ForCluster(cluster)
 	if err != nil {
 		return nil, fmt.Errorf("deriving topology root for client certificate: %w", err)
 	}
@@ -181,8 +183,12 @@ func buildTopoClientCertificate(
 	commonName := roots.ClusterRoot()
 	if len(commonName) > certs.MaxCommonNameBytes {
 		return nil, fmt.Errorf(
-			"topology root %q is %d bytes, over the %d byte certificate common name limit",
-			commonName, len(commonName), certs.MaxCommonNameBytes,
+			"topology root %q is %d bytes, over the %d byte certificate common name limit; shorten annotation %s to at most %d bytes after path escaping",
+			commonName,
+			len(commonName),
+			certs.MaxCommonNameBytes,
+			metadata.AnnotationProjectRef,
+			certs.MaxCommonNameBytes-len("/multigres/"),
 		)
 	}
 
@@ -202,10 +208,9 @@ func buildTopoClientCertificate(
 	})
 }
 
-// topologyIsManaged reports whether the cluster's resolved global topology is a
-// managed etcd server the operator runs and issues a serving certificate for,
-// as opposed to an external topology server the user operates.
-func (r *MultigresClusterReconciler) topologyIsManaged(
+// managedTopologyForCertificate reports whether topology is managed and
+// checks configured roots against the shortened certificate prefix.
+func (r *MultigresClusterReconciler) managedTopologyForCertificate(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
 ) (bool, error) {
@@ -215,6 +220,62 @@ func (r *MultigresClusterReconciler) topologyIsManaged(
 		return false, fmt.Errorf(
 			"failed to resolve global topology for client certificate: %w", err,
 		)
+	}
+	if spec.Etcd != nil {
+		roots, err := topology.ForCluster(cluster)
+		if err != nil {
+			return false, fmt.Errorf("deriving topology certificate identity: %w", err)
+		}
+		unbounded, err := topology.NewRoots(
+			cluster.Annotations,
+			cluster.Namespace,
+			cluster.Name,
+			false,
+		)
+		if err != nil {
+			return false, fmt.Errorf("deriving unbounded topology root: %w", err)
+		}
+		// Changing a saved root would abandon its existing keys.
+		// Reject roots outside the certificate prefix.
+		if roots == unbounded {
+			return true, nil
+		}
+		if !strings.HasPrefix(spec.Etcd.RootPath, roots.KeyPrefix()) {
+			return false, fmt.Errorf(
+				"configured topology root %q is outside certificate identity %q; set the global topology root to %q and migrate any existing topology data",
+				spec.Etcd.RootPath,
+				roots.ClusterRoot(),
+				roots.Global(),
+			)
+		}
+		for _, cell := range cluster.Spec.Cells {
+			cell.CellTemplate = cluster.Spec.EffectiveCellTemplate(cell.CellTemplate)
+			_, _, local, err := res.ResolveCell(ctx, cluster, &cell)
+			if err != nil {
+				return false, fmt.Errorf(
+					"resolving cell %q topology for certificate: %w",
+					cell.Name,
+					err,
+				)
+			}
+			if local == nil {
+				continue
+			}
+			var localRoot string
+			if local.Etcd != nil {
+				localRoot = local.Etcd.RootPath
+			} else if local.External != nil {
+				localRoot = local.External.RootPath
+			}
+			if localRoot != "" && !strings.HasPrefix(localRoot, roots.KeyPrefix()) {
+				return false, fmt.Errorf(
+					"cell %q topology root %q is outside certificate identity %q; align the cell topology root and migrate any existing topology data",
+					cell.Name,
+					localRoot,
+					roots.ClusterRoot(),
+				)
+			}
+		}
 	}
 	return spec.Etcd != nil, nil
 }
@@ -274,8 +335,9 @@ func (r *MultigresClusterReconciler) reconcileCertificate(
 		desiredCerts = append(desiredCerts, internalCerts...)
 	}
 	if cluster.Spec.TopoTLS.IsEnabled() {
-		managed, err := r.topologyIsManaged(ctx, cluster)
+		managed, err := r.managedTopologyForCertificate(ctx, cluster)
 		if err != nil {
+			r.markTopologyFailed(ctx, cluster, "TopoCertificateFailed", err, log.FromContext(ctx))
 			return err
 		}
 		// An external topology server brings its own CA and client Secrets, so a
@@ -286,6 +348,13 @@ func (r *MultigresClusterReconciler) reconcileCertificate(
 		if managed {
 			topoClientCert, err := buildTopoClientCertificate(cluster, r.Scheme)
 			if err != nil {
+				r.markTopologyFailed(
+					ctx,
+					cluster,
+					"TopoCertificateFailed",
+					err,
+					log.FromContext(ctx),
+				)
 				return fmt.Errorf(
 					"failed to build topology client cert-manager Certificate: %w", err,
 				)

--- a/pkg/cluster-handler/controller/multigrescluster/certificate_topo_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/certificate_topo_test.go
@@ -7,16 +7,165 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/multigres/multigres/go/common/topoclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/resolver"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
+
+func TestTopologyTLSLongFallbackUsesSameRoot(t *testing.T) {
+	cluster := topoTLSCluster("cluster-abcdefghijklmnop", "namespace-abcdefghijklmnopqrstu", nil)
+	cluster.Spec.Cells = []multigresv1alpha1.CellConfig{{Name: "zone-a"}}
+	scheme := setupScheme()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	store := newClusterTopologyMemoryStore(t)
+	r := &MultigresClusterReconciler{
+		Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10),
+		CreateTopoStore: func(ref multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+			assert.Equal(
+				t,
+				"/multigres-fallback/b-Tmo_r9oWzDWEuz_6f6LFOAmYO7ve1i4ksIy7qa9ac/global",
+				ref.RootPath,
+			)
+			return noCloseStore{Store: store}, nil
+		},
+	}
+	require.NoError(t, r.reconcileCertificate(t.Context(), cluster))
+	cert := &unstructured.Unstructured{}
+	cert.SetGroupVersionKind(certGVK)
+	require.NoError(t, c.Get(t.Context(), client.ObjectKey{
+		Namespace: cluster.Namespace, Name: multigresv1alpha1.TopoClientCertName(cluster.Name),
+	}, cert))
+	subject, _, err := unstructured.NestedString(cert.Object, "spec", "literalSubject")
+	require.NoError(t, err)
+	cn, ok := parseCommonName(subject)
+	require.True(t, ok)
+	assert.Equal(t, "/multigres-fallback/b-Tmo_r9oWzDWEuz_6f6LFOAmYO7ve1i4ksIy7qa9ac", cn)
+
+	res := resolver.NewResolver(c, cluster.Namespace)
+	result, err := r.reconcileTopology(t.Context(), cluster, res)
+	require.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+	cell, err := store.GetCell(t.Context(), "zone-a")
+	require.NoError(t, err)
+	assert.Equal(t, cn+"/global", cell.Root)
+
+	cluster.Spec.Cells[0].Spec = &multigresv1alpha1.CellInlineSpec{
+		LocalTopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+			Etcd: &multigresv1alpha1.EtcdSpec{},
+		},
+	}
+	_, _, local, err := res.ResolveCell(t.Context(), cluster, &cluster.Spec.Cells[0])
+	require.NoError(t, err)
+	assert.Equal(t, cn+"/zone-a", local.Etcd.RootPath)
+}
+
+func TestReconcileOversizedProjectRefStatusAndRecovery(t *testing.T) {
+	for _, ref := range []string{strings.Repeat("p", 55), strings.Repeat("/", 19)} {
+		t.Run(ref, func(t *testing.T) {
+			cluster := topoTLSCluster(
+				"cluster",
+				"default",
+				map[string]string{metadata.AnnotationProjectRef: ref},
+			)
+			cluster.Generation = 3
+			scheme := setupScheme()
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).
+				WithStatusSubresource(cluster).Build()
+			r := &MultigresClusterReconciler{
+				Client:   c,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(100),
+				CreateTopoStore: func(_ multigresv1alpha1.GlobalTopoServerRef) (topoclient.Store, error) {
+					return noCloseStore{Store: newClusterTopologyMemoryStore(t)}, nil
+				},
+			}
+			key := client.ObjectKeyFromObject(cluster)
+			_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+			require.ErrorContains(t, err, "64 byte certificate common name limit")
+			require.NoError(t, c.Get(t.Context(), key, cluster))
+			assert.Equal(t, multigresv1alpha1.PhaseDegraded, cluster.Status.Phase)
+			condition := meta.FindStatusCondition(cluster.Status.Conditions, conditionTopologyReady)
+			require.NotNil(t, condition)
+			assert.Equal(t, metav1.ConditionFalse, condition.Status)
+			assert.Equal(t, "TopoCertificateFailed", condition.Reason)
+			assert.Equal(t, cluster.Generation, condition.ObservedGeneration)
+			assert.Contains(
+				t,
+				condition.Message,
+				"shorten annotation multigres.com/project-ref to at most 53 bytes after path escaping",
+			)
+
+			cluster.Annotations[metadata.AnnotationProjectRef] = strings.Repeat("p", 53)
+			require.NoError(t, c.Update(t.Context(), cluster))
+			_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+			require.NoError(t, err)
+			require.NoError(t, c.Get(t.Context(), key, cluster))
+			condition = meta.FindStatusCondition(cluster.Status.Conditions, conditionTopologyReady)
+			require.NotNil(t, condition)
+			assert.Equal(t, metav1.ConditionTrue, condition.Status)
+			assert.Equal(t, "TopoConnected", condition.Reason)
+			assert.NotContains(t, cluster.Status.Message, "certificate common name limit")
+		})
+	}
+}
+
+func TestReconcileCertificatePreservesExplicitLongRoot(t *testing.T) {
+	cluster := topoTLSCluster("cluster-abcdefghijklmnop", "namespace-abcdefghijklmnopqrstu", nil)
+	const explicitRoot = "/multigres/namespace-abcdefghijklmnopqrstu/cluster-abcdefghijklmnop/global"
+	cluster.Spec.GlobalTopoServer = &multigresv1alpha1.GlobalTopoServerSpec{
+		Etcd: &multigresv1alpha1.EtcdSpec{RootPath: explicitRoot},
+	}
+	scheme := setupScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster).
+		WithStatusSubresource(cluster).
+		Build()
+	r := &MultigresClusterReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	require.ErrorContains(
+		t,
+		r.reconcileCertificate(t.Context(), cluster),
+		"outside certificate identity",
+	)
+	require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(cluster), cluster))
+	assert.Equal(t, explicitRoot, cluster.Spec.GlobalTopoServer.Etcd.RootPath)
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, conditionTopologyReady)
+	require.NotNil(t, condition)
+	assert.Equal(t, "TopoCertificateFailed", condition.Reason)
+	assert.Contains(t, condition.Message, "migrate any existing topology data")
+
+	cluster.Spec.GlobalTopoServer.Etcd.RootPath = ""
+	cluster.Spec.Cells = []multigresv1alpha1.CellConfig{{
+		Name: "zone-a",
+		Spec: &multigresv1alpha1.CellInlineSpec{
+			LocalTopoServer: &multigresv1alpha1.LocalTopoServerSpec{
+				Etcd: &multigresv1alpha1.EtcdSpec{RootPath: explicitRoot + "/zone-a"},
+			},
+		},
+	}}
+	require.NoError(t, c.Update(t.Context(), cluster))
+	require.ErrorContains(
+		t,
+		r.reconcileCertificate(t.Context(), cluster),
+		`cell "zone-a" topology root`,
+	)
+}
 
 func topoTLSCluster(
 	name, namespace string,

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology.go
@@ -97,7 +97,7 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 		// stays not ready is visible without reading the operator logs.
 		r.Recorder.Eventf(cluster, "Warning", "TopoConnectFailed",
 			"Failed to connect to topology server: %v", err)
-		r.markTopologyConnectFailed(ctx, cluster, err, logger)
+		r.markTopologyFailed(ctx, cluster, "TopoConnectFailed", err, logger)
 		return ctrl.Result{}, fmt.Errorf("failed to open topology store: %w", err)
 	}
 	defer func() { _ = store.Close() }()
@@ -200,20 +200,19 @@ func (r *MultigresClusterReconciler) reconcileTopology(
 // server with the configured credentials.
 const conditionTopologyReady = "TopologyReady"
 
-// markTopologyConnectFailed records a topology connection failure in the
-// cluster status: a Degraded phase, a message carrying the error, and a
-// TopologyReady=False condition. The status write is best effort, since the
-// reconcile already returns the error and will retry.
-func (r *MultigresClusterReconciler) markTopologyConnectFailed(
+// markTopologyFailed sets Degraded and TopologyReady=False.
+// Status write failures are logged; reconciliation will retry the original error.
+func (r *MultigresClusterReconciler) markTopologyFailed(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
+	reason string,
 	cause error,
 	logger interface{ Error(error, string, ...any) },
 ) {
 	meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
 		Type:               conditionTopologyReady,
 		Status:             metav1.ConditionFalse,
-		Reason:             "TopoConnectFailed",
+		Reason:             reason,
 		Message:            cause.Error(),
 		ObservedGeneration: cluster.Generation,
 		LastTransitionTime: metav1.Now(),
@@ -221,7 +220,7 @@ func (r *MultigresClusterReconciler) markTopologyConnectFailed(
 	cluster.Status.Phase = multigresv1alpha1.PhaseDegraded
 	cluster.Status.Message = cause.Error()
 	if err := r.Status().Update(ctx, cluster); err != nil {
-		logger.Error(err, "Failed to persist topology connection failure to status")
+		logger.Error(err, "Failed to persist topology failure to status")
 	}
 }
 

--- a/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_tls_test.go
+++ b/pkg/cluster-handler/controller/multigrescluster/reconcile_topology_tls_test.go
@@ -40,7 +40,7 @@ func TestMarkTopologyConnectFailed_SurfacesInStatus(t *testing.T) {
 	cause := errors.New(
 		`reading topology client TLS Secret "test-cluster-topo-client-tls" in namespace "supabase": not found`,
 	)
-	r.markTopologyConnectFailed(context.Background(), cluster, cause, testLogger{})
+	r.markTopologyFailed(context.Background(), cluster, "TopoConnectFailed", cause, testLogger{})
 
 	got := &multigresv1alpha1.MultigresCluster{}
 	if err := c.Get(

--- a/pkg/data-handler/topo/cell.go
+++ b/pkg/data-handler/topo/cell.go
@@ -22,6 +22,7 @@ func RegisterCell(
 	store topoclient.Store,
 	recorder record.EventRecorder,
 	cell *multigresv1alpha1.Cell,
+	topoTLS bool,
 ) error {
 	logger := log.FromContext(ctx)
 
@@ -30,6 +31,7 @@ func RegisterCell(
 		cell.Annotations,
 		cell.Namespace,
 		cell.Labels[metadata.LabelMultigresCluster],
+		topoTLS,
 	)
 	if err != nil {
 		return fmt.Errorf("deriving topology roots for cell %q: %w", cellName, err)

--- a/pkg/data-handler/topo/cell_test.go
+++ b/pkg/data-handler/topo/cell_test.go
@@ -94,7 +94,7 @@ func TestRegisterCell(t *testing.T) {
 		// Register a different cell name to ensure it's not already in topo
 		cell := newTestCell("cell2")
 
-		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(t.Context(), store, recorder, cell, false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -128,7 +128,7 @@ func TestRegisterCell(t *testing.T) {
 		cell := newTestCell("cell2")
 		cell.Spec.Metadata = `{"zoneId":"use1-az1","custom":"value"}`
 
-		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(t.Context(), store, recorder, cell, false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -153,12 +153,12 @@ func TestRegisterCell(t *testing.T) {
 		cell := newTestCell("cell1")
 		cell.Spec.Metadata = `{"zoneId":"use1-az1"}`
 
-		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(t.Context(), store, recorder, cell, false); err != nil {
 			t.Fatalf("first registration failed: %v", err)
 		}
 
 		cell.Spec.Metadata = `{"zoneId":"use1-az2"}`
-		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(t.Context(), store, recorder, cell, false); err != nil {
 			t.Fatalf("re-registration failed: %v", err)
 		}
 
@@ -182,7 +182,7 @@ func TestRegisterCell(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 		cell := newTestCell("cell1")
 
-		err := topo.RegisterCell(context.Background(), store, recorder, cell)
+		err := topo.RegisterCell(t.Context(), store, recorder, cell, false)
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -199,10 +199,10 @@ func TestRegisterCell(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 		cell := newTestCell("cell1")
 
-		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(t.Context(), store, recorder, cell, false); err != nil {
 			t.Fatalf("first registration failed: %v", err)
 		}
-		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(t.Context(), store, recorder, cell, false); err != nil {
 			t.Fatalf("second registration should succeed (idempotent), got: %v", err)
 		}
 	})
@@ -229,7 +229,7 @@ func TestRegisterCell(t *testing.T) {
 			t.Fatalf("seeding stale cell: %v", err)
 		}
 
-		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(t.Context(), store, recorder, cell, false); err != nil {
 			t.Fatalf("re-registration should update stale cell, got: %v", err)
 		}
 
@@ -260,7 +260,7 @@ func TestRegisterCell(t *testing.T) {
 		cell := newTestCell("cell2")
 		cell.Spec.TopoServer = nil
 
-		if err := topo.RegisterCell(context.Background(), store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(t.Context(), store, recorder, cell, false); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -289,7 +289,7 @@ func TestRegisterCell(t *testing.T) {
 		cell.Spec.TopoServer.External.RootPath = ""
 
 		if err := topo.RegisterCell(
-			context.Background(), store, record.NewFakeRecorder(10), cell,
+			context.Background(), store, record.NewFakeRecorder(10), cell, false,
 		); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -319,7 +319,7 @@ func TestUnregisterCell(t *testing.T) {
 		cell := newTestCell("cell1")
 		ctx := context.Background()
 
-		if err := topo.RegisterCell(ctx, store, recorder, cell); err != nil {
+		if err := topo.RegisterCell(ctx, store, recorder, cell, false); err != nil {
 			t.Fatalf("registration failed: %v", err)
 		}
 		if err := topo.UnregisterCell(ctx, store, recorder, cell); err != nil {

--- a/pkg/data-handler/topo/topology.go
+++ b/pkg/data-handler/topo/topology.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/multigres/multigres/go/common/topoclient"
 	clustermetadatapb "github.com/multigres/multigres/go/pb/clustermetadata"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -120,7 +119,7 @@ func RegisterCellFromSpec(
 	ctx context.Context,
 	store topoclient.Store,
 	recorder record.EventRecorder,
-	owner runtime.Object,
+	owner *multigresv1alpha1.MultigresCluster,
 	cellConfig multigresv1alpha1.CellConfig,
 	localTopo *multigresv1alpha1.LocalTopoServerSpec,
 	topoRef multigresv1alpha1.GlobalTopoServerRef,
@@ -134,15 +133,7 @@ func RegisterCellFromSpec(
 		managedAddress = managedTopoAddress[0]
 	}
 
-	ownerMeta, err := meta.Accessor(owner)
-	if err != nil {
-		return fmt.Errorf("accessing cluster metadata for cell %q: %w", cellName, err)
-	}
-	roots, err := topology.NewRoots(
-		ownerMeta.GetAnnotations(),
-		ownerMeta.GetNamespace(),
-		ownerMeta.GetName(),
-	)
+	roots, err := topology.ForCluster(owner)
 	if err != nil {
 		return fmt.Errorf("deriving topology roots for cell %q: %w", cellName, err)
 	}

--- a/pkg/resolver/cell.go
+++ b/pkg/resolver/cell.go
@@ -35,7 +35,7 @@ func (r *Resolver) ResolveCell(
 
 	// Note: We do NOT default LocalTopo here because it is optional.
 	if localTopo != nil {
-		roots, err := topology.NewRoots(cluster.Annotations, cluster.Namespace, cluster.Name)
+		roots, err := topology.ForCluster(cluster)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf(
 				"deriving topology roots for cell %q: %w",

--- a/pkg/resolver/cluster.go
+++ b/pkg/resolver/cluster.go
@@ -168,7 +168,7 @@ func (r *Resolver) ResolveGlobalTopo(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
 ) (*multigresv1alpha1.GlobalTopoServerSpec, error) {
-	roots, err := topology.NewRoots(cluster.Annotations, cluster.Namespace, cluster.Name)
+	roots, err := topology.ForCluster(cluster)
 	if err != nil {
 		return nil, fmt.Errorf("deriving global topology root: %w", err)
 	}

--- a/pkg/topology/roots.go
+++ b/pkg/topology/roots.go
@@ -3,24 +3,41 @@
 package topology
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strings"
 
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
 
 const rootPrefix = "/multigres"
+
+// maxTLSRootBytes is the X.509 common name limit.
+const maxTLSRootBytes = 64
 
 // Roots builds canonical, disjoint topology roots for one Multigres cluster.
 type Roots struct {
 	clusterRoot string
 }
 
-// NewRoots uses the downstream project reference as the stable cluster
-// identity when it is present. Otherwise namespace and cluster name form the
-// identity, preventing equal names in different namespaces from colliding.
-func NewRoots(annotations map[string]string, namespace, clusterName string) (Roots, error) {
+// ForCluster applies the CN length limit only to managed topology TLS.
+func ForCluster(cluster *multigresv1alpha1.MultigresCluster) (Roots, error) {
+	managedTLS := cluster.Spec.TopoTLS.IsEnabled() &&
+		(cluster.Spec.GlobalTopoServer == nil || cluster.Spec.GlobalTopoServer.External == nil)
+	return NewRoots(cluster.Annotations, cluster.Namespace, cluster.Name, managedTLS)
+}
+
+// NewRoots uses the project ref, or namespace/name if absent.
+// With topoTLS, fallbacks over the CN limit are hashed. Explicit refs and
+// plaintext roots are unchanged.
+func NewRoots(
+	annotations map[string]string,
+	namespace, clusterName string,
+	topoTLS bool,
+) (Roots, error) {
 	if projectRef := annotations[metadata.AnnotationProjectRef]; projectRef != "" {
 		encoded, err := encodeSegment("project reference", projectRef)
 		if err != nil {
@@ -37,7 +54,14 @@ func NewRoots(annotations map[string]string, namespace, clusterName string) (Roo
 	if err != nil {
 		return Roots{}, err
 	}
-	return Roots{clusterRoot: rootPrefix + "/" + encodedNamespace + "/" + encodedClusterName}, nil
+	clusterRoot := rootPrefix + "/" + encodedNamespace + "/" + encodedClusterName
+	if topoTLS && len(clusterRoot) > maxTLSRootBytes {
+		// Keep hashes outside /multigres/ so existing prefixes cannot authorize them.
+		// Hashing the escaped path preserves namespace/name boundaries.
+		digest := sha256.Sum256([]byte(clusterRoot))
+		clusterRoot = rootPrefix + "-fallback/" + base64.RawURLEncoding.EncodeToString(digest[:])
+	}
+	return Roots{clusterRoot: clusterRoot}, nil
 }
 
 // ClusterRoot returns the prefix that encloses every topology record this

--- a/pkg/topology/roots_test.go
+++ b/pkg/topology/roots_test.go
@@ -4,8 +4,98 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	multigresv1alpha1 "github.com/multigres/multigres-operator/api/v1alpha1"
+	"github.com/multigres/multigres-operator/pkg/util/certs"
 	"github.com/multigres/multigres-operator/pkg/util/metadata"
 )
+
+func TestExternalTopologyKeepsLongRoot(t *testing.T) {
+	cluster := &multigresv1alpha1.MultigresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-abcdefghijklmnop",
+			Namespace: "namespace-abcdefghijklmnopqrstu",
+		},
+		Spec: multigresv1alpha1.MultigresClusterSpec{
+			TopoTLS: &multigresv1alpha1.TopoTLSConfig{Enabled: ptr.To(true)},
+			GlobalTopoServer: &multigresv1alpha1.GlobalTopoServerSpec{
+				External: &multigresv1alpha1.ExternalTopoServerSpec{},
+			},
+		},
+	}
+	roots, err := ForCluster(cluster)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"/multigres/namespace-abcdefghijklmnopqrstu/cluster-abcdefghijklmnop",
+		roots.ClusterRoot(),
+	)
+}
+
+func TestRootsWithTopologyTLS(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "namespace-abcdefghijklmnopqrstu"
+	const clusterName = "cluster-abcdefghijklmnop"
+	const unboundedRoot = "/multigres/" + namespace + "/" + clusterName
+	const hashedRoot = "/multigres-fallback/b-Tmo_r9oWzDWEuz_6f6LFOAmYO7ve1i4ksIy7qa9ac"
+
+	for _, tc := range []struct {
+		name        string
+		namespace   string
+		clusterName string
+		topoTLS     bool
+		want        string
+	}{
+		{"67 byte TLS fallback", namespace, clusterName, true, hashedRoot},
+		{"plaintext keeps existing root", namespace, clusterName, false, unboundedRoot},
+		{"64 byte TLS fallback is unchanged", namespace, clusterName[:21], true, unboundedRoot[:64]},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			roots, err := NewRoots(nil, tc.namespace, tc.clusterName, tc.topoTLS)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, roots.ClusterRoot())
+			assert.Equal(t, tc.want+"/global", roots.Global())
+			cellRoot, err := roots.Cell("zone-a")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want+"/zone-a", cellRoot)
+			assert.True(t, strings.HasPrefix(cellRoot, roots.KeyPrefix()))
+			if tc.topoTLS {
+				assert.LessOrEqual(t, len(roots.ClusterRoot()), certs.MaxCommonNameBytes)
+			}
+		})
+	}
+
+	for _, ref := range []string{"~", "namespace-abcdefghijklmnopqrstu", "../multigres-fallback", strings.Repeat("p", 64)} {
+		annotations := map[string]string{metadata.AnnotationProjectRef: ref}
+		plain, err := NewRoots(annotations, namespace, clusterName, false)
+		require.NoError(t, err)
+		tls, err := NewRoots(annotations, namespace, clusterName, true)
+		require.NoError(t, err)
+		assert.Equal(t, plain, tls, "explicit refs must not change with TLS")
+		assert.NotEqual(t, hashedRoot, tls.ClusterRoot())
+		assert.False(t, strings.HasPrefix(hashedRoot+"/global", tls.KeyPrefix()))
+	}
+
+	seen := map[string]bool{hashedRoot: true}
+	for _, pair := range [][2]string{
+		{namespace + "x", clusterName},
+		{namespace, clusterName + "x"},
+		{namespace + "/a", clusterName},
+		{namespace, "a/" + clusterName},
+		{strings.Repeat("n", 63), strings.Repeat("c", 253)},
+	} {
+		roots, err := NewRoots(nil, pair[0], pair[1], true)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, len(roots.ClusterRoot()), certs.MaxCommonNameBytes)
+		assert.False(t, seen[roots.ClusterRoot()], "fallback identities must be distinct")
+		seen[roots.ClusterRoot()] = true
+	}
+}
 
 func TestRoots(t *testing.T) {
 	t.Parallel()
@@ -50,7 +140,7 @@ func TestRoots(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			roots, err := NewRoots(tc.annotations, tc.namespace, tc.clusterName)
+			roots, err := NewRoots(tc.annotations, tc.namespace, tc.clusterName, false)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected an error")
@@ -80,11 +170,11 @@ func TestRoots(t *testing.T) {
 func TestFallbackIdentityIsNamespaceScoped(t *testing.T) {
 	t.Parallel()
 
-	first, err := NewRoots(nil, "tenant-a", "production")
+	first, err := NewRoots(nil, "tenant-a", "production", false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := NewRoots(nil, "tenant-b", "production")
+	second, err := NewRoots(nil, "tenant-b", "production", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +205,7 @@ func TestClusterRootPrefixesEveryRoot(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			roots, err := NewRoots(tc.annotations, tc.namespace, tc.clusterName)
+			roots, err := NewRoots(tc.annotations, tc.namespace, tc.clusterName, false)
 			if err != nil {
 				t.Fatalf("NewRoots() error = %v", err)
 			}
@@ -141,13 +231,13 @@ func TestClusterRootPrefixesEveryRoot(t *testing.T) {
 // prefix that includes the separator.
 func TestKeyPrefixDoesNotReachSiblingClusters(t *testing.T) {
 	short, err := NewRoots(
-		map[string]string{metadata.AnnotationProjectRef: "proj_123"}, "supabase", "a",
+		map[string]string{metadata.AnnotationProjectRef: "proj_123"}, "supabase", "a", false,
 	)
 	if err != nil {
 		t.Fatalf("NewRoots() error = %v", err)
 	}
 	long, err := NewRoots(
-		map[string]string{metadata.AnnotationProjectRef: "proj_1234"}, "supabase", "b",
+		map[string]string{metadata.AnnotationProjectRef: "proj_1234"}, "supabase", "b", false,
 	)
 	if err != nil {
 		t.Fatalf("NewRoots() error = %v", err)

--- a/pkg/util/metadata/project_ref.go
+++ b/pkg/util/metadata/project_ref.go
@@ -1,8 +1,8 @@
 package metadata
 
 const (
-	// AnnotationProjectRef carries the downstream-facing project identity used
-	// by observability collectors. When absent, cluster name is the fallback.
+	// AnnotationProjectRef identifies the project for observability and topology.
+	// If absent, observability uses the cluster name; topology uses namespace/name.
 	AnnotationProjectRef = "multigres.com/project-ref"
 
 	// Prometheus scrape annotations for autodiscovery of exporter endpoints.

--- a/tools/observer/pkg/observer/topology.go
+++ b/tools/observer/pkg/observer/topology.go
@@ -73,7 +73,7 @@ func (o *Observer) globalTopologyRoot(
 	ctx context.Context,
 	cluster *multigresv1alpha1.MultigresCluster,
 ) (string, error) {
-	roots, err := topology.NewRoots(cluster.Annotations, cluster.Namespace, cluster.Name)
+	roots, err := topology.ForCluster(cluster)
 	if err != nil {
 		return "", err
 	}
@@ -125,7 +125,10 @@ func (o *Observer) globalTopologyRoot(
 	return rootPath, nil
 }
 
-func (o *Observer) findEtcdAddress(ctx context.Context, cluster *multigresv1alpha1.MultigresCluster) string {
+func (o *Observer) findEtcdAddress(
+	ctx context.Context,
+	cluster *multigresv1alpha1.MultigresCluster,
+) string {
 	// Check external etcd endpoints first.
 	if cluster.Spec.GlobalTopoServer != nil &&
 		cluster.Spec.GlobalTopoServer.External != nil &&

--- a/tools/observer/pkg/observer/topology_test.go
+++ b/tools/observer/pkg/observer/topology_test.go
@@ -5,6 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -20,6 +21,25 @@ func TestGlobalTopologyRoot(t *testing.T) {
 		objects []client.Object
 		want    string
 	}{
+		"uses bounded fallback for topology TLS": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-abcdefghijklmnop", Namespace: "namespace-abcdefghijklmnopqrstu",
+				},
+				Spec: multigresv1alpha1.MultigresClusterSpec{
+					TopoTLS: &multigresv1alpha1.TopoTLSConfig{Enabled: ptr.To(true)},
+				},
+			},
+			want: "/multigres-fallback/b-Tmo_r9oWzDWEuz_6f6LFOAmYO7ve1i4ksIy7qa9ac/global",
+		},
+		"preserves long plaintext fallback": {
+			cluster: &multigresv1alpha1.MultigresCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-abcdefghijklmnop", Namespace: "namespace-abcdefghijklmnopqrstu",
+				},
+			},
+			want: "/multigres/namespace-abcdefghijklmnopqrstu/cluster-abcdefghijklmnop/global",
+		},
 		"uses canonical project root by default": {
 			cluster: &multigresv1alpha1.MultigresCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -67,7 +87,12 @@ func TestGlobalTopologyRoot(t *testing.T) {
 			if err := multigresv1alpha1.AddToScheme(scheme); err != nil {
 				t.Fatal(err)
 			}
-			o := &Observer{client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build()}
+			o := &Observer{
+				client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(tc.objects...).
+					Build(),
+			}
 
 			got, err := o.globalTopologyRoot(t.Context(), tc.cluster)
 			if err != nil {


### PR DESCRIPTION
## Description

this PR fixes topology certificate creation when the namespace/name fallback exceeds the 64-byte common name limit.

For managed topology TLS, oversized fallbacks use `/multigres-fallback/<hash>`. The certificate and topology clients use the same root. Shorter roots, explicit project refs, plaintext roots, and external topology roots are unchanged.

## Main changes

- Use the bounded root in certificate creation, resolution, cell registration, and the observer.
- Set `TopologyReady=False` with an actionable error when certificate creation fails.
- Reject configured roots outside the shortened certificate prefix without rewriting them.
- Add regression coverage for root lengths, namespace isolation, certificate/root agreement, and status recovery.

## Testing

- `make verify pre-commit`
- Cluster-controller and resolver integration suites
- Observer test suite
- Reran affected tests after the final cleanup
