### PR TITLE
chore: make dependabot ignore multigres

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "github.com/multigres/multigres"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Make depensabot ignore multigres dependencies.